### PR TITLE
refactor(stream): add asio session coordinator

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -151,6 +151,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/httpcommon.h"
         "${CMAKE_SOURCE_DIR}/src/launch_session_manager.cpp"
         "${CMAKE_SOURCE_DIR}/src/launch_session_manager.h"
+        "${CMAKE_SOURCE_DIR}/src/session_coordinator.cpp"
+        "${CMAKE_SOURCE_DIR}/src/session_coordinator.h"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.cpp"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"

--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -247,6 +247,20 @@ namespace rtsp_stream {
   }
 
   std::size_t
+  launch_session_manager_t::erase_client_sessions(std::string_view client_cert_uuid) {
+    if (client_cert_uuid.empty()) {
+      return 0;
+    }
+
+    std::lock_guard lock { _impl->mutex };
+    const auto old_size = _impl->tickets.size();
+    std::erase_if(_impl->tickets, [client_cert_uuid](const auto &ticket) {
+      return ticket.session && ticket.session->client_cert_uuid == client_cert_uuid;
+    });
+    return old_size - _impl->tickets.size();
+  }
+
+  std::size_t
   launch_session_manager_t::prune(clock_t::time_point now) {
     std::lock_guard lock { _impl->mutex };
     const auto old_size = _impl->tickets.size();

--- a/src/launch_session_manager.h
+++ b/src/launch_session_manager.h
@@ -82,6 +82,9 @@ namespace rtsp_stream {
     erase(std::uint32_t launch_session_id);
 
     std::size_t
+    erase_client_sessions(std::string_view client_cert_uuid);
+
+    std::size_t
     prune(clock_t::time_point now = clock_t::now());
 
     void

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -834,17 +834,30 @@ namespace nvhttp {
       response->close_connection_after_response = true;
     });
 
+    const auto client_cert_uuid = get_client_cert_uuid_from_request(request);
+    if (client_cert_uuid.empty()) {
+      tree.put("root.cancel", 0);
+      tree.put("root.<xmlattr>.status_code", 401);
+      tree.put("root.<xmlattr>.status_message", "Unable to identify the authenticated client");
+      return;
+    }
+
+    const auto result = rtsp_stream::cancel_client_sessions(client_cert_uuid);
+    BOOST_LOG(info) << "Client-scoped cancel [client_uuid="sv << client_cert_uuid
+                    << ", cancelled="sv << result.cancelled_sessions
+                    << ", remaining="sv << result.remaining_sessions << ']';
+
     tree.put("root.cancel", 1);
     tree.put("root.<xmlattr>.status_code", 200);
 
-    rtsp_stream::terminate_sessions();
+    if (result.remaining_sessions == 0) {
+      if (proc::proc.running() > 0) {
+        proc::proc.terminate();
+      }
 
-    if (proc::proc.running() > 0) {
-      proc::proc.terminate();
+      // Preserve the legacy single-client behavior once no other session is using the host.
+      display_device::session_t::get().restore_state();
     }
-
-    // The state needs to be restored regardless of whether "proc::proc.terminate()" was called or not.
-    display_device::session_t::get().restore_state();
   }
 
   void

--- a/src/nvhttp/sessions.cpp
+++ b/src/nvhttp/sessions.cpp
@@ -1,5 +1,6 @@
 #include "sessions.h"
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -78,6 +79,7 @@ namespace nvhttp::sessions {
 
     try {
       auto sessions_info = stream::session::get_all_sessions_info();
+      auto lifecycle = rtsp_stream::session_lifecycle_snapshot();
 
       json response_json;
       response_json["success"] = true;
@@ -85,11 +87,24 @@ namespace nvhttp::sessions {
       response_json["status_message"] = "Success";
       response_json["total_sessions"] = sessions_info.size();
       response_json["pending_sessions"] = rtsp_stream::pending_session_count();
+      response_json["coordinator_version"] = lifecycle->version;
+      response_json["coordinator_rejected_events"] = lifecycle->rejected_events;
 
       json sessions_array = json::array();
 
       for (const auto &session_info : sessions_info) {
-        sessions_array.push_back(make_session_json(session_info));
+        auto session_obj = make_session_json(session_info);
+        const auto lifecycle_record = std::ranges::find(
+          lifecycle->records, session_info.session_id, &session_coord::record_t::session_id);
+        if (lifecycle_record == lifecycle->records.end() ||
+            lifecycle_record->state == session_coord::state_e::closed) {
+          session_obj["lifecycle_state"] = nullptr;
+        }
+        else {
+          session_obj["lifecycle_state"] = session_coord::state_name(lifecycle_record->state);
+        }
+
+        sessions_array.push_back(session_obj);
       }
 
       response_json["sessions"] = sessions_array;

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -789,13 +789,14 @@ namespace rtsp_stream {
     cancel_client_sessions(std::string_view client_cert_uuid) {
       client_session_cancel_result_t result;
       result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
+      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
 
       {
         auto lg = _session_slots.lock();
         for (auto i = _session_slots->begin(); i != _session_slots->end();) {
           auto &slot = *(*i);
           if (stream::session::stop_client_session(slot, client_cert_uuid)) {
-            stream::session::join(slot);
+            sessions_to_join.push_back(*i);
             i = _session_slots->erase(i);
             ++result.cancelled_sessions;
           }
@@ -806,6 +807,10 @@ namespace rtsp_stream {
             ++i;
           }
         }
+      }
+
+      for (const auto &session : sessions_to_join) {
+        stream::session::join(*session);
       }
 
       result.remaining_sessions += _launch_sessions.size();

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -785,6 +785,33 @@ namespace rtsp_stream {
       return static_cast<int>(_launch_sessions.size());
     }
 
+    client_session_cancel_result_t
+    cancel_client_sessions(std::string_view client_cert_uuid) {
+      client_session_cancel_result_t result;
+      result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
+
+      {
+        auto lg = _session_slots.lock();
+        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+          auto &slot = *(*i);
+          if (stream::session::stop_client_session(slot, client_cert_uuid)) {
+            stream::session::join(slot);
+            i = _session_slots->erase(i);
+            ++result.cancelled_sessions;
+          }
+          else {
+            if (stream::session::state(slot) != stream::session::state_e::STOPPING) {
+              ++result.remaining_sessions;
+            }
+            ++i;
+          }
+        }
+      }
+
+      result.remaining_sessions += _launch_sessions.size();
+      return result;
+    }
+
     bool
     activate_launch_session(std::uint32_t launch_session_id) {
       return _launch_sessions.activate(launch_session_id);
@@ -928,6 +955,11 @@ namespace rtsp_stream {
   void
   terminate_sessions() {
     server.clear(true);
+  }
+
+  client_session_cancel_result_t
+  cancel_client_sessions(std::string_view client_cert_uuid) {
+    return server.cancel_client_sessions(client_cert_uuid);
   }
 
   int

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -796,6 +796,8 @@ namespace rtsp_stream {
         for (auto i = _session_slots->begin(); i != _session_slots->end();) {
           auto &slot = *(*i);
           if (stream::session::stop_client_session(slot, client_cert_uuid)) {
+            const auto reason = stream::session::stop_reason(slot);
+            observe_session(slot, session_coord::state_e::draining, stream::session::stop_reason_name(reason));
             sessions_to_join.push_back(*i);
             i = _session_slots->erase(i);
             ++result.cancelled_sessions;
@@ -811,6 +813,8 @@ namespace rtsp_stream {
 
       for (const auto &session : sessions_to_join) {
         stream::session::join(*session);
+        const auto reason = stream::session::stop_reason(*session);
+        observe_session(*session, session_coord::state_e::closed, stream::session::stop_reason_name(reason));
       }
 
       result.remaining_sessions += _launch_sessions.size();
@@ -842,6 +846,24 @@ namespace rtsp_stream {
 
     launch_session_manager_t _launch_sessions;
 
+    void
+    observe_session(stream::session_t &session,
+                    session_coord::state_e state,
+                    std::string stop_reason = {}) noexcept {
+      try {
+        auto identity = stream::session::identity(session);
+        _session_coordinator.observe({
+          .session_id = identity.session_id,
+          .client_uuid = std::move(identity.client_uuid),
+          .state = state,
+          .stop_reason = std::move(stop_reason),
+        });
+      }
+      catch (...) {
+        // The coordinator is observational in this migration phase.
+      }
+    }
+
     /**
      * @brief Clear launch sessions.
      * @param all If true, clear all sessions. Otherwise, only clear timed out and stopped sessions.
@@ -864,7 +886,10 @@ namespace rtsp_stream {
         auto &slot = *(*i);
         if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
           stream::session::stop(slot, stream::session::stop_reason_e::host_terminate);
+          const auto reason = stream::session::stop_reason(slot);
+          observe_session(slot, session_coord::state_e::draining, stream::session::stop_reason_name(reason));
           stream::session::join(slot);
+          observe_session(slot, session_coord::state_e::closed, stream::session::stop_reason_name(reason));
 
           i = _session_slots->erase(i);
         }
@@ -880,8 +905,14 @@ namespace rtsp_stream {
      */
     void
     remove(const std::shared_ptr<stream::session_t> &session) {
-      auto lg = _session_slots.lock();
-      _session_slots->erase(session);
+      bool removed;
+      {
+        auto lg = _session_slots.lock();
+        removed = _session_slots->erase(session) != 0;
+      }
+      if (removed) {
+        observe_session(*session, session_coord::state_e::closed, "start_failed");
+      }
     }
 
     /**
@@ -890,9 +921,22 @@ namespace rtsp_stream {
      */
     void
     insert(const std::shared_ptr<stream::session_t> &session) {
-      auto lg = _session_slots.lock();
-      _session_slots->emplace(session);
-      BOOST_LOG(info) << "New streaming session started [active sessions: "sv << _session_slots->size() << ']';
+      {
+        auto lg = _session_slots.lock();
+        _session_slots->emplace(session);
+        BOOST_LOG(info) << "New streaming session started [active sessions: "sv << _session_slots->size() << ']';
+      }
+      observe_session(*session, session_coord::state_e::starting);
+    }
+
+    void
+    mark_active(const std::shared_ptr<stream::session_t> &session) {
+      observe_session(*session, session_coord::state_e::active);
+    }
+
+    std::shared_ptr<const session_coord::snapshot_t>
+    lifecycle_snapshot() const {
+      return _session_coordinator.snapshot();
     }
 
     /**
@@ -926,6 +970,7 @@ namespace rtsp_stream {
     sync_util::sync_t<std::set<std::shared_ptr<stream::session_t>>> _session_slots;
 
     boost::asio::io_context io_context;
+    session_coord::coordinator_t _session_coordinator { io_context.get_executor() };
     tcp::acceptor acceptor { io_context };
     boost::asio::steady_timer raised_timer { io_context };
 
@@ -965,6 +1010,11 @@ namespace rtsp_stream {
   client_session_cancel_result_t
   cancel_client_sessions(std::string_view client_cert_uuid) {
     return server.cancel_client_sessions(client_cert_uuid);
+  }
+
+  std::shared_ptr<const session_coord::snapshot_t>
+  session_lifecycle_snapshot() {
+    return server.lifecycle_snapshot();
   }
 
   int
@@ -1595,6 +1645,8 @@ namespace rtsp_stream {
       respond(sock, session, &option, 500, "Internal Server Error", req->sequenceNumber, {});
       return;
     }
+
+    server->mark_active(stream_session);
 
     respond(sock, session, &option, 200, "OK", req->sequenceNumber, {});
   }

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
+#include <string_view>
 
 #include <boost/process/v1.hpp>
 
@@ -14,6 +16,11 @@
 
 namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
+
+  struct client_session_cancel_result_t {
+    std::size_t cancelled_sessions {};
+    std::size_t remaining_sessions {};
+  };
 
   struct launch_session_t {
     uint32_t id;
@@ -88,6 +95,12 @@ namespace rtsp_stream {
    */
   void
   terminate_sessions();
+
+  /**
+   * @brief Terminates sessions owned by one authenticated client.
+   */
+  client_session_cancel_result_t
+  cancel_client_sessions(std::string_view client_cert_uuid);
 
   /**
    * @brief Runs the RTSP server loop.

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -12,6 +12,7 @@
 
 #include "crypto.h"
 #include "launch_session_manager.h"
+#include "session_coordinator.h"
 #include "thread_safe.h"
 
 namespace rtsp_stream {
@@ -101,6 +102,9 @@ namespace rtsp_stream {
    */
   client_session_cancel_result_t
   cancel_client_sessions(std::string_view client_cert_uuid);
+
+  std::shared_ptr<const session_coord::snapshot_t>
+  session_lifecycle_snapshot();
 
   /**
    * @brief Runs the RTSP server loop.

--- a/src/session_coordinator.cpp
+++ b/src/session_coordinator.cpp
@@ -1,0 +1,181 @@
+/**
+ * @file src/session_coordinator.cpp
+ * @brief Serialized active-session lifecycle observations.
+ */
+
+#include "session_coordinator.h"
+
+#include <algorithm>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+#include <boost/asio/post.hpp>
+#include <boost/asio/strand.hpp>
+
+namespace session_coord {
+  namespace {
+    int
+    state_rank(state_e state) noexcept {
+      return static_cast<int>(state);
+    }
+  }  // namespace
+
+  const char *
+  state_name(state_e state) noexcept {
+    switch (state) {
+      case state_e::starting:
+        return "starting";
+      case state_e::active:
+        return "active";
+      case state_e::draining:
+        return "draining";
+      case state_e::closed:
+        return "closed";
+    }
+    return "unknown";
+  }
+
+  struct coordinator_t::impl_t {
+    explicit impl_t(boost::asio::any_io_executor executor):
+        strand { boost::asio::make_strand(std::move(executor)) },
+        published { std::make_shared<const snapshot_t>() } {
+    }
+
+    void
+    apply(event_t event) {
+      if (event.session_id == 0) {
+        ++rejected_events;
+        ++version;
+        publish();
+        return;
+      }
+
+      auto entry = records.find(event.session_id);
+      if (entry == records.end()) {
+        record_t record {
+          .session_id = event.session_id,
+          .client_uuid = std::move(event.client_uuid),
+          .state = event.state,
+          .stop_reason = std::move(event.stop_reason),
+          .updated_version = ++version,
+        };
+        const auto closed = record.state == state_e::closed;
+        auto inserted = records.emplace(record.session_id, std::move(record)).first;
+        if (closed) {
+          remember_closed(inserted->second);
+        }
+        publish();
+        return;
+      }
+
+      auto &record = entry->second;
+      if (!record.client_uuid.empty() &&
+          !event.client_uuid.empty() &&
+          record.client_uuid != event.client_uuid) {
+        ++rejected_events;
+        ++version;
+        publish();
+        return;
+      }
+
+      bool changed { false };
+      if (record.client_uuid.empty() && !event.client_uuid.empty()) {
+        record.client_uuid = std::move(event.client_uuid);
+        changed = true;
+      }
+
+      const auto previous_state = record.state;
+      if (state_rank(event.state) > state_rank(record.state)) {
+        record.state = event.state;
+        changed = true;
+      }
+
+      if (state_rank(event.state) >= state_rank(state_e::draining) &&
+          record.stop_reason.empty() &&
+          !event.stop_reason.empty()) {
+        record.stop_reason = std::move(event.stop_reason);
+        changed = true;
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      record.updated_version = ++version;
+      if (previous_state != state_e::closed && record.state == state_e::closed) {
+        remember_closed(record);
+      }
+      publish();
+    }
+
+    void
+    remember_closed(const record_t &record) {
+      closed_order.emplace_back(record.session_id, record.updated_version);
+      while (closed_order.size() > MAX_CLOSED_TOMBSTONES) {
+        const auto [session_id, closed_version] = closed_order.front();
+        closed_order.pop_front();
+
+        auto old = records.find(session_id);
+        if (old != records.end() &&
+            old->second.state == state_e::closed &&
+            old->second.updated_version == closed_version) {
+          records.erase(old);
+        }
+      }
+    }
+
+    void
+    publish() {
+      auto next = std::make_shared<snapshot_t>();
+      next->version = version;
+      next->rejected_events = rejected_events;
+      next->records.reserve(records.size());
+      for (const auto &[_, record] : records) {
+        next->records.push_back(record);
+      }
+      std::ranges::sort(next->records, {}, &record_t::session_id);
+
+      std::lock_guard lock { published_mutex };
+      published = std::move(next);
+    }
+
+    std::shared_ptr<const snapshot_t>
+    snapshot() const {
+      std::lock_guard lock { published_mutex };
+      return published;
+    }
+
+    boost::asio::strand<boost::asio::any_io_executor> strand;
+    std::unordered_map<std::uint32_t, record_t> records;
+    std::deque<std::pair<std::uint32_t, std::uint64_t>> closed_order;
+    std::uint64_t version {};
+    std::size_t rejected_events {};
+
+    mutable std::mutex published_mutex;
+    std::shared_ptr<const snapshot_t> published;
+  };
+
+  coordinator_t::coordinator_t(boost::asio::any_io_executor executor):
+      _impl { std::make_shared<impl_t>(std::move(executor)) } {
+  }
+
+  void
+  coordinator_t::observe(event_t event) const noexcept {
+    try {
+      auto impl = _impl;
+      boost::asio::post(impl->strand, [impl, event = std::move(event)]() mutable {
+        impl->apply(std::move(event));
+      });
+    }
+    catch (...) {
+      // Observability must never alter the streaming lifecycle.
+    }
+  }
+
+  std::shared_ptr<const snapshot_t>
+  coordinator_t::snapshot() const {
+    return _impl->snapshot();
+  }
+}  // namespace session_coord

--- a/src/session_coordinator.h
+++ b/src/session_coordinator.h
@@ -1,0 +1,76 @@
+/**
+ * @file src/session_coordinator.h
+ * @brief Serialized active-session lifecycle observations.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <boost/asio/any_io_executor.hpp>
+
+namespace session_coord {
+  constexpr std::size_t MAX_CLOSED_TOMBSTONES = 256;
+
+  enum class state_e : int {
+    // State order is monotonic. Events may advance but never rewind a record.
+    starting,
+    active,
+    draining,
+    closed,
+  };
+
+  const char *
+  state_name(state_e state) noexcept;
+
+  struct event_t {
+    std::uint32_t session_id {};
+    std::string client_uuid;
+    state_e state { state_e::starting };
+    std::string stop_reason;
+  };
+
+  struct record_t {
+    std::uint32_t session_id {};
+    std::string client_uuid;
+    state_e state { state_e::starting };
+    std::string stop_reason;
+    std::uint64_t updated_version {};
+  };
+
+  struct snapshot_t {
+    std::uint64_t version {};
+    std::size_t rejected_events {};
+    std::vector<record_t> records;
+  };
+
+  /**
+   * @brief Maintains a monotonic lifecycle view on an Asio strand.
+   *
+   * The coordinator is observational for now: it does not own transport or
+   * media resources. Recent late lifecycle events cannot resurrect a closed
+   * session, and a non-empty authenticated owner cannot be replaced by another
+   * owner.
+   */
+  class coordinator_t {
+  public:
+    explicit coordinator_t(boost::asio::any_io_executor executor);
+    coordinator_t(const coordinator_t &) = delete;
+    coordinator_t &
+    operator=(const coordinator_t &) = delete;
+
+    void
+    observe(event_t event) const noexcept;
+
+    std::shared_ptr<const snapshot_t>
+    snapshot() const;
+
+  private:
+    struct impl_t;
+    std::shared_ptr<impl_t> _impl;
+  };
+}  // namespace session_coord

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -3033,6 +3033,8 @@ namespace stream {
           return "video_ended";
         case stop_reason_e::audio_ended:
           return "audio_ended";
+        case stop_reason_e::client_cancel:
+          return "client_cancel";
         case stop_reason_e::host_terminate:
           return "host_terminate";
       }
@@ -3061,6 +3063,16 @@ namespace stream {
 
       perf::end_session(session.launch_session_id);
       session.shutdown_event->raise(true);
+    }
+
+    bool
+    stop_client_session(session_t &session, std::string_view client_cert_uuid) {
+      if (client_cert_uuid.empty() || session.client_cert_uuid != client_cert_uuid) {
+        return false;
+      }
+
+      stop(session, stop_reason_e::client_cancel);
+      return session.lifecycle.state() == state_e::STOPPING;
     }
 
     void

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -3045,6 +3045,19 @@ namespace stream {
       return session.lifecycle.state();
     }
 
+    identity_t
+    identity(const session_t &session) {
+      return {
+        .session_id = session.launch_session_id,
+        .client_uuid = session.client_cert_uuid,
+      };
+    }
+
+    stop_reason_e
+    stop_reason(const session_t &session) {
+      return session.lifecycle.snapshot().stop_reason;
+    }
+
     bool
     has_active_video_sessions() {
       return running_non_control_only_sessions.load(std::memory_order_relaxed) > 0;

--- a/src/stream.h
+++ b/src/stream.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -51,6 +52,7 @@ namespace stream {
       protocol_error,
       video_ended,
       audio_ended,
+      client_cancel,
       host_terminate,
     };
 
@@ -144,6 +146,8 @@ namespace stream {
     start(session_t &session, const std::string &addr_string);
     void
     stop(session_t &session, stop_reason_e reason = stop_reason_e::none);
+    bool
+    stop_client_session(session_t &session, std::string_view client_cert_uuid);
     void
     join(session_t &session);
     state_e

--- a/src/stream.h
+++ b/src/stream.h
@@ -45,6 +45,11 @@ namespace stream {
   };
 
   namespace session {
+    struct identity_t {
+      std::uint32_t session_id {};
+      std::string client_uuid;
+    };
+
     enum class stop_reason_e : int {
       none,
       control_disconnect,
@@ -152,6 +157,10 @@ namespace stream {
     join(session_t &session);
     state_e
     state(session_t &session);
+    identity_t
+    identity(const session_t &session);
+    stop_reason_e
+    stop_reason(const session_t &session);
 
     bool
     has_active_video_sessions();

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -135,6 +135,27 @@ TEST(LaunchSessionManager, PreservesClaimedTicketsPastPendingExpiry) {
   EXPECT_EQ(manager.size(now + 4s), 0U);
 }
 
+TEST(LaunchSessionManager, ErasesOnlyTicketsOwnedByAuthenticatedClient) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(40, "cert-a", "192.0.2.40"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(41, "cert-b", "192.0.2.41"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(42, {}, "192.0.2.42"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  EXPECT_EQ(manager.erase_client_sessions({}), 0U);
+  EXPECT_EQ(manager.erase_client_sessions("cert-a"), 1U);
+  EXPECT_EQ(manager.size(now), 2U);
+
+  EXPECT_FALSE(manager.claim_plaintext("192.0.2.40", now));
+  auto other_client = manager.claim_plaintext("192.0.2.41", now);
+  ASSERT_TRUE(other_client);
+  EXPECT_EQ(other_client->id, 41U);
+}
+
 TEST(LaunchSessionManager, SupportsOverlappingRtspConnectionsForOneLaunch) {
   rtsp_stream::launch_session_manager_t manager;
   const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();

--- a/tests/unit/test_session_coordinator.cpp
+++ b/tests/unit/test_session_coordinator.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file tests/unit/test_session_coordinator.cpp
+ * @brief Tests for the serialized active-session lifecycle coordinator.
+ */
+
+#include <algorithm>
+#include <array>
+#include <thread>
+
+#include <boost/asio/io_context.hpp>
+
+#include "src/session_coordinator.h"
+
+#include "../tests_common.h"
+
+namespace {
+  const session_coord::record_t *
+  find_record(const session_coord::snapshot_t &snapshot, std::uint32_t session_id) {
+    auto record = std::ranges::find(snapshot.records, session_id, &session_coord::record_t::session_id);
+    return record == snapshot.records.end() ? nullptr : &*record;
+  }
+}  // namespace
+
+TEST(SessionCoordinator, KeepsLifecycleMonotonicAndClosed) {
+  boost::asio::io_context context;
+  session_coord::coordinator_t coordinator { context.get_executor() };
+
+  coordinator.observe({ 1, "cert-a", session_coord::state_e::starting, {} });
+  coordinator.observe({ 1, "cert-a", session_coord::state_e::active, {} });
+  coordinator.observe({ 1, "cert-a", session_coord::state_e::draining, "control_timeout" });
+  coordinator.observe({ 1, "cert-a", session_coord::state_e::closed, "host_terminate" });
+  coordinator.observe({ 1, "cert-a", session_coord::state_e::active, {} });
+  context.run();
+
+  const auto snapshot = coordinator.snapshot();
+  const auto *record = find_record(*snapshot, 1);
+  ASSERT_NE(record, nullptr);
+  EXPECT_EQ(record->state, session_coord::state_e::closed);
+  EXPECT_EQ(record->stop_reason, "control_timeout");
+  EXPECT_EQ(snapshot->version, 4U);
+  EXPECT_EQ(snapshot->rejected_events, 0U);
+}
+
+TEST(SessionCoordinator, RejectsAuthenticatedOwnerChanges) {
+  boost::asio::io_context context;
+  session_coord::coordinator_t coordinator { context.get_executor() };
+
+  coordinator.observe({ 2, "cert-a", session_coord::state_e::starting, {} });
+  coordinator.observe({ 2, "cert-b", session_coord::state_e::active, {} });
+  coordinator.observe({ 2, "cert-a", session_coord::state_e::active, {} });
+  context.run();
+
+  const auto snapshot = coordinator.snapshot();
+  const auto *record = find_record(*snapshot, 2);
+  ASSERT_NE(record, nullptr);
+  EXPECT_EQ(record->client_uuid, "cert-a");
+  EXPECT_EQ(record->state, session_coord::state_e::active);
+  EXPECT_EQ(snapshot->rejected_events, 1U);
+}
+
+TEST(SessionCoordinator, SerializesConcurrentObservers) {
+  boost::asio::io_context context;
+  session_coord::coordinator_t coordinator { context.get_executor() };
+
+  std::array<std::thread, 4> producers {
+    std::thread { [&] { coordinator.observe({ 3, "cert-c", session_coord::state_e::starting, {} }); } },
+    std::thread { [&] { coordinator.observe({ 3, "cert-c", session_coord::state_e::active, {} }); } },
+    std::thread { [&] { coordinator.observe({ 3, "cert-c", session_coord::state_e::draining, "client_cancel" }); } },
+    std::thread { [&] { coordinator.observe({ 3, "cert-c", session_coord::state_e::closed, "client_cancel" }); } },
+  };
+  for (auto &producer : producers) {
+    producer.join();
+  }
+
+  std::array<std::thread, 4> runners {
+    std::thread { [&] { context.run(); } },
+    std::thread { [&] { context.run(); } },
+    std::thread { [&] { context.run(); } },
+    std::thread { [&] { context.run(); } },
+  };
+  for (auto &runner : runners) {
+    runner.join();
+  }
+
+  const auto snapshot = coordinator.snapshot();
+  const auto *record = find_record(*snapshot, 3);
+  ASSERT_NE(record, nullptr);
+  EXPECT_EQ(record->state, session_coord::state_e::closed);
+  EXPECT_EQ(record->client_uuid, "cert-c");
+  EXPECT_EQ(snapshot->rejected_events, 0U);
+}
+
+TEST(SessionCoordinator, BoundsClosedTombstones) {
+  boost::asio::io_context context;
+  session_coord::coordinator_t coordinator { context.get_executor() };
+
+  constexpr auto session_count = static_cast<std::uint32_t>(session_coord::MAX_CLOSED_TOMBSTONES + 32);
+  for (std::uint32_t id = 1; id <= session_count; ++id) {
+    coordinator.observe({ id, "cert", session_coord::state_e::closed, "host_terminate" });
+  }
+  context.run();
+
+  const auto snapshot = coordinator.snapshot();
+  EXPECT_EQ(snapshot->records.size(), session_coord::MAX_CLOSED_TOMBSTONES);
+  EXPECT_EQ(find_record(*snapshot, 1), nullptr);
+  EXPECT_NE(find_record(*snapshot, session_count), nullptr);
+}

--- a/tests/unit/test_stream_session_observability.cpp
+++ b/tests/unit/test_stream_session_observability.cpp
@@ -23,6 +23,7 @@ TEST(StreamSessionObservability, NamesEveryStopReason) {
   EXPECT_STREQ(stop_reason_name(stop_reason_e::protocol_error), "protocol_error");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::video_ended), "video_ended");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::audio_ended), "audio_ended");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::client_cancel), "client_cancel");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::host_terminate), "host_terminate");
 }
 


### PR DESCRIPTION
## 依赖

- #801 已经合入 `master`
- 当前堆叠为：`master` ← #802 ← 本 PR
- 本分支已重放到更新后的 #802，不再携带 #801 的旧提交

## 改了啥呀

- 新增基于 Boost.Asio `strand` 的活动会话协调器，所有生命周期观测在单写执行域内更新
- 使用单调状态 `starting → active → draining → closed`，迟到事件不能让最近关闭的会话复活
- 固化已认证证书 UUID 所有权；同一会话 ID 尝试切换到其他非空 UUID 时拒绝并计数
- 保留最多 256 个关闭墓碑，防止迟到回调复活，同时限制内存增长
- RTSP 的创建、启动成功、客户端取消、自然停止、启动失败和关闭路径发送协调器事件
- `/sessions` 增加 `lifecycle_state`、协调器版本和拒绝事件计数，方便对照现有真实会话状态

## 迁移边界

这层仍是影子协调器：它不拥有 socket、编码器或音视频线程，也不改变现有 timeout、`join()`、应用终止和显示恢复时序。事件投递失败会被隔离，不能反向影响串流生命周期。控制面事件经过 strand；编码、采集、加密和媒体发包仍保持原来的并行数据面。

## 验证

- `git diff --check`
- range-diff 确认旧的 #802 lifecycle 修补已归入基线，coordinator 独有逻辑保持不变
- 使用现有 Windows `-Werror` 编译参数检查 `stream.cpp`、`sessions.cpp`、`rtsp.cpp`、`session_coordinator.cpp` 和协调器测试
- 完整 Windows 构建与原生测试重新交给本分支 CI