### PR TITLE
feat: QR code pairing support

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -13,6 +13,7 @@
 #include <iomanip>
 #include <atomic>
 #include <stdexcept>
+#include <random>
 #include <map>
 #include <set>
 #include <sstream>

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -58,6 +58,10 @@
 #include "version.h"
 #include "webhook.h"
 
+#ifdef _WIN32
+  #include <iphlpapi.h>
+#endif
+
 using namespace std::literals;
 using json = nlohmann::json;
 
@@ -1248,6 +1252,21 @@ namespace confighttp {
   }
 
   void
+  getQrPairStatus(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+
+    print_req(request);
+
+    nlohmann::json j;
+    j["status"] = nvhttp::get_qr_pair_status();
+
+    std::string content = j.dump();
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "application/json");
+    response->write(SimpleWeb::StatusCode::success_ok, content, headers);
+  }
+
+  void
   generateQrPairInfo(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) return;
 
@@ -1281,8 +1300,68 @@ namespace confighttp {
     auto local_addr = net::addr_to_normalized_string(request->local_endpoint().address());
     auto port = net::map_port(nvhttp::PORT_HTTP);
 
-    // Use external_ip if configured, otherwise use the local endpoint address
-    std::string host = config::nvhttp.external_ip.empty() ? local_addr : config::nvhttp.external_ip;
+    // Determine the host address for the QR code URL
+    std::string host;
+    if (!config::nvhttp.external_ip.empty()) {
+      // User explicitly configured an external IP (could be WAN for port-forwarded setups)
+      host = config::nvhttp.external_ip;
+    }
+    else {
+      // Detect a usable LAN IP (local_endpoint may be loopback or VPN)
+      host = local_addr;
+      auto host_net_type = net::from_address(host);
+      if (host_net_type != net::LAN) {
+        std::string resolved_host;
+
+        // Method 1: UDP connect trick to find default outgoing interface
+        try {
+          boost::asio::io_context io_ctx;
+          boost::asio::ip::udp::socket socket(io_ctx);
+          socket.connect(boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("8.8.8.8"), 53));
+          auto lan_addr = socket.local_endpoint().address();
+          socket.close();
+          auto candidate = net::addr_to_normalized_string(lan_addr);
+          if (net::from_address(candidate) == net::LAN) {
+            resolved_host = candidate;
+          }
+        }
+        catch (...) {}
+
+#ifdef _WIN32
+        // Method 2 (Windows): enumerate adapters via GetAdaptersAddresses
+        if (resolved_host.empty()) {
+          ULONG bufLen = 15000;
+          std::vector<uint8_t> buf(bufLen);
+          auto pAddresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buf.data());
+          if (GetAdaptersAddresses(AF_INET, GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST, nullptr, pAddresses, &bufLen) == NO_ERROR) {
+            for (auto adapter = pAddresses; adapter; adapter = adapter->Next) {
+              if (adapter->OperStatus != IfOperStatusUp) continue;
+              if (adapter->IfType == IF_TYPE_TUNNEL || adapter->IfType == IF_TYPE_PPP) continue;
+              for (auto unicast = adapter->FirstUnicastAddress; unicast; unicast = unicast->Next) {
+                if (unicast->Address.lpSockaddr->sa_family != AF_INET) continue;
+                auto sin = reinterpret_cast<sockaddr_in *>(unicast->Address.lpSockaddr);
+                boost::asio::ip::address_v4 addr(ntohl(sin->sin_addr.s_addr));
+                auto candidate = addr.to_string();
+                if (net::from_address(candidate) == net::LAN) {
+                  resolved_host = candidate;
+                  break;
+                }
+              }
+              if (!resolved_host.empty()) break;
+            }
+          }
+        }
+#endif
+
+        if (!resolved_host.empty()) {
+          host = resolved_host;
+          BOOST_LOG(info) << "QR pair: resolved to LAN IP " << host;
+        }
+        else {
+          BOOST_LOG(warning) << "QR pair: could not find a LAN IP, using " << host;
+        }
+      }
+    }
 
     // Build the moonlight:// URL
     std::string url = "moonlight://pair?host=" + host +
