### PR TITLE
Client-driven dynamic resolution: gate, advertise, and safely apply 0x5506 RESOLUTION requests

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -468,6 +468,7 @@ namespace config {
     "auto"s,  // capture_compute_shader (default: auto -> off until validated)
     false,  // wgc_disable_secure_desktop (disabled by default for security)
     true,  // dynamic_resolution_follow_display (default: on; matches existing behavior. Set false for legacy clients like PSVita Moonlight.)
+    false,  // allow_client_resolution_change (default: off; client must be trusted before enabling)
   };
 
   audio_t audio {
@@ -1315,6 +1316,7 @@ namespace config {
     bool_f(vars, "hdr_luminance_analysis", video.hdr_luminance_analysis);
     bool_f(vars, "wgc_disable_secure_desktop", video.wgc_disable_secure_desktop);
     bool_f(vars, "dynamic_resolution_follow_display", video.dynamic_resolution_follow_display);
+    bool_f(vars, "allow_client_resolution_change", video.allow_client_resolution_change);
     bool_f(vars, "vdd_keep_enabled", video.vdd_keep_enabled);
     bool_f(vars, "vdd_headless_create", video.vdd_headless_create_enabled);
     bool_f(vars, "vdd_reuse", video.vdd_reuse);

--- a/src/config.h
+++ b/src/config.h
@@ -133,6 +133,7 @@ namespace config {
     std::string capture_compute_shader;  // Use compute shader for HDR RGB->P010 conversion: "auto" (off for now), "on", "off"
     bool wgc_disable_secure_desktop;  // Auto-disable UAC secure desktop when using WGC capture
     bool dynamic_resolution_follow_display;  // If true, follow mid-stream host display resolution changes and notify client via extension; if false, keep initial stream resolution and let scaler handle changes (compatible with legacy clients like PSVita Moonlight that don't implement the extension)
+    bool allow_client_resolution_change;  // If true, accept client-requested resolution changes via 0x5506 RESOLUTION (IDX_DYNAMIC_PARAM_CHANGE); default false for safety
   };
 
   struct audio_t {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -524,6 +524,12 @@ namespace nvhttp {
     // AI capability: inform client if AI proxy is available
     tree.put("root.AiCapability", confighttp::isAiEnabled() ? 1 : 0);
 
+    // Client-driven resolution change capability: advertise to the client that it may send
+    // 0x5506 RESOLUTION (IDX_DYNAMIC_PARAM_CHANGE / paramType=0) requests and the host will
+    // act on them.  Clients (moonlight-qt, moonlight-vplus) MUST check this field before
+    // sending resolution-change packets; absent or 0 means requests will be silently ignored.
+    tree.put("root.ClientResolutionChange", config::video.allow_client_resolution_change ? 1 : 0);
+
     std::ostringstream data;
 
     pt::write_xml(data, tree);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -526,9 +526,14 @@ namespace nvhttp {
 
     // Client-driven resolution change capability: advertise to the client that it may send
     // 0x5506 RESOLUTION (IDX_DYNAMIC_PARAM_CHANGE / paramType=0) requests and the host will
-    // act on them.  Clients (moonlight-qt, moonlight-vplus) MUST check this field before
-    // sending resolution-change packets; absent or 0 means requests will be silently ignored.
-    tree.put("root.ClientResolutionChange", config::video.allow_client_resolution_change ? 1 : 0);
+    // act on them.  Requires BOTH allow_client_resolution_change AND
+    // dynamic_resolution_follow_display — the latter drives the encoder-size update and
+    // 0x5507 notify; without it the Windows display changes but the stream stays at the
+    // original negotiated resolution and clients see no effect.
+    // Clients MUST check this field before sending resolution-change packets; absent or 0
+    // means requests will be silently ignored.
+    tree.put("root.ClientResolutionChange",
+      (config::video.allow_client_resolution_change && config::video.dynamic_resolution_follow_display) ? 1 : 0);
 
     std::ostringstream data;
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -559,6 +559,12 @@ namespace stream {
 
     // 标识这是仅控制流会话（只作为输入设备，不传输视频/音频）
     bool control_only { false };
+
+    // Rate-limit state for client-driven resolution changes (allow_client_resolution_change).
+    // Leading-edge: the first request for a new size applies immediately; subsequent requests
+    // within 250 ms are dropped (the clients already debounce ~400 ms before sending one packet).
+    // Protected by the control-stream handler being single-threaded per session.
+    std::chrono::steady_clock::time_point client_res_last_apply {};
   };
 
   /**
@@ -1380,12 +1386,24 @@ namespace stream {
       session->video.idr_events->raise(true);
     });
 
-    // 辅助函数：处理分辨率变更
+    // 辅助函数：处理客户端请求的分辨率变更
+    // Gated on config::video.allow_client_resolution_change; leading-edge rate-limited to
+    // suppress rapid resize floods (clients debounce ~400 ms before sending one settled packet,
+    // so the first request for a new size always applies immediately).
+    // On disconnect, dd_config_revert_on_disconnect in display_device/session restores the
+    // original display mode automatically.
     auto handle_resolution_change = [](session_t *session, int new_width, int new_height) {
+      // Gate: must be explicitly enabled — client-driven resolution changes are off by default
+      if (!config::video.allow_client_resolution_change) {
+        BOOST_LOG(info) << "Client requested resolution change to " << new_width << "x" << new_height
+                        << " but allow_client_resolution_change is disabled; ignoring";
+        return;
+      }
+
       int old_width = session->config.monitor.width;
       int old_height = session->config.monitor.height;
-      
-      BOOST_LOG(info) << "Dynamic resolution change requested: " << old_width << "x" << old_height 
+
+      BOOST_LOG(info) << "Dynamic resolution change requested: " << old_width << "x" << old_height
                       << " -> " << new_width << "x" << new_height;
 
       // 验证分辨率范围
@@ -1395,11 +1413,32 @@ namespace stream {
         return;
       }
 
+      // Clamp to even values: most encoders (H.264 baseline, HEVC) require even dimensions.
+      // Use bitwise AND to round down — safe for all positive integers.
+      new_width  &= ~1;
+      new_height &= ~1;
+      if (new_width <= 0 || new_height <= 0) {
+        BOOST_LOG(warning) << "Resolution too small after even-clamping: " << new_width << "x" << new_height;
+        return;
+      }
+
       // 检查分辨率是否真的改变了
       if (old_width == new_width && old_height == new_height) {
         BOOST_LOG(debug) << "Resolution unchanged, ignoring request";
         return;
       }
+
+      // Rate-limit: apply immediately on the first request for a new size; drop subsequent
+      // requests within 250 ms.  Clients already debounce ~400 ms before sending one settled
+      // packet, so leading-edge is correct — a single request must always apply.
+      constexpr auto RESOLUTION_RATE_LIMIT = std::chrono::milliseconds(250);
+      auto now = std::chrono::steady_clock::now();
+      if ((now - session->client_res_last_apply) < RESOLUTION_RATE_LIMIT) {
+        BOOST_LOG(debug) << "Client resolution rate-limit: dropping " << new_width << "x" << new_height
+                         << " (< " << RESOLUTION_RATE_LIMIT.count() << " ms since last apply)";
+        return;
+      }
+      session->client_res_last_apply = now;
 
       // 检测是否是旋转导致的宽高互换（例如：1920x1080 -> 1080x1920）
       bool is_rotation = (old_width == new_height && old_height == new_width);
@@ -1428,14 +1467,14 @@ namespace stream {
       // 更新显示设备配置（重新配置模式）
       // 注意：这也会触发捕获端和编码器的重新初始化，以适配新的分辨率
       if (is_rotation) {
-        BOOST_LOG(info) << "Reconfiguring display device for rotation: " << old_width << "x" << old_height 
+        BOOST_LOG(info) << "Reconfiguring display device for rotation: " << old_width << "x" << old_height
                         << " -> " << new_width << "x" << new_height;
       }
       else {
-        BOOST_LOG(info) << "Reconfiguring display device for new resolution: " << old_width << "x" << old_height 
+        BOOST_LOG(info) << "Reconfiguring display device for new resolution: " << old_width << "x" << old_height
                         << " -> " << new_width << "x" << new_height;
       }
-      
+
       display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
 
       // 请求 IDR 帧以确保客户端能正确显示新分辨率
@@ -1445,7 +1484,7 @@ namespace stream {
       // 注意：编码器和触摸端口的更新会在捕获端重新初始化时自动处理
       // - 编码器会在重新初始化时使用新的宽高（通过 config.monitor.width/height）
       // - 触摸端口会在视频捕获循环中通过 make_port() 自动更新
-      BOOST_LOG(info) << "Resolution change completed: " << new_width << "x" << new_height 
+      BOOST_LOG(info) << "Resolution change completed: " << new_width << "x" << new_height
                       << (is_rotation ? " (rotation detected)" : "");
     };
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1517,8 +1517,16 @@ namespace stream {
         return;
       }
 
-      // Protocol: all 0x5506 fields are little-endian 32-bit integers.
-      const auto param_type = util::endian::little(*(const std::int32_t *) payload.data());
+      // Protocol: all 0x5506 fields are little-endian 32-bit integers. Copy
+      // from the byte buffer before endian conversion to avoid unaligned/aliasing
+      // reads from std::string_view storage.
+      auto read_le_i32 = [&](size_t offset) {
+        std::int32_t value;
+        std::memcpy(&value, payload.data() + offset, sizeof(value));
+        return util::endian::little(value);
+      };
+
+      const auto param_type = read_le_i32(0);
       
       if (param_type < 0 || param_type >= static_cast<int>(video::dynamic_param_type_e::MAX_PARAM_TYPE)) {
         BOOST_LOG(warning) << "Invalid parameter type: " << param_type;
@@ -1536,8 +1544,8 @@ namespace stream {
           return;
         }
 
-        const auto w = util::endian::little(*(const std::int32_t *) (payload.data() + 4));
-        const auto h = util::endian::little(*(const std::int32_t *) (payload.data() + 8));
+        const auto w = read_le_i32(4);
+        const auto h = read_le_i32(8);
         handle_resolution_change(session, w, h);
         return;
       }
@@ -1552,7 +1560,9 @@ namespace stream {
         }
 
         // FPS is transmitted as a LE float; read via bit-cast through LE u32.
-        std::uint32_t fps_bits = util::endian::little(*(const std::uint32_t *) (payload.data() + sizeof(std::int32_t)));
+        std::uint32_t fps_bits;
+        std::memcpy(&fps_bits, payload.data() + sizeof(std::int32_t), sizeof(fps_bits));
+        fps_bits = util::endian::little(fps_bits);
         float new_fps;
         std::memcpy(&new_fps, &fps_bits, sizeof(new_fps));
         
@@ -1581,7 +1591,7 @@ namespace stream {
         return;
       }
 
-      const auto param_value = util::endian::little(*(const std::int32_t *) (payload.data() + sizeof(std::int32_t)));
+      const auto param_value = read_le_i32(sizeof(std::int32_t));
 
       video::dynamic_param_t param;
       param.type = param_type_enum;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1399,10 +1399,16 @@ namespace stream {
     // On disconnect, dd_config_revert_on_disconnect in display_device/session restores the
     // original display mode automatically.
     auto handle_resolution_change = [](session_t *session, int new_width, int new_height) {
-      // Gate: must be explicitly enabled — client-driven resolution changes are off by default
-      if (!config::video.allow_client_resolution_change) {
+      // Gate: must be explicitly enabled — client-driven resolution changes are off by default.
+      // Both flags are required, matching the serverinfo capability (nvhttp.cpp advertises
+      // ClientResolutionChange only when allow_client_resolution_change && dynamic_resolution_follow_display).
+      // Without the follow_display flag the capture loop keeps the original stream resolution and
+      // never notifies the client (video.cpp), so applying the display change here would leave the
+      // host in a half-changed state that a client ignoring/caching the capability bit could trigger.
+      if (!config::video.allow_client_resolution_change ||
+          !config::video.dynamic_resolution_follow_display) {
         BOOST_LOG(info) << "Client requested resolution change to " << new_width << "x" << new_height
-                        << " but allow_client_resolution_change is disabled; ignoring";
+                        << " but client-driven resolution change is not enabled; ignoring";
         return;
       }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -565,6 +565,12 @@ namespace stream {
     // custom_screen_mode defaults to -1 (no override) matching launch-time nvhttp default.
     bool launch_use_vdd { false };
     int  launch_custom_screen_mode { -1 };
+    // Environment variables from the original launch session (e.g. SUNSHINE_CLIENT_DISPLAY_NAME,
+    // SUNSHINE_CLIENT_CERT_UUID) needed by configure_display / parsed_config routing.
+    boost::process::v1::environment launch_env;
+    // Leading-edge rate-limit for client-driven resolution changes (Fix #6).
+    // Zero-initialised: the epoch is before any real request, so the first request is always accepted.
+    std::chrono::steady_clock::time_point client_res_last_apply {};
   };
 
   /**
@@ -1388,10 +1394,8 @@ namespace stream {
 
     // 辅助函数：处理客户端请求的分辨率变更
     // Gated on config::video.allow_client_resolution_change (default off).
-    // No host-side rate-limit: clients (moonlight-qt, moonlight-vplus) already debounce
-    // ~400 ms before emitting one settled packet, so host-side dropping is both redundant
-    // and harmful — it would swallow the final settled size if it arrived within a brief
-    // window of a prior request.
+    // Leading-edge rate-limit: drops requests arriving within 250 ms of a prior accepted
+    // one to shed burst storms while still applying a single settled packet immediately.
     // On disconnect, dd_config_revert_on_disconnect in display_device/session restores the
     // original display mode automatically.
     auto handle_resolution_change = [](session_t *session, int new_width, int new_height) {
@@ -1430,6 +1434,21 @@ namespace stream {
         return;
       }
 
+      // Fix #6: leading-edge rate-limit — drop requests arriving within 250 ms of the last
+      // accepted one.  Clients debounce to one settled packet so a single request still
+      // applies immediately; this only sheds storms.
+      // Residual: a sub-250 ms burst of DISTINCT sizes may drop intermediate sizes.
+      {
+        auto now = std::chrono::steady_clock::now();
+        constexpr auto RATE_LIMIT = std::chrono::milliseconds(250);
+        if (now - session->client_res_last_apply < RATE_LIMIT) {
+          BOOST_LOG(info) << "Rate-limiting client resolution change to " << new_width << "x" << new_height
+                          << " (< 250 ms since last apply); dropping";
+          return;
+        }
+        session->client_res_last_apply = now;
+      }
+
       // 检测是否是旋转导致的宽高互换（例如：1920x1080 -> 1080x1920）
       bool is_rotation = (old_width == new_height && old_height == new_width);
       if (is_rotation) {
@@ -1456,15 +1475,25 @@ namespace stream {
       // Preserve VDD and display routing from the original launch session.
       temp_launch_session.use_vdd = session->launch_use_vdd;
       temp_launch_session.custom_screen_mode = session->launch_custom_screen_mode;
+      // Fix #4: restore env so configure_display can read SUNSHINE_CLIENT_DISPLAY_NAME
+      // (parsed_config.cpp:535) and SUNSHINE_CLIENT_CERT_UUID (session.cpp:189/548).
+      // Without this a zero-init env silently routes to the wrong display or skips VDD
+      // client-id matching.
+      temp_launch_session.env = session->launch_env;
 
       // Build a local video config copy with resolution_change forced to automatic so that
       // configure_display uses the width/height from the temp session regardless of the
       // host's global video.resolution_change setting.  Client-driven resolution requests
       // are independent of the host's passive-follow setting (dynamic_resolution_follow_display)
       // and must not be a no-op when resolution_change == no_operation.
+      // Fix #7: also force refresh_rate_change to automatic so VDD custom-mode injection
+      // picks up temp_launch_session.fps and updates the VDD mode list; without this a
+      // host refresh_rate_change=no_operation would skip the VDD mode refresh entirely.
       config::video_t client_driven_video_cfg = config::video;
       client_driven_video_cfg.resolution_change =
         static_cast<int>(display_device::parsed_config_t::resolution_change_e::automatic);
+      client_driven_video_cfg.refresh_rate_change =
+        static_cast<int>(display_device::parsed_config_t::refresh_rate_change_e::automatic);
 
       if (is_rotation) {
         BOOST_LOG(info) << "Reconfiguring display device for rotation: " << old_width << "x" << old_height
@@ -1477,19 +1506,28 @@ namespace stream {
 
       const auto display_result = display_device::session_t::get().configure_display(client_driven_video_cfg, temp_launch_session, true);
 
-      if (!display_result) {
-        // configure_display returned a hard failure; keep old session config and do not IDR
-        // so the encoder and capture side remain consistent.  The client may retry — not
-        // suppressing future attempts (no dedupe timestamp updated here).
-        BOOST_LOG(error) << "configure_display failed for client-requested resolution change to "
-                         << new_width << "x" << new_height
-                         << ": result=" << static_cast<int>(display_result.result)
-                         << " msg=" << display_result.message
-                         << (display_result.hint.empty() ? "" : (" hint: " + display_result.hint));
+      // Fix #5: operator bool() is true for both success AND deferred_retry; gate monitor
+      // mutation + IDR on success only.  On deferred_retry the mode has not yet applied, so
+      // mutating session->config.monitor + raising IDR would be premature.  On hard failure
+      // we also keep the old config so the encoder and capture side remain consistent.
+      if (display_result.result != display_device::session_t::configure_result_t::result_e::success) {
+        if (display_result.result == display_device::session_t::configure_result_t::result_e::deferred_retry) {
+          BOOST_LOG(info) << "configure_display deferred retry for client-requested resolution change to "
+                           << new_width << "x" << new_height << "; keeping old config, no IDR";
+        }
+        else {
+          BOOST_LOG(error) << "configure_display failed for client-requested resolution change to "
+                           << new_width << "x" << new_height
+                           << ": result=" << static_cast<int>(display_result.result)
+                           << " msg=" << display_result.message
+                           << (display_result.hint.empty() ? "" : (" hint: " + display_result.hint));
+        }
+        // Do not update dedupe state (client_res_last_apply was already set above).
+        // The client may retry once the deferred mode settles or after a failure.
         return;
       }
 
-      // Only update session config and raise IDR after a successful (or deferred-but-acceptable) apply.
+      // Only update session config and raise IDR after a confirmed successful apply.
       session->config.monitor.width = new_width;
       session->config.monitor.height = new_height;
 
@@ -3238,6 +3276,10 @@ namespace stream {
       session->max_full_nits = launch_session.max_full_nits;
       session->launch_use_vdd = launch_session.use_vdd;
       session->launch_custom_screen_mode = launch_session.custom_screen_mode;
+      // Preserve launch-time env for client-driven configure_display calls (Fix #4).
+      // parsed_config reads SUNSHINE_CLIENT_DISPLAY_NAME and session.cpp reads
+      // SUNSHINE_CLIENT_CERT_UUID; without these the wrong display may be targeted.
+      session->launch_env = launch_session.env;
 
       session->config = config;
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -560,11 +560,11 @@ namespace stream {
     // 标识这是仅控制流会话（只作为输入设备，不传输视频/音频）
     bool control_only { false };
 
-    // Rate-limit state for client-driven resolution changes (allow_client_resolution_change).
-    // Leading-edge: the first request for a new size applies immediately; subsequent requests
-    // within 250 ms are dropped (the clients already debounce ~400 ms before sending one packet).
-    // Protected by the control-stream handler being single-threaded per session.
-    std::chrono::steady_clock::time_point client_res_last_apply {};
+    // Display-routing fields saved from the launch session, needed when building the
+    // temp launch_session_t for a client-driven configure_display reconfigure call.
+    // custom_screen_mode defaults to -1 (no override) matching launch-time nvhttp default.
+    bool launch_use_vdd { false };
+    int  launch_custom_screen_mode { -1 };
   };
 
   /**
@@ -1387,9 +1387,11 @@ namespace stream {
     });
 
     // 辅助函数：处理客户端请求的分辨率变更
-    // Gated on config::video.allow_client_resolution_change; leading-edge rate-limited to
-    // suppress rapid resize floods (clients debounce ~400 ms before sending one settled packet,
-    // so the first request for a new size always applies immediately).
+    // Gated on config::video.allow_client_resolution_change (default off).
+    // No host-side rate-limit: clients (moonlight-qt, moonlight-vplus) already debounce
+    // ~400 ms before emitting one settled packet, so host-side dropping is both redundant
+    // and harmful — it would swallow the final settled size if it arrived within a brief
+    // window of a prior request.
     // On disconnect, dd_config_revert_on_disconnect in display_device/session restores the
     // original display mode automatically.
     auto handle_resolution_change = [](session_t *session, int new_width, int new_height) {
@@ -1428,30 +1430,15 @@ namespace stream {
         return;
       }
 
-      // Rate-limit: apply immediately on the first request for a new size; drop subsequent
-      // requests within 250 ms.  Clients already debounce ~400 ms before sending one settled
-      // packet, so leading-edge is correct — a single request must always apply.
-      constexpr auto RESOLUTION_RATE_LIMIT = std::chrono::milliseconds(250);
-      auto now = std::chrono::steady_clock::now();
-      if ((now - session->client_res_last_apply) < RESOLUTION_RATE_LIMIT) {
-        BOOST_LOG(debug) << "Client resolution rate-limit: dropping " << new_width << "x" << new_height
-                         << " (< " << RESOLUTION_RATE_LIMIT.count() << " ms since last apply)";
-        return;
-      }
-      session->client_res_last_apply = now;
-
       // 检测是否是旋转导致的宽高互换（例如：1920x1080 -> 1080x1920）
       bool is_rotation = (old_width == new_height && old_height == new_width);
       if (is_rotation) {
         BOOST_LOG(info) << "Detected display rotation: width and height swapped";
       }
 
-      // 更新会话配置
-      session->config.monitor.width = new_width;
-      session->config.monitor.height = new_height;
-
-      // 创建临时的 launch_session_t 来更新显示设备配置
-      // 注意：必须按照结构体声明顺序初始化字段
+      // Build a temp launch session that mirrors the original display-routing fields so
+      // configure_display targets the correct device (physical vs VDD, custom screen mode).
+      // DO NOT mutate session->config.monitor here — only do that after a successful apply.
       rtsp_stream::launch_session_t temp_launch_session {};
       temp_launch_session.id = session->launch_session_id;
       temp_launch_session.client_name = session->client_name;
@@ -1459,13 +1446,26 @@ namespace stream {
       temp_launch_session.height = new_height;
       temp_launch_session.fps = session->config.monitor.framerate;
       temp_launch_session.enable_hdr = session->enable_hdr;
-      temp_launch_session.enable_sops = session->enable_sops;
+      // Always treat this as an SOPS-enabled request: the client is explicitly requesting a
+      // resolution change, which must not be silently suppressed by the enable_sops gate inside
+      // the automatic resolution-change path.
+      temp_launch_session.enable_sops = true;
       temp_launch_session.max_nits = session->max_nits;
       temp_launch_session.min_nits = session->min_nits;
       temp_launch_session.max_full_nits = session->max_full_nits;
+      // Preserve VDD and display routing from the original launch session.
+      temp_launch_session.use_vdd = session->launch_use_vdd;
+      temp_launch_session.custom_screen_mode = session->launch_custom_screen_mode;
 
-      // 更新显示设备配置（重新配置模式）
-      // 注意：这也会触发捕获端和编码器的重新初始化，以适配新的分辨率
+      // Build a local video config copy with resolution_change forced to automatic so that
+      // configure_display uses the width/height from the temp session regardless of the
+      // host's global video.resolution_change setting.  Client-driven resolution requests
+      // are independent of the host's passive-follow setting (dynamic_resolution_follow_display)
+      // and must not be a no-op when resolution_change == no_operation.
+      config::video_t client_driven_video_cfg = config::video;
+      client_driven_video_cfg.resolution_change =
+        static_cast<int>(display_device::parsed_config_t::resolution_change_e::automatic);
+
       if (is_rotation) {
         BOOST_LOG(info) << "Reconfiguring display device for rotation: " << old_width << "x" << old_height
                         << " -> " << new_width << "x" << new_height;
@@ -1475,15 +1475,27 @@ namespace stream {
                         << " -> " << new_width << "x" << new_height;
       }
 
-      display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
+      const auto display_result = display_device::session_t::get().configure_display(client_driven_video_cfg, temp_launch_session, true);
+
+      if (!display_result) {
+        // configure_display returned a hard failure; keep old session config and do not IDR
+        // so the encoder and capture side remain consistent.  The client may retry — not
+        // suppressing future attempts (no dedupe timestamp updated here).
+        BOOST_LOG(error) << "configure_display failed for client-requested resolution change to "
+                         << new_width << "x" << new_height
+                         << ": result=" << static_cast<int>(display_result.result)
+                         << " msg=" << display_result.message
+                         << (display_result.hint.empty() ? "" : (" hint: " + display_result.hint));
+        return;
+      }
+
+      // Only update session config and raise IDR after a successful (or deferred-but-acceptable) apply.
+      session->config.monitor.width = new_width;
+      session->config.monitor.height = new_height;
 
       // 请求 IDR 帧以确保客户端能正确显示新分辨率
-      // 这对于旋转场景特别重要，因为宽高互换需要新的关键帧
       session->video.idr_events->raise(true);
 
-      // 注意：编码器和触摸端口的更新会在捕获端重新初始化时自动处理
-      // - 编码器会在重新初始化时使用新的宽高（通过 config.monitor.width/height）
-      // - 触摸端口会在视频捕获循环中通过 make_port() 自动更新
       BOOST_LOG(info) << "Resolution change completed: " << new_width << "x" << new_height
                       << (is_rotation ? " (rotation detected)" : "");
     };
@@ -1505,7 +1517,8 @@ namespace stream {
         return;
       }
 
-      const int param_type = *reinterpret_cast<const int *>(payload.data());
+      // Protocol: all 0x5506 fields are little-endian 32-bit integers.
+      const auto param_type = util::endian::little(*(const std::int32_t *) payload.data());
       
       if (param_type < 0 || param_type >= static_cast<int>(video::dynamic_param_type_e::MAX_PARAM_TYPE)) {
         BOOST_LOG(warning) << "Invalid parameter type: " << param_type;
@@ -1523,8 +1536,9 @@ namespace stream {
           return;
         }
 
-        const auto *resolution_data = reinterpret_cast<const int *>(payload.data());
-        handle_resolution_change(session, resolution_data[1], resolution_data[2]);
+        const auto w = util::endian::little(*(const std::int32_t *) (payload.data() + 4));
+        const auto h = util::endian::little(*(const std::int32_t *) (payload.data() + 8));
+        handle_resolution_change(session, w, h);
         return;
       }
 
@@ -1537,7 +1551,10 @@ namespace stream {
           return;
         }
 
-        const float new_fps = *reinterpret_cast<const float *>(payload.data() + sizeof(int));
+        // FPS is transmitted as a LE float; read via bit-cast through LE u32.
+        std::uint32_t fps_bits = util::endian::little(*(const std::uint32_t *) (payload.data() + sizeof(std::int32_t)));
+        float new_fps;
+        std::memcpy(&new_fps, &fps_bits, sizeof(new_fps));
         
         if (new_fps <= 0.0f || new_fps > 1000.0f) {
           BOOST_LOG(warning) << "Invalid FPS value: " << new_fps;
@@ -1564,7 +1581,7 @@ namespace stream {
         return;
       }
 
-      const int param_value = reinterpret_cast<const int *>(payload.data())[1];
+      const auto param_value = util::endian::little(*(const std::int32_t *) (payload.data() + sizeof(std::int32_t)));
 
       video::dynamic_param_t param;
       param.type = param_type_enum;
@@ -3209,6 +3226,8 @@ namespace stream {
       session->max_nits = launch_session.max_nits;
       session->min_nits = launch_session.min_nits;
       session->max_full_nits = launch_session.max_full_nits;
+      session->launch_use_vdd = launch_session.use_vdd;
+      session->launch_custom_screen_mode = launch_session.custom_screen_mode;
 
       session->config = config;
 


### PR DESCRIPTION
## Summary

Implements the server side of client-driven ("RDP-style") dynamic resolution: when a client requests a stream resolution change mid-session, the host validates and applies it, then notifies the client. Closes AlkaidLab/foundation-sunshine#728.

This builds on the existing `0x5506`/`0x5507` machinery (PRs #424/#669) and adds the gating, capability advertisement, and safety pieces that were missing for a client to safely *drive* it.

## What it does

- **Opt-in config** `video.allow_client_resolution_change` (default **off**) — accept client `0x5506` RESOLUTION requests.
- **Capability advertisement** in `/serverinfo`: `<ClientResolutionChange>` is emitted as `1` only when `allow_client_resolution_change && dynamic_resolution_follow_display`, since the encoder-resolution update + `0x5507` notify in the capture loop are gated on `dynamic_resolution_follow_display`. Advertising honestly avoids telling clients to send requests the host would only half-apply.
- **Apply path** (`handle_resolution_change`): even-clamp, no-op dedupe, leading-edge 250 ms rate-limit (storm protection; clients also debounce), then `configure_display`. Session resolution is mutated and an IDR raised **only** on `configure_result_t::result_e::success` — `deferred_retry` and failures keep the old state and allow a retry.
- **Correct display routing**: the temporary launch session preserves the original launch `env` (client display name, client cert / VDD identity), `use_vdd`, and `custom_screen_mode`, and forces `resolution_change`/`refresh_rate_change` to `automatic` so arbitrary client sizes inject into the VDD mode list.
- Decodes the `0x5506` payload with explicit little-endian reads (no unaligned `reinterpret_cast`).

## Client side

Requires the shared common-c API and the matching clients:
- common-c: qiin2333/moonlight-common-c#10 (`LiSendResolutionChangeRequest`)
- PC client: qiin2333/moonlight-qt (issue qiin2333/moonlight-qt#103)
- Android client: qiin2333/moonlight-vplus (issue qiin2333/moonlight-vplus#353)

## Known limitation

Client-driven resolution currently takes effect end-to-end only when `dynamic_resolution_follow_display=true` (the capture loop's encoder-size update + `0x5507` notify path is gated on that flag). The capability is advertised accordingly. Wiring the capture loop to also fire for client-driven changes when follow-display is off is a sensible follow-up.

## Testing

Reviewed across two independent adversarial + correctness passes; all raised findings addressed. **Not built in this environment** (no local MSVC/CUDA/boost toolchain) — static review only. A maintainer build + a live client-resize smoke test (physical display and VDD) is the recommended gate before merge, per this repo's AI-code testing guidance.

Opened by a regular contributor (AsafMah).
