### PR TITLE
perf(windows): drop trailing retry backoff and instrument DDA init

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -49,6 +49,11 @@ namespace platf::dxgi {
   duplication_t::init(display_base_t *display, const ::video::config_t &config) {
     HRESULT status;
 
+    // Number of DuplicateOutput attempts before giving up. The backoff between attempts is
+    // only useful when another attempt actually follows, so the last iteration must not sleep.
+    constexpr int max_duplicate_attempts = 2;
+    constexpr auto duplicate_retry_delay = 200ms;
+
     // Capture format will be determined from the first call to AcquireNextFrame()
     display->capture_format = DXGI_FORMAT_UNKNOWN;
 
@@ -66,7 +71,7 @@ namespace platf::dxgi {
         }
 
         // We try this twice, in case we still get an error on reinitialization
-        for (int x = 0; x < 2; ++x) {
+        for (int x = 0; x < max_duplicate_attempts; ++x) {
           // Ensure we can duplicate the current display
           syncThreadDesktop();
 
@@ -74,7 +79,9 @@ namespace platf::dxgi {
           if (SUCCEEDED(status)) {
             break;
           }
-          std::this_thread::sleep_for(200ms);
+          if (x + 1 < max_duplicate_attempts) {
+            std::this_thread::sleep_for(duplicate_retry_delay);
+          }
         }
 
         // We don't retry with DuplicateOutput() because we can hit this codepath when we're racing
@@ -95,7 +102,7 @@ namespace platf::dxgi {
           return -1;
         }
 
-        for (int x = 0; x < 2; ++x) {
+        for (int x = 0; x < max_duplicate_attempts; ++x) {
           // Ensure we can duplicate the current display
           syncThreadDesktop();
 
@@ -103,7 +110,9 @@ namespace platf::dxgi {
           if (SUCCEEDED(status)) {
             break;
           }
-          std::this_thread::sleep_for(200ms);
+          if (x + 1 < max_duplicate_attempts) {
+            std::this_thread::sleep_for(duplicate_retry_delay);
+          }
         }
 
         if (FAILED(status)) {
@@ -493,7 +502,8 @@ namespace platf::dxgi {
     }
 
     // Check if we can use the Desktop Duplication API on this output
-    for (int x = 0; x < 2; ++x) {
+    constexpr int max_duplicate_attempts = 2;
+    for (int x = 0; x < max_duplicate_attempts; ++x) {
       dup_t dup;
 
       // Only resynchronize the thread desktop when not enumerating displays.
@@ -513,7 +523,10 @@ namespace platf::dxgi {
       if (enumeration_only && status == E_ACCESSDENIED) {
         break;
       }
-      else {
+      else if (x + 1 < max_duplicate_attempts) {
+        // Only back off when another attempt follows. This function is called once per
+        // output on every display enumeration, and enumeration itself runs on every
+        // capture reinit, so a trailing sleep here is paid repeatedly for no benefit.
         std::this_thread::sleep_for(200ms);
       }
     }
@@ -546,6 +559,32 @@ namespace platf::dxgi {
   int
   display_base_t::init(const ::video::config_t &config, const std::string &display_name) {
     static std::once_flag windows_cpp_once_flag;
+
+    // Phase timings for the init path. Capture reinit latency is dominated by the fixed
+    // backoffs in this function rather than by steady-state work, so record where the time
+    // actually goes instead of guessing. All stamps start equal so that an early failure
+    // reports zero for the phases it never reached.
+    const auto init_start = std::chrono::steady_clock::now();
+    auto output_selected_at = init_start;
+    auto device_created_at = init_start;
+    auto hdr_probed_at = init_start;
+    int output_select_passes = 0;
+    int dda_test_count = 0;
+    int hdr_metadata_retries = 0;
+
+    auto ms_between = [](std::chrono::steady_clock::time_point from, std::chrono::steady_clock::time_point to) {
+      return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(to - from).count();
+    };
+
+    auto log_init_timing = [&](const char *outcome) {
+      BOOST_LOG(info)
+        << "[Display Init] timing ("sv << outcome << "): total="sv << ms_between(init_start, std::chrono::steady_clock::now()) << "ms"sv
+        << ", output_select="sv << ms_between(init_start, output_selected_at) << "ms"sv
+        << " (passes="sv << output_select_passes << ", dda_tests="sv << dda_test_count << ')'
+        << ", device_create="sv << ms_between(output_selected_at, device_created_at) << "ms"sv
+        << ", hdr_probe="sv << ms_between(device_created_at, hdr_probed_at) << "ms"sv
+        << " (retries="sv << hdr_metadata_retries << ')';
+    };
 
     std::call_once(windows_cpp_once_flag, []() {
       if (auto user32 = LoadLibraryA("user32.dll")) {
@@ -590,6 +629,7 @@ namespace platf::dxgi {
     //       filter and accept any adapter so a misconfigured / stale
     //       adapter_name doesn't make capture init fail outright.
     for (int tries = 0; tries < 3 && !output; ++tries) {
+      ++output_select_passes;
       if (tries == 1) {
         SetThreadExecutionState(ES_DISPLAY_REQUIRED);
         Sleep(500);
@@ -623,8 +663,13 @@ namespace platf::dxgi {
             continue;
           }
 
-          const bool output_accepted = is_rdp_session ||
-                                       (desc.AttachedToDesktop && test_dxgi_duplication(adapter_tmp, output_tmp, false));
+          // Same short-circuit as before: RDP accepts any enumerated output, and the
+          // (expensive) duplication test only runs for desktop-attached outputs.
+          bool output_accepted = is_rdp_session;
+          if (!output_accepted && desc.AttachedToDesktop) {
+            ++dda_test_count;
+            output_accepted = test_dxgi_duplication(adapter_tmp, output_tmp, false);
+          }
 
           if (output_accepted) {
             BOOST_LOG(is_rdp_session ? info : debug) << "[Display Init] Selected display: " << to_utf8(desc.DeviceName);
@@ -658,8 +703,11 @@ namespace platf::dxgi {
       }
     }
 
+    output_selected_at = std::chrono::steady_clock::now();
+
     if (!output) {
       BOOST_LOG(error) << "Failed to locate an output device"sv;
+      log_init_timing("no output found");
       return -1;
     }
 
@@ -692,8 +740,11 @@ namespace platf::dxgi {
 
     adapter_p->Release();
 
+    device_created_at = std::chrono::steady_clock::now();
+
     if (FAILED(status)) {
       BOOST_LOG(error) << "Failed to create D3D11 device [0x"sv << util::hex(status).to_string_view() << ']';
+      log_init_timing("device create failed");
       return -1;
     }
 
@@ -821,6 +872,7 @@ namespace platf::dxgi {
 
       if (!is_hdr_metadata_valid(desc1) && !is_rdp_session) {
         for (int retry = 0; retry < 3 && !is_hdr_metadata_valid(desc1); ++retry) {
+          ++hdr_metadata_retries;
           std::this_thread::sleep_for(std::chrono::milliseconds(100 * (1 << retry)));
           output6->GetDesc1(&desc1);
         }
@@ -849,14 +901,19 @@ namespace platf::dxgi {
                                                  "sRGB (G22)");
     }
 
+    hdr_probed_at = std::chrono::steady_clock::now();
+
     if (!timer || !*timer) {
       BOOST_LOG(error) << "Uninitialized high precision timer";
+      log_init_timing("no timer");
       return -1;
     }
 
     // Initialize HDR metadata cache for change detection
     cached_hdr_metadata.reset();
     last_hdr_check_time = std::chrono::steady_clock::now();
+
+    log_init_timing("ok");
 
     return 0;
   }

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -607,6 +607,7 @@ namespace platf::dxgi {
     HRESULT status = CreateDXGIFactory1(IID_IDXGIFactory1, (void **) &factory);
     if (FAILED(status)) {
       BOOST_LOG(error) << "Failed to create DXGIFactory1 [0x"sv << util::hex(status).to_string_view() << ']';
+      log_init_timing("factory create failed");
       return -1;
     }
 
@@ -724,6 +725,7 @@ namespace platf::dxgi {
     status = adapter->QueryInterface(IID_IDXGIAdapter, (void **) &adapter_p);
     if (FAILED(status)) {
       BOOST_LOG(error) << "Failed to query IDXGIAdapter interface"sv;
+      log_init_timing("adapter query failed");
       return -1;
     }
 
@@ -829,6 +831,7 @@ namespace platf::dxgi {
       status = device->QueryInterface(IID_IDXGIDevice, (void **) &dxgi);
       if (FAILED(status)) {
         BOOST_LOG(warning) << "Failed to query DXGI interface [0x"sv << util::hex(status).to_string_view() << ']';
+        log_init_timing("dxgi device query failed");
         return -1;
       }
 


### PR DESCRIPTION
Reduces DXGI capture reinit latency, and adds the measurement needed to decide what to do next.

## The bug

All three DDA retry loops sleep 200 ms after *every* failed attempt — including the final one, where the loop exits immediately afterward so the delay cannot affect the outcome:

```cpp
for (int x = 0; x < 2; ++x) {
  status = ...DuplicateOutput...;
  if (SUCCEEDED(status)) break;
  std::this_thread::sleep_for(200ms);   // x == 1: sleeps, then the loop ends
}
```

Sites: both `DuplicateOutput` paths in `duplication_t::init`, and `test_dxgi_duplication`.

`test_dxgi_duplication` is the expensive one. `display_base_t::init` wraps its output scan in a **three-pass** retry and calls the test once per desktop-attached output on every pass — so an attached but non-duplicatable output pays the useless 200 ms three times per init. And that init runs on **every capture reinit**, because the reinit path calls `refresh_displays()` → `platf::display_names()` ([video.cpp:1745](../blob/master/src/video.cpp#L1745)).

Modeled cost of a fully failing scan:

| failing outputs | before | after | saved |
|---|---|---|---|
| 1 | 1200 ms | 600 ms | 600 ms |
| 2 | 2400 ms | 1200 ms | 1200 ms |
| 3 | 3600 ms | 1800 ms | 1800 ms |

## Why this is safe

**No success path changes.** Both loop shapes were extracted into a native harness and compared across all 16 combinations of *(attempt-1 result, attempt-2 result, `enumeration_only`, `E_ACCESSDENIED`)*:

- outcome and attempt count identical in all 16
- the new loop never sleeps more than the old
- sleep counts match **exactly** on every path that succeeds or breaks early on `E_ACCESSDENIED` — including "succeeds on attempt 2", which still sleeps once

The only divergence is the all-attempts-failed path. That is the intent.

## Instrumentation

One info line per init:

```
[Display Init] timing (ok): total=743.2ms, output_select=612.4ms (passes=2, dda_tests=3),
               device_create=8.1ms, hdr_probe=122.7ms (retries=1)
```

Emitted on success and on all three early-return failures.

**Why:** `a3bd8799` attributed multi-second reinit to unfair-lock starvation and added short-timeout polling to mitigate it. But `display_base_t::init` also contains several seconds of worst-case fixed sleeps that compound inside the three-pass retry — `Sleep(500)` on the second pass, up to 700 ms of HDR metadata backoff, plus the per-output delays above. Which of the two actually dominates is not determinable by reading the code, so this measures it instead of guessing further.

## Deliberately not done

Both are real but should be driven by the numbers above, not assumed:

1. **`test_dxgi_duplication` creates a fresh D3D11 device per output** ([display_base.cpp:473](../blob/master/src/platform/windows/display_base.cpp#L473)) where one per adapter would do. The device is only used for the `DuplicateOutput` probe.
2. **The HDR metadata backoff is not gated on the display being in HDR mode** ([display_base.cpp:873](../blob/master/src/platform/windows/display_base.cpp#L873)). `is_hdr_metadata_valid` only guards luminance values, which are consumed solely by `get_hdr_metadata()` under `is_hdr()` (G2084). An SDR display reporting zeroed luminance would burn the full 700 ms for nothing. The new `hdr_probe`/`retries` fields will show whether this fires in practice.

## Testing

**Not compile-verified** — Windows-only translation unit, changed on macOS with no build tree. Verified structurally: braces balanced in all three edited functions (`duplication_t::init`, `test_dxgi_duplication`, `display_base_t::init`), and the short-circuit evaluation order is preserved in the one refactored condition (the `output_accepted` rewrite exists only to count probe calls and keeps `is_rdp_session ||` / `AttachedToDesktop &&` ordering intact, so the expensive probe still runs in exactly the same cases).

### What a reviewer should check on Windows

1. **Build.**
2. Normal stream start and a capture reinit (change resolution or toggle HDR mid-stream) — confirm the new timing line appears and reinit still succeeds.
3. **Multi-monitor, especially with a display that fails duplication** — this is where the saving lands. Confirm the correct output is still selected.
4. A genuinely failing init (e.g. unplug the target display) — confirm it still fails cleanly, only faster.
5. Worth noting from the logs: whether `hdr_probe` retries are non-zero on an SDR display. That decides item 2 above.

## Not in scope

Dirty-rect capture (`GetFrameDirtyRects`/`GetFrameMoveRects`) is still unused — every frame is a full-screen `CopyResource`. That is a real gap but a design change: dirty regions must accumulate across frames when `last_frame_variant` is reused, and it is coupled to the cursor-blend state machine touched by #859. Should be its own change, driven by measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)