@@ -2026,6 +2105,7 @@ namespace confighttp {
     server.resource["^/api/pin$"]["POST"] = savePin;
     server.resource["^/api/qr-pair$"]["POST"] = generateQrPairInfo;
     server.resource["^/api/qr-pair/cancel$"]["POST"] = cancelQrPair;
+    server.resource["^/api/qr-pair$"]["GET"] = getQrPairStatus;
     server.resource["^/api/apps$"]["GET"] = getApps;
     server.resource["^/api/logs$"]["GET"] = getLogs;
     server.resource["^/api/apps$"]["POST"] = saveApp;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6,6 +6,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 // standard includes
+#include <chrono>
 #include <filesystem>
 #include <map>
 #include <memory>
@@ -90,8 +91,52 @@ namespace nvhttp {
     std::string pin;
     std::string name;
     std::chrono::steady_clock::time_point expires_at;
+    bool paired = false;
     std::mutex mutex;
   } preset_pin_state;
+
+  // Rate limiting for pairing attempts per IP
+  struct pair_rate_limiter_t {
+    std::unordered_map<std::string, std::pair<int, std::chrono::steady_clock::time_point>> attempts;
+    std::mutex mutex;
+
+    bool
+    check_and_record(const std::string &ip) {
+      constexpr int max_attempts = 5;
+      constexpr int window_seconds = 60;
+      std::lock_guard lock { mutex };
+      auto now = std::chrono::steady_clock::now();
+      auto &entry = attempts[ip];
+
+      // Reset window if expired
+      if (now - entry.second > std::chrono::seconds(window_seconds)) {
+        entry = { 0, now };
+      }
+
+      if (entry.first >= max_attempts) {
+        return false;  // rate limited
+      }
+
+      entry.first++;
+      return true;
+    }
+
+    void
+    cleanup() {
+      constexpr int window_seconds = 60;
+      std::lock_guard lock { mutex };
+      auto now = std::chrono::steady_clock::now();
+      for (auto it = attempts.begin(); it != attempts.end();) {
+        if (now - it->second.second > std::chrono::seconds(window_seconds * 2)) {
+          it = attempts.erase(it);
+        }
+        else {
+          ++it;
+        }
+      }
+    }
+  };
+  static pair_rate_limiter_t pair_rate_limit;
 
   // Map to store certificate UUIDs keyed by request pointer
   // Using weak_ptr to track request lifetime and prevent memory leaks
@@ -740,6 +785,24 @@ namespace nvhttp {
   pair(std::shared_ptr<safe::queue_t<crypto::x509_t>> &add_cert, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> response, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Request> request) {
     print_req<T>(request);
 
+    // Rate limit pairing attempts per IP
+    auto client_ip = request->remote_endpoint().address().to_string();
+    if (!pair_rate_limit.check_and_record(client_ip)) {
+      BOOST_LOG(warning) << "Pairing rate limited for IP: " << client_ip;
+      pt::ptree rate_tree;
+      rate_tree.put("root.<xmlattr>.status_code", 429);
+      rate_tree.put("root.<xmlattr>.status_message", "Too many pairing attempts. Try again later.");
+      rate_tree.put("root.paired", 0);
+      std::ostringstream data;
+      pt::write_xml(data, rate_tree);
+      response->write(data.str());
+      response->close_connection_after_response = true;
+      return;
+    }
+
+    // Periodically clean up stale rate limit entries
+    pair_rate_limit.cleanup();
+
     pt::ptree tree;
 
     auto fg = util::fail_guard([&]() {
@@ -1013,6 +1076,7 @@ namespace nvhttp {
     preset_pin_state.pin = pin;
     preset_pin_state.name = name;
     preset_pin_state.expires_at = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_seconds);
+    preset_pin_state.paired = false;
     BOOST_LOG(info) << "Preset PIN set for QR pairing, expires in " << timeout_seconds << "s";
     return true;
   }
@@ -1039,6 +1103,20 @@ namespace nvhttp {
     std::lock_guard lock { preset_pin_state.mutex };
     preset_pin_state.pin.clear();
     preset_pin_state.name.clear();
+    preset_pin_state.paired = true;
+  }
+
+  std::string
+  get_qr_pair_status() {
+    std::lock_guard lock { preset_pin_state.mutex };
+    if (preset_pin_state.paired) return "paired";
+    if (preset_pin_state.pin.empty()) return "inactive";
+    if (std::chrono::steady_clock::now() > preset_pin_state.expires_at) {
+      preset_pin_state.pin.clear();
+      preset_pin_state.name.clear();
+      return "expired";
+    }
+    return "active";
   }
 
   // Use keep-alive connection

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -235,6 +235,13 @@ namespace nvhttp {
   clear_preset_pin();
 
   /**
+   * @brief Get the current QR pair status.
+   * @return "active", "paired", "expired", or "inactive".
+   */
+  std::string
+  get_qr_pair_status();
+
+  /**
    * @brief Remove all paired clients.
    * @examples
    * nvhttp::erase_all_clients();

--- a/src_assets/common/assets/web/composables/useQrPair.js
+++ b/src_assets/common/assets/web/composables/useQrPair.js
@@ -9,10 +9,18 @@ export function useQrPair() {
   const qrRemaining = ref(0)
   const qrLoading = ref(false)
   const qrError = ref('')
+  const qrPaired = ref(false)
 
   let countdownTimer = null
+  let pollTick = 0
 
   const qrActive = computed(() => qrRemaining.value > 0 && qrDataUrl.value !== '')
+
+  const resetQrDisplay = () => {
+    qrDataUrl.value = ''
+    qrPin.value = ''
+    qrUrl.value = ''
+  }
 
   const stopCountdown = () => {
     if (countdownTimer) {
@@ -23,15 +31,28 @@ export function useQrPair() {
 
   const startCountdown = () => {
     stopCountdown()
-    countdownTimer = setInterval(() => {
+    pollTick = 0
+    countdownTimer = setInterval(async () => {
       const now = Date.now()
       const remaining = Math.max(0, Math.floor((qrExpiresAt.value - now) / 1000))
       qrRemaining.value = remaining
       if (remaining <= 0) {
         stopCountdown()
-        qrDataUrl.value = ''
-        qrPin.value = ''
-        qrUrl.value = ''
+        resetQrDisplay()
+        return
+      }
+
+      // Poll status every 2 ticks
+      if (++pollTick % 2 === 0) {
+        try {
+          const res = await fetch('/api/qr-pair')
+          const data = await res.json()
+          if (data.status === 'paired') {
+            stopCountdown()
+            resetQrDisplay()
+            qrPaired.value = true
+          }
+        } catch (e) { /* ignore */ }
       }
     }, 1000)
   }
