### PR TITLE
feat(video): add HLG (Hybrid Log-Gamma) HDR support

### DIFF
--- a/src/nvenc/common_impl/nvenc_utils.cpp
+++ b/src/nvenc/common_impl/nvenc_utils.cpp
@@ -82,10 +82,18 @@ namespace nvenc {
         break;
 
       case video::colorspace_e::bt2020:
-        // Rec. 2020 with ST 2084 perceptual quantizer
+        // Rec. 2020 with ST 2084 perceptual quantizer (PQ)
         colorspace.primaries = NV_ENC_VUI_COLOR_PRIMARIES_BT2020;
         assert(sunshine_colorspace.bit_depth == 10);
         colorspace.tranfer_function = NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE2084;
+        colorspace.matrix = NV_ENC_VUI_MATRIX_COEFFS_BT2020_NCL;
+        break;
+
+      case video::colorspace_e::bt2020hlg:
+        // Rec. 2020 with Hybrid Log-Gamma (HLG)
+        colorspace.primaries = NV_ENC_VUI_COLOR_PRIMARIES_BT2020;
+        assert(sunshine_colorspace.bit_depth == 10);
+        colorspace.tranfer_function = NV_ENC_VUI_TRANSFER_CHARACTERISTIC_ARIB_STD_B67;
         colorspace.matrix = NV_ENC_VUI_MATRIX_COEFFS_BT2020_NCL;
         break;
     }

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -452,7 +452,7 @@ namespace platf {
 
   struct nvenc_encode_device_t: encode_device_t {
     virtual bool
-    init_encoder(const video::config_t &client_config, const video::sunshine_colorspace_t &colorspace) = 0;
+    init_encoder(const video::config_t &client_config, const video::sunshine_colorspace_t &colorspace, bool is_probe = false) = 0;
 
     nvenc::nvenc_encoder *nvenc = nullptr;
   };

--- a/src/platform/windows/display_device/device_hdr_states.cpp
+++ b/src/platform/windows/display_device/device_hdr_states.cpp
@@ -34,8 +34,10 @@ namespace display_device {
           return false;
         }
 
-        if (current_state == state) {
-          BOOST_LOG(debug) << "HDR state for " << device_id << " is already " << to_string(state) << ", skipping";
+        // 仅当「请求关闭且当前已关闭」时跳过。请求启用 HDR 时始终执行 set，避免因 get_hdr_state
+        // 滞后/错误（如 VDD 或拓扑刚变更）误判为已 enabled 而跳过，导致主机端实际仍为 SDR。
+        if (state == hdr_state_e::disabled && current_state == hdr_state_e::disabled) {
+          BOOST_LOG(debug) << "HDR state for " << device_id << " is already disabled, skipping";
           continue;
         }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1077,6 +1077,7 @@ namespace rtsp_stream {
       auto &monitor = config.monitor;
       monitor.height = getArg("x-nv-video[0].clientViewportHt"sv);
       monitor.width = getArg("x-nv-video[0].clientViewportWd"sv);
+      BOOST_LOG(info) << "Client requested stream resolution (clientViewport): " << monitor.width << "x" << monitor.height;
       monitor.framerate = getArg("x-nv-video[0].maxFPS"sv);
       monitor.bitrate = getArg("x-nv-vqos[0].bw.maximumBitrateKbps"sv);
       monitor.slicesPerFrame = getArg("x-nv-video[0].videoEncoderSlicesPerFrame"sv);

--- a/src/video.h
+++ b/src/video.h
@@ -65,8 +65,11 @@ namespace video {
 
     int videoFormat;  // 0 - H.264, 1 - HEVC, 2 - AV1
 
-    /* Encoding color depth (bit depth): 0 - 8-bit, 1 - 10-bit
-       HDR encoding activates when color depth is higher than 8-bit and the display which is being captured is operating in HDR mode */
+    /* Encoding color depth and HDR transfer function:
+       0 - SDR 8-bit
+       1 - HDR 10-bit with PQ (SMPTE ST 2084)
+       2 - HDR 10-bit with HLG (ARIB STD-B67)
+       HDR encoding activates when dynamicRange > 0 and the display is operating in HDR mode */
     int dynamicRange;
 
     int chromaSamplingType;  // 0 - 4:2:0, 1 - 4:4:4

--- a/src/video_colorspace.h
+++ b/src/video_colorspace.h
@@ -14,7 +14,8 @@ namespace video {
     rec601,  ///< Rec. 601
     rec709,  ///< Rec. 709
     bt2020sdr,  ///< Rec. 2020 SDR
-    bt2020,  ///< Rec. 2020 HDR
+    bt2020,  ///< Rec. 2020 HDR with PQ (ST 2084)
+    bt2020hlg,  ///< Rec. 2020 HDR with HLG (ARIB STD-B67)
   };
 
   struct sunshine_colorspace_t {
@@ -25,6 +26,12 @@ namespace video {
 
   bool
   colorspace_is_hdr(const sunshine_colorspace_t &colorspace);
+
+  bool
+  colorspace_is_hlg(const sunshine_colorspace_t &colorspace);
+
+  bool
+  colorspace_is_pq(const sunshine_colorspace_t &colorspace);
 
   // Declared in video.h
   struct config_t;

--- a/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_bicubic_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_bicubic_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,3 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#include "include/convert_yuv420_packed_uv_bicubic_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_type0_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_type0_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,5 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#define LEFT_SUBSAMPLING
+
+#include "include/convert_yuv420_packed_uv_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_type0s_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv420_packed_uv_type0s_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,5 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#define LEFT_SUBSAMPLING_SCALE
+
+#include "include/convert_yuv420_packed_uv_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv420_planar_y_bicubic_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv420_planar_y_bicubic_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,3 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#include "include/convert_yuv420_planar_y_bicubic_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv420_planar_y_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv420_planar_y_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,3 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#include "include/convert_yuv420_planar_y_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv444_packed_y410_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv444_packed_y410_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,4 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#define Y410
+#include "include/convert_yuv444_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/convert_yuv444_planar_ps_hybrid_log_gamma.hlsl
+++ b/src_assets/windows/assets/shaders/directx/convert_yuv444_planar_ps_hybrid_log_gamma.hlsl
@@ -1,0 +1,4 @@
+#include "include/convert_hybrid_log_gamma_base.hlsl"
+
+#define PLANAR_VIEWPORTS
+#include "include/convert_yuv444_ps_base.hlsl"

--- a/src_assets/windows/assets/shaders/directx/include/common.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/common.hlsl
@@ -39,3 +39,68 @@ float3 scRGBTo2100PQ(float3 rgb)
     // Apply the PQ transfer function on the raw color values in nits
     return NitsToPQ(rgb);
 }
+
+// HLG (Hybrid Log-Gamma) OETF as defined in ARIB STD-B67 / ITU-R BT.2100
+// Optimized: branchless vectorized implementation
+//
+// Note: HLG OETF is mathematically valid for L > 1, but output > 1 will be
+// clipped by the encoder (10-bit can only represent [0, 1]). We don't clip
+// in the shader to preserve precision; the encoder handles clipping.
+float3 LinearToHLG(float3 L)
+{
+    // HLG constants from ARIB STD-B67
+    static const float a = 0.17883277;
+    static const float b = 0.28466892;  // 1 - 4 * a
+    static const float c = 0.55991073;  // 0.5 - a * ln(4 * a)
+    static const float threshold = 1.0 / 12.0;
+
+    // Clamp negative values only (out of gamut), allow > 1 for HDR headroom
+    L = max(L, 0.0);
+
+    // Compute both branches for all channels (branchless)
+    // Low range: sqrt(3 * L)
+    float3 lowRange = sqrt(3.0 * L);
+
+    // High range: a * log(12 * L - b) + c
+    // For L > 1, this produces output > 1 which is fine (encoder clips later)
+    float3 highRange = a * log(max(12.0 * L - b, 1e-6)) + c;
+
+    // Branchless select using step function
+    float3 selector = step(threshold, L);
+
+    // Return unclamped result - let encoder handle clipping
+    return lerp(lowRange, highRange, selector);
+}
+
+float3 scRGBTo2100HLG(float3 rgb)
+{
+    // Convert from Rec 709 primaries (used by scRGB) to Rec 2020 primaries (used by Rec 2100)
+    rgb = Rec709toRec2020(rgb);
+
+    // scRGB luminance mapping to HLG:
+    // - scRGB 1.0 = 80 nits (SDR reference white)
+    // - HLG is scene-referred, OETF expects normalized scene light [0, 1]
+    // - For a 1000 nits peak display, HLG signal 1.0 maps to ~1000 nits
+    // - HLG reference white (75% signal) is ~203 nits
+    //
+    // Mapping strategy:
+    // - scRGB 1.0 (80 nits) should map to HLG ~0.5 (SDR-compatible level)
+    // - scRGB 12.5 (1000 nits) should map to HLG 1.0 (peak white)
+    //
+    // Scale factor: 80 nits / 1000 nits = 0.08
+    // This maps the full HDR range [0, 1000 nits] to HLG input [0, 1]
+    
+    static const float HDR_PEAK_NITS = 1000.0;
+    static const float SCRGB_NITS_PER_UNIT = 80.0;
+    static const float scaleToHLG = SCRGB_NITS_PER_UNIT / HDR_PEAK_NITS;  // 0.08
+    
+    // Convert scRGB to normalized scene light for HLG
+    // Negative values are clamped (out of gamut), but > 1.0 is preserved
+    // This allows content > 1000 nits to pass through (soft rolloff)
+    rgb = max(rgb, 0.0) * scaleToHLG;
+
+    // Apply the HLG OETF
+    // For input > 1.0, output will exceed 1.0 and be clipped by encoder
+    // This provides a natural "soft knee" rolloff for super-bright content
+    return LinearToHLG(rgb);
+}

--- a/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
@@ -1,0 +1,3 @@
+#include "include/common.hlsl"
+
+#define CONVERT_FUNCTION scRGBTo2100HLG


### PR DESCRIPTION
## Summary
Add HLG (Hybrid Log-Gamma) HDR encoding support alongside existing PQ (ST 2084).

## Changes
- **Colorspace**: `bt2020hlg`, `colorspace_is_hlg()` / `colorspace_is_pq()`
- **Client config**: `dynamicRange=2` selects HLG (1 = PQ, 0 = SDR)
- **Encoders**: NVENC VUI ARIB STD-B67; FFmpeg AVCOL_TRC_ARIB_STD_B67 for other encoders
- **Shaders**: scRGB→HLG conversion with luminance scaling and soft rolloff for highlights; HLG pixel shaders for all YUV layouts
- **Metadata**: PQ-only metadata (Mastering Display, HDR10+) when PQ; no static metadata for HLG