### PR TITLE
fix(vdd): synchronize display readiness and driver upgrades

### DIFF
--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -40,8 +40,8 @@ option(DRIVER_DEPS_REQUIRED "Treat missing driver dependencies as a fatal error"
 
 # Version pins
 set(VMOUSE_DRIVER_VERSION "v1.2.0" CACHE STRING "ZakoVirtualMouse driver version tag")
-set(VDD_DRIVER_VERSION "v0.17.0" CACHE STRING "ZakoVDD driver version tag")
-set(VDD_WIN10_DRIVER_VERSION "v0.15.2" CACHE STRING "Win10-pinned ZakoVDD driver version tag")
+set(VDD_DRIVER_VERSION "v0.17.1" CACHE STRING "ZakoVDD driver version tag")
+set(VDD_WIN10_DRIVER_VERSION "v0.15.3" CACHE STRING "Win10-pinned ZakoVDD driver version tag")
 set(VDD_DRIVER_ASSET_NAME "zakovdd.zip" CACHE STRING "Latest ZakoVDD release asset name")
 set(VDD_WIN10_DRIVER_ASSET_NAME "zakovdd.zip" CACHE STRING "Win10-pinned ZakoVDD release asset name")
 set(NEFCON_VERSION "v1.17.40" CACHE STRING "nefcon version tag")

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -281,7 +281,7 @@ Filename: "{cmd}"; Parameters: "/c icacls ""{app}"" /reset /T /C > ""{tmp}\sunsh
 Filename: "{app}\scripts\update-path.bat"; Parameters: "add"; StatusMsg: "{cm:StatusUpdatePath}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\migrate-config.bat"; StatusMsg: "{cm:StatusMigrateConfig}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\add-firewall-rule.bat"; StatusMsg: "{cm:StatusFirewall}"; Flags: runhidden waituntilterminated; Components: firewall
-; Leave a healthy older VDD active during unattended upgrades; the GUI offers an explicit repair action.
+; Upgrade older VDDs, but never silently replace a healthy newer/custom driver.
 Filename: "{app}\scripts\install-vdd.bat"; Parameters: "--preserve-healthy-existing"; StatusMsg: "{cm:StatusInstallVDD}"; Flags: runhidden waituntilterminated; Components: vdd
 Filename: "{app}\scripts\install-gamepad.bat"; StatusMsg: "{cm:StatusInstallGamepad}"; Flags: runhidden waituntilterminated; Components: gamepad
 Filename: "{app}\scripts\vmouse\install-vmouse.bat"; StatusMsg: "{cm:StatusInstallVmouse}"; Flags: runhidden waituntilterminated; Components: vmouse

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -655,8 +655,6 @@ namespace display_device {
     }
 
     std::string mode_rebuild_old_vdd_id;
-    bool verify_mode_publication_after_create = false;
-
     // Update VDD resolution configuration
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
       config.resolution && config.refresh_rate) {
@@ -665,10 +663,8 @@ namespace display_device {
         return false;
       }
 
-      verify_mode_publication_after_create = device_zako.empty();
       if (mode_update == vdd_mode_update_e::recreate_monitor) {
         mode_rebuild_old_vdd_id = device_zako;
-        verify_mode_publication_after_create = true;
         if (!vdd_utils::destroy_vdd_monitor()) {
           BOOST_LOG(error) << "Failed to destroy the VDD monitor for an IOCTL mode-list rebuild";
           return false;
@@ -734,17 +730,39 @@ namespace display_device {
       return false;
     }
 
-    if (verify_mode_publication_after_create) {
+    // Apply topology before mode verification so a cold-created monitor
+    // receives the GDI display name consumed by EnumDisplaySettingsW.
+    if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
+      if (!vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
+        BOOST_LOG(error) << "Failed to apply the requested VDD topology";
+        return false;
+      }
+      BOOST_LOG(info) << "已应用VDD屏幕布局设置";
+    }
+    else {
+      std::vector<std::string> physical_devices_to_preserve;
+      const auto append_physical_devices = [&](device_state_e state) {
+        for (const auto &[device_id, info] : pre_vdd_devices) {
+          if (info.friendly_name != ZAKO_NAME && info.device_state == state) {
+            physical_devices_to_preserve.push_back(device_id);
+          }
+        }
+      };
+      append_physical_devices(device_state_e::primary);
+      append_physical_devices(device_state_e::active);
+
+      if (!vdd_utils::ensure_vdd_extended_mode(device_zako, physical_devices_to_preserve)) {
+        BOOST_LOG(error) << "Failed to ensure the default VDD extended topology";
+        return false;
+      }
+      BOOST_LOG(info) << "VDD extended topology is ready";
+    }
+
+    // Wait for the OS-facing mode contract using the utility's bounded
+    // deadline policy rather than driver-specific timing assumptions.
+    if (config.resolution && config.refresh_rate) {
       const display_mode_t requested_mode {*config.resolution, *config.refresh_rate};
-      const bool mode_advertised = vdd_utils::retry_with_backoff(
-        [&]() {
-          return vdd_utils::is_mode_advertised(device_zako, requested_mode);
-        },
-        { .max_attempts = 5,
-          .initial_delay = 100ms,
-          .max_delay = 1000ms,
-          .context = "Waiting for VDD mode publication" });
-      if (!mode_advertised) {
+      if (!vdd_utils::wait_for_mode_publication(device_zako, requested_mode)) {
         BOOST_LOG(error) << "VDD monitor did not publish "
                          << to_string(*config.resolution) << "@" << to_string(*config.refresh_rate);
         return false;
@@ -775,24 +793,6 @@ namespace display_device {
     config::video.output_name = device_zako;
     current_vdd_client_id = current_client_id;
     BOOST_LOG(info) << "成功配置VDD设备: " << device_zako;
-
-    // Apply VDD prep settings to handle display topology
-    // This determines how VDD interacts with physical displays
-    // VDD模式下的拓扑控制与普通模式分开处理
-    if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
-      // User has specified a display configuration, apply it
-      if (vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
-        BOOST_LOG(info) << "已应用VDD屏幕布局设置";
-        std::this_thread::sleep_for(200ms);
-      }
-    }
-    else {
-      // No specific configuration, ensure VDD is in extended mode (default behavior)
-      if (vdd_utils::ensure_vdd_extended_mode(device_zako)) {
-        BOOST_LOG(info) << "已将VDD切换到扩展模式";
-        std::this_thread::sleep_for(500ms);
-      }
-    }
 
     // Set HDR state with retry
     if (!vdd_utils::set_hdr_state(false)) {

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -48,6 +48,52 @@ namespace display_device {
     // 上一次使用的客户端UUID，用于在没有提供UUID时使用
     static std::string last_used_client_uuid;
 
+    namespace {
+      constexpr auto kModePublicationTimeout = 3s;
+      constexpr auto kModePublicationInitialPoll = 50ms;
+      constexpr auto kModePublicationMaxPoll = 500ms;
+
+      std::vector<std::string>
+      collect_physical_devices_for_preservation() {
+        const auto topology = get_current_topology();
+        const auto devices = enum_available_devices();
+        std::vector<std::string> ordered_devices;
+        std::unordered_set<std::string> included;
+
+        const auto append = [&](const std::string &device_id) {
+          const auto device_it = devices.find(device_id);
+          const auto friendly_name = device_it != devices.end() ?
+                                       device_it->second.friendly_name :
+                                       get_display_friendly_name(device_id);
+          if (friendly_name != ZAKO_NAME && included.insert(device_id).second) {
+            ordered_devices.push_back(device_id);
+          }
+        };
+
+        // Active topology order preserves the current primary display first.
+        for (const auto &group : topology) {
+          for (const auto &device_id : group) {
+            append(device_id);
+          }
+        }
+
+        if (ordered_devices.empty()) {
+          // If no topology is active, preserve the enumerated primary first,
+          // followed by the remaining physical displays.
+          for (const auto &[device_id, device_info] : devices) {
+            if (device_info.device_state == device_state_e::primary) {
+              append(device_id);
+            }
+          }
+          for (const auto &entry : devices) {
+            append(entry.first);
+          }
+        }
+
+        return ordered_devices;
+      }
+    }  // namespace
+
     vdd_status_t
     get_vdd_status() {
       vdd_status_t status;
@@ -575,24 +621,7 @@ namespace display_device {
 
     bool
     create_vdd_monitor_noninteractive() {
-      std::unordered_set<std::string> physical_devices_before;
-      const auto topology_before = get_current_topology();
-      const auto all_devices_before = enum_available_devices();
-
-      for (const auto &group : topology_before) {
-        for (const auto &device_id : group) {
-          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
-            physical_devices_before.insert(device_id);
-          }
-        }
-      }
-      if (physical_devices_before.empty()) {
-        for (const auto &[device_id, device_info] : all_devices_before) {
-          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
-            physical_devices_before.insert(device_id);
-          }
-        }
-      }
+      const auto physical_devices_before = collect_physical_devices_for_preservation();
 
       if (!create_vdd_monitor("", hdr_brightness_t {}, physical_size_t {})) {
         return false;
@@ -649,28 +678,7 @@ namespace display_device {
 
       // 保存创建虚拟显示器前的物理设备列表
       // 同时从所有可用设备中查找物理显示器（包括可能被禁用的）
-      std::unordered_set<std::string> physical_devices_before;
-      auto topology_before = get_current_topology();
-      auto all_devices_before = enum_available_devices();
-
-      // 从当前拓扑中获取活动的物理设备
-      for (const auto &group : topology_before) {
-        for (const auto &device_id : group) {
-          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
-            physical_devices_before.insert(device_id);
-          }
-        }
-      }
-
-      // 如果拓扑中没有物理设备，尝试从所有设备中查找（可能被禁用了）
-      if (physical_devices_before.empty()) {
-        for (const auto &[device_id, device_info] : all_devices_before) {
-          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
-            physical_devices_before.insert(device_id);
-            BOOST_LOG(debug) << "从所有设备中找到物理显示器: " << device_id;
-          }
-        }
-      }
+      const auto physical_devices_before = collect_physical_devices_for_preservation();
 
       // 后台线程确保VDD处于扩展模式，并进行二次确认
       std::thread([vdd_device_id = find_device_by_friendlyname(ZAKO_NAME), physical_devices_before]() mutable {
@@ -790,16 +798,34 @@ namespace display_device {
     }
 
     bool
-    ensure_vdd_extended_mode(const std::string &device_id, const std::unordered_set<std::string> &physical_devices_to_preserve) {
+    wait_for_mode_publication(const std::string &device_id, const display_mode_t &requested_mode) {
+      const auto deadline = std::chrono::steady_clock::now() + kModePublicationTimeout;
+      auto poll_delay = kModePublicationInitialPoll;
+
+      while (true) {
+        if (is_mode_advertised(device_id, requested_mode)) {
+          return true;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+          return false;
+        }
+
+        std::this_thread::sleep_for(std::min(
+          poll_delay,
+          std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)));
+        poll_delay = std::min(kModePublicationMaxPoll, poll_delay * 2);
+      }
+    }
+
+    bool
+    ensure_vdd_extended_mode(const std::string &device_id, const std::vector<std::string> &physical_devices_to_preserve) {
       if (device_id.empty()) {
         return false;
       }
 
       auto current_topology = get_current_topology();
-      if (current_topology.empty()) {
-        BOOST_LOG(warning) << "无法获取当前显示器拓扑";
-        return false;
-      }
 
       // 查找VDD所在的拓扑组
       std::size_t vdd_group_index = SIZE_MAX;
@@ -810,13 +836,39 @@ namespace display_device {
         }
       }
 
+      if (vdd_group_index == SIZE_MAX) {
+        // A cold-created IDDCX monitor can be available to DisplayConfig while
+        // remaining absent from the active topology (and therefore have no
+        // \\.\DISPLAYn name). Add it as an independent extended display.
+        active_topology_t new_topology = current_topology;
+        std::unordered_set<std::string> included;
+        for (const auto &group : new_topology) {
+          included.insert(group.begin(), group.end());
+        }
+
+        for (const auto &physical_id : physical_devices_to_preserve) {
+          if (physical_id != device_id && included.insert(physical_id).second) {
+            new_topology.push_back({ physical_id });
+          }
+        }
+        new_topology.push_back({ device_id });
+
+        if (!is_topology_valid(new_topology) || !set_topology(new_topology)) {
+          BOOST_LOG(error) << "Failed to add inactive VDD to the extended topology";
+          return false;
+        }
+
+        BOOST_LOG(info) << "Added inactive VDD to the extended topology";
+        return true;
+      }
+
       // 检查是否需要切换
-      bool is_duplicated = (vdd_group_index != SIZE_MAX && current_topology[vdd_group_index].size() > 1);
+      bool is_duplicated = current_topology[vdd_group_index].size() > 1;
       bool is_vdd_only = (current_topology.size() == 1 && current_topology[0].size() == 1 && current_topology[0][0] == device_id);
 
       if (!is_duplicated && !is_vdd_only) {
         BOOST_LOG(debug) << "VDD已经是扩展模式";
-        return false;
+        return true;
       }
 
       BOOST_LOG(info) << "检测到VDD处于" << (is_vdd_only ? "仅启用" : "复制") << "模式，切换到扩展模式";
@@ -958,8 +1010,9 @@ namespace display_device {
       }
 
       if (physical_devices.empty()) {
-        BOOST_LOG(debug) << "没有物理显示器需要处理";
-        return true;
+        // Continue building a VDD-only topology. This is required on headless
+        // systems where a cold-created monitor is not activated automatically.
+        BOOST_LOG(debug) << "No physical displays to preserve; activating a VDD-only topology";
       }
 
       active_topology_t new_topology;

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <string_view>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 #include <windows.h>
 
@@ -81,6 +80,14 @@ namespace display_device::vdd_utils {
    */
   bool
   is_mode_advertised(const std::string &device_id, const display_mode_t &requested_mode);
+
+  /**
+   * @brief Wait until Windows exposes a requested mode for a display device.
+   * @details Uses a bounded deadline internally. Callers do not need to encode
+   *          driver timing assumptions or retry counts.
+   */
+  bool
+  wait_for_mode_publication(const std::string &device_id, const display_mode_t &requested_mode);
 
   struct vdd_status_t {
     std::string state;
@@ -237,7 +244,7 @@ namespace display_device::vdd_utils {
   set_hdr_state(bool enable_hdr);
 
   bool
-  ensure_vdd_extended_mode(const std::string &device_id, const std::unordered_set<std::string> &physical_devices_to_preserve = {});
+  ensure_vdd_extended_mode(const std::string &device_id, const std::vector<std::string> &physical_devices_to_preserve = {});
 
   /**
    * @brief Apply VDD prep settings to handle physical displays.

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -36,6 +36,13 @@ if (-not (Test-Path -LiteralPath $HelperScript)) {
 
 . $HelperScript
 
+Assert-Equal $false (Test-VddVersionAtLeast '100.0.16.5' '100.0.16.6') `
+    'An older driver version must not satisfy the bundled minimum.'
+Assert-Equal $true (Test-VddVersionAtLeast '100.0.16.7' '100.0.16.6') `
+    'A newer driver version must satisfy the bundled minimum.'
+Assert-Equal $true (Test-VddVersionAtLeast 'custom-build' '100.0.16.6') `
+    'An incomparable healthy custom driver must be preserved.'
+
 $cases = @(
     @{
         Name = 'No device requires one install'
@@ -559,8 +566,25 @@ try {
 
     $script:workflowCalls = @()
     Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
+        ($script:workflowCalls -join ',') `
+        'An unattended upgrade must replace a healthy older driver.'
+
+    $script:workflowCalls = @()
+    $script:workflowDevices = @(New-TestDevice '100.0.16.7' 'OK' 'oem43.inf')
+    $script:workflowDecision = [pscustomobject]@{
+        DeviceCount = 1
+        CleanupRequired = 1
+        InstallRequired = 1
+        HealthyExisting = 1
+        ControlAvailable = 1
+        CurrentVersion = '100.0.16.7'
+        CurrentStatus = 'OK'
+        CurrentInf = 'oem43.inf'
+    }
+    Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
     Assert-Equal 'Stage,Configure' ($script:workflowCalls -join ',') `
-        'An unattended upgrade must preserve a healthy mismatched driver for later GUI maintenance.'
+        'An unattended upgrade must not downgrade a healthy newer driver.'
 
     $script:workflowCalls = @()
     $script:workflowDevices = @(New-TestDevice '100.0.16.6')

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -241,6 +241,17 @@ function Test-VddDeviceReady([object] $Device, [string] $ExpectedVersion = '') {
         (-not $ExpectedVersion -or $Device.Version -eq $ExpectedVersion))
 }
 
+function Test-VddVersionAtLeast([string] $InstalledVersion, [string] $BundledVersion) {
+    try {
+        return [version] $InstalledVersion -ge [version] $BundledVersion
+    }
+    catch {
+        # Never silently replace a healthy custom driver whose version cannot
+        # be compared with the bundled Windows dotted-quad version.
+        return $true
+    }
+}
+
 function Get-VddDecision(
     [object[]] $Devices,
     [string] $BundledVersion,
@@ -848,8 +859,9 @@ function Invoke-VddInstall(
     if ($PreserveHealthyExisting -and
         $decision.InstallRequired -and
         $decision.HealthyExisting -and
-        $decision.ControlAvailable) {
-        Write-Output 'A healthy VDD is already active; deferring the bundled driver update.'
+        $decision.ControlAvailable -and
+        (Test-VddVersionAtLeast $decision.CurrentVersion $state.BundledVersion)) {
+        Write-Output 'A healthy same-or-newer VDD is already active; deferring the bundled driver update.'
         Write-Output 'VDD_DRIVER_UPDATE_DEFERRED=1'
         return
     }


### PR DESCRIPTION
## 做了什么

- 在创建 VDD 后先恢复扩展拓扑，再等待 Windows 发布目标模式
- pin 主线 VDD `v0.17.1` 与 Win10 VDD `v0.15.3`
- 无人值守安装时自动升级健康的旧版驱动，同时保留健康的更新版或自定义版本
- 控制接口缺失时仍走修复路径，并保留安装失败回滚

## 为什么

旧驱动即使设备状态为 OK，也可能缺少本次分辨率创建修复。原逻辑会把所有“健康但版本不匹配”的驱动都留给用户手动修复，导致 Sunshine 更新后仍继续使用旧驱动。现在只阻止静默降级，不再阻止正常升级，杂鱼安装器这次会把该做的升级做完啦～

## 发布

- 主线：[zako-vdd v0.17.1](https://github.com/qiin2333/zako-vdd/releases/tag/v0.17.1) (`DriverVer 100.0.17.1`)
- Win10：[zako-vdd v0.15.3](https://github.com/qiin2333/zako-vdd/releases/tag/v0.15.3) (`DriverVer 100.0.15.3`)

## 验证

- `smoke-test-vdd-device-helper.ps1`
- `smoke-test-install-vdd-selection.ps1`
- 两个 release workflow 均成功
- 实际下载并检查两个 `zakovdd.zip` 的 INF 版本与文件清单

自动 pin PR #851 只收到主线事件、遗漏 Win10 pin，因此由本 PR 原子地更新两个版本。