@@ -39,6 +60,7 @@ export function useQrPair() {
   const generateQrCode = async () => {
     qrLoading.value = true
     qrError.value = ''
+    qrPaired.value = false
     try {
       const response = await fetch('/api/qr-pair', { method: 'POST' })
       const data = await response.json()
@@ -70,9 +92,7 @@ export function useQrPair() {
 
   const cancelQrCode = async () => {
     stopCountdown()
-    qrDataUrl.value = ''
-    qrPin.value = ''
-    qrUrl.value = ''
+    resetQrDisplay()
     qrRemaining.value = 0
     try {
       await fetch('/api/qr-pair/cancel', { method: 'POST' })
@@ -92,6 +112,7 @@ export function useQrPair() {
     qrRemaining,
     qrLoading,
     qrError,
+    qrPaired,
     qrActive,
     generateQrCode,
     cancelQrCode,

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -601,6 +601,7 @@
     "qr_generate": "Generate QR Code",
     "qr_refresh": "Refresh",
     "qr_expires_in": "Expires in {seconds}s",
+    "qr_paired_success": "Pairing successful!",
     "or_manual_pin": "or enter PIN manually",
     "remove_paired_devices_desc": "Remove your paired devices.",
     "save_changes": "Save changes",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -601,6 +601,7 @@
     "qr_generate": "生成二维码",
     "qr_refresh": "刷新",
     "qr_expires_in": "{seconds} 秒后过期",
+    "qr_paired_success": "配对成功！",
     "or_manual_pin": "或手动输入 PIN 码",
     "remove_paired_devices_desc": "移除您已配对的设备。",
     "save_changes": "保存更改",

--- a/src_assets/common/assets/web/views/Pin.vue
+++ b/src_assets/common/assets/web/views/Pin.vue
@@ -39,6 +39,17 @@
             </div>
           </div>
 
+          <!-- Pairing Success -->
+          <div v-else-if="qrPaired" class="qr-success">
+            <div class="mb-3">
+              <i class="fas fa-check-circle text-success" style="font-size: 3rem;"></i>
+            </div>
+            <h5 class="text-success mb-3">{{ $t('pin.qr_paired_success') }}</h5>
+            <button class="btn btn-outline-primary btn-sm" @click="qrPaired = false">
+              {{ $t('_common.ok') }}
+            </button>
+          </div>
+
           <!-- Generate Button -->
           <div v-else>
             <div v-if="qrError" class="alert alert-danger mb-3">{{ qrError }}</div>
@@ -320,6 +331,7 @@ const {
   qrRemaining,
   qrLoading,
   qrError,
+  qrPaired,
   qrActive,
   generateQrCode,
   cancelQrCode,


### PR DESCRIPTION
## Summary

Add QR code pairing support to Sunshine, allowing Moonlight clients to pair by scanning a QR code from the Web UI instead of manually entering a PIN.

## Changes

### Core QR Pairing (`62025988`)
- **`POST /api/qr-pair`** endpoint generates a `moonlight://pair?host=...&port=...&pin=...` URL
- Preset PIN mechanism in nvhttp: `set_preset_pin()` / `get_preset_pin()` / `clear_preset_pin()` with 120s auto-expiry
- PIN consumed automatically during `getservercert` pairing phase
- Web UI: QR code display with countdown timer, cancel/refresh controls
- Vue composable `useQrPair.js` for state management

### IP Detection & Security Hardening (`6fa0c2b0`)
- **LAN IP detection**: resolve loopback/VPN addresses to real LAN IP
  - UDP connect trick (connect to 8.8.8.8:53, read local endpoint)
  - Windows fallback: `GetAdaptersAddresses` enumeration, skip tunnel/PPP adapters
  - `external_ip` config takes priority for WAN/port-forwarded setups
- **Security**: `random_device` for PIN generation, 4-digit format validation, per-IP rate limiting (5 attempts/min)
- **Pairing feedback**: `GET /api/qr-pair` returns status (`active`/`paired`/`expired`/`inactive`), frontend polls every 2s and shows success UI on completion

### Misc
- Remove non-ASCII image filenames that break CPack ZIP packaging
- Update sunshine-control-panel submodule