### PR TITLE
fix(vdd): probe direct capture without DDX

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -575,6 +575,14 @@ namespace platf::dxgi {
     auto adapter_name = from_utf8(config::video.adapter_name);
     const bool is_rdp_session = !is_running_as_system_user && display_device::w_utils::is_any_rdp_session_active();
     auto output_name = is_rdp_session ? std::wstring {} : from_utf8(display_name);
+    const bool direct_vdd_capture = config::video.capture == "vdd";
+    std::wstring vdd_output_name;
+    if (direct_vdd_capture) {
+      const auto vdd_device_id = display_device::find_device_by_friendlyname(ZAKO_NAME);
+      if (!vdd_device_id.empty()) {
+        vdd_output_name = from_utf8(display_device::get_display_name(vdd_device_id));
+      }
+    }
 
     if (is_rdp_session) {
       BOOST_LOG(info) << "[Display Init] RDP session detected - using first available RDP virtual display";
@@ -623,11 +631,27 @@ namespace platf::dxgi {
           if (!is_rdp_session && !output_name.empty() && desc.DeviceName != output_name) {
             continue;
           }
+          if (direct_vdd_capture &&
+              output_name.empty() &&
+              !vdd_output_name.empty() &&
+              desc.DeviceName != vdd_output_name) {
+            continue;
+          }
 
+          const bool is_selected_vdd_output =
+            direct_vdd_capture &&
+            !vdd_output_name.empty() &&
+            desc.DeviceName == vdd_output_name;
           const bool output_accepted = is_rdp_session ||
-                                       (desc.AttachedToDesktop && test_dxgi_duplication(adapter_tmp, output_tmp, false));
+                                       (desc.AttachedToDesktop &&
+                                        (is_selected_vdd_output ||
+                                         test_dxgi_duplication(adapter_tmp, output_tmp, false)));
 
           if (output_accepted) {
+            if (is_selected_vdd_output) {
+              BOOST_LOG(info) << "[vdd] Selected ZakoVDD output without requiring DXGI Desktop Duplication: "
+                              << to_utf8(desc.DeviceName);
+            }
             BOOST_LOG(is_rdp_session ? info : debug) << "[Display Init] Selected display: " << to_utf8(desc.DeviceName);
 
             output = std::move(output_tmp);
@@ -1131,7 +1155,7 @@ namespace platf {
     // Build list of capture methods to try
     std::vector<std::string> try_types;
 
-    const auto capture_backend = config.capture_backend_override.empty() ? config::video.capture : config.capture_backend_override;
+    const auto &capture_backend = config::video.capture;
 
     if (capture_backend.empty()) {
       if (is_running_as_system_user) {
@@ -1202,6 +1226,14 @@ namespace platf {
   std::vector<std::string>
   display_names(mem_type_e) {
     std::vector<std::string> display_names;
+    const bool direct_vdd_capture = config::video.capture == "vdd";
+    std::string vdd_output_name;
+    if (direct_vdd_capture) {
+      const auto vdd_device_id = display_device::find_device_by_friendlyname(ZAKO_NAME);
+      if (!vdd_device_id.empty()) {
+        vdd_output_name = display_device::get_display_name(vdd_device_id);
+      }
+    }
 
     HRESULT status;
 
@@ -1260,7 +1292,22 @@ namespace platf {
 
         bool can_capture = false;
 
-        if (is_rdp) {
+        const bool is_selected_vdd_output =
+          direct_vdd_capture &&
+          !vdd_output_name.empty() &&
+          device_name == vdd_output_name;
+
+        if (is_selected_vdd_output && desc.AttachedToDesktop) {
+          can_capture = true;
+          BOOST_LOG(debug) << "[Display] Accepting ZakoVDD output without a DXGI Desktop Duplication test: "
+                           << device_name;
+        }
+        else if (direct_vdd_capture && !vdd_output_name.empty()) {
+          BOOST_LOG(debug) << "[Display] Skipping non-ZakoVDD output while direct VDD capture is configured: "
+                           << device_name;
+          continue;
+        }
+        else if (is_rdp) {
           // In RDP, accept any enumerated output regardless of AttachedToDesktop status
           // Virtual displays may not report this correctly
           can_capture = true;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -55,22 +55,6 @@ namespace video {
     std::map<std::uint64_t, hdr_pipeline_status_t> hdr_pipeline_statuses;
     std::atomic<std::uint64_t> next_hdr_pipeline_status_id { 1 };
 
-    std::optional<std::string>
-    capture_override_for_encoder_probe() {
-#ifdef _WIN32
-      // VDD shared-texture producer may not be ready (metadata mapping / KeyedMutex
-      // not yet published) at encoder-probe time. Probing the real VDD backend
-      // therefore tends to fail on cold start, even though runtime capture works
-      // fine once the producer comes up. Fall back to ddx for the probe only;
-      // this override is injected per-display via config_t::capture_backend_override
-      // so it does not mutate the global config::video.capture used at runtime.
-      if (config::video.capture == "vdd") {
-        return std::string { "ddx" };
-      }
-#endif
-      return std::nullopt;
-    }
-
     /**
      * @brief Check if we can allow probing for the encoders.
      * @return True if there should be no issues with the probing, false if we should prevent it.
@@ -3790,19 +3774,11 @@ namespace video {
   bool
   validate_encoder(encoder_t &encoder, bool expect_failure) {
     std::shared_ptr<platf::display_t> disp;
-    const auto configured_capture_backend = config::video.capture;
-    auto probe_capture_override = capture_override_for_encoder_probe();
 
     BOOST_LOG(info) << "Trying encoder ["sv << encoder.name << ']';
     auto fg = util::fail_guard([&]() {
       BOOST_LOG(info) << "Encoder ["sv << encoder.name << "] failed"sv;
     });
-
-    if (probe_capture_override) {
-      BOOST_LOG(info) << "Temporarily using capture backend ["sv << *probe_capture_override
-                      << "] for encoder probe while configured capture backend is ["sv
-                      << configured_capture_backend << "]"sv;
-    }
 
     // Quick GPU compatibility check: skip encoders that definitely won't work on this GPU
     // This optimization prevents testing encoders on incompatible hardware (e.g., NVIDIA NVENC on AMD GPU)
@@ -3827,10 +3803,6 @@ namespace video {
     // Note: videoFormat starts at 0 (H.264), will be changed to 1 (HEVC) or 2 (AV1) later if needed
     config_t config_max_ref_frames { 1920, 1080, 60, 1000, 1, 1, 1, 0, 0, 0, 0 };
     config_t config_autoselect { 1920, 1080, 60, 1000, 1, 1, 0, 0, 0, 0, 0 };
-    if (probe_capture_override) {
-      config_max_ref_frames.capture_backend_override = *probe_capture_override;
-      config_autoselect.capture_backend_override = *probe_capture_override;
-    }
 
     // If the encoder isn't supported at all (not even H.264), bail early
     const auto output_display_name { display_device::get_display_name(config::video.output_name) };
@@ -3955,10 +3927,7 @@ namespace video {
         encoder.av1[encoder_t::DYNAMIC_RANGE] = false;
       }
       else {
-        config_t generic_hdr_config = { 1920, 1080, 60, 1000, 1, 1, 0, 3, 1, 1, 0 };
-        if (probe_capture_override) {
-          generic_hdr_config.capture_backend_override = *probe_capture_override;
-        }
+        const config_t generic_hdr_config = { 1920, 1080, 60, 1000, 1, 1, 0, 3, 1, 1, 0 };
 
         // Reset the display since we're switching from SDR to HDR
         reset_display(disp, encoder.platform_formats->dev_type, output_display_name, generic_hdr_config);

--- a/src/video.h
+++ b/src/video.h
@@ -121,11 +121,6 @@ namespace video {
     // If empty, use the default display from global configuration
     std::string display_name;
 
-    // Optional per-display initialization capture backend override.
-    // This is intentionally scoped to a single platf::display() call so encoder
-    // probing can avoid mutating the global config::video.capture string.
-    std::string capture_backend_override;
-
     // Helper to get effective framerate as double
     double get_effective_framerate() const {
       if (frameRateNum > 0 && frameRateDen > 0) {


### PR DESCRIPTION
## 改了啥呀

- 显式配置 `capture = vdd` 时，编码器探测直接使用 VDD，不再偷偷覆盖成 DDX
- 解析并锁定 ZakoVDD 对应的输出，只对这个确认过的虚拟输出跳过 Desktop Duplication 可用性检查
- VDD 枚举时排除其他物理/幽灵输出，避免自动选择跑偏
- 删除已经不再需要的 per-display capture backend override

## 为啥要改

Hyper-V GPU-PV 来宾可以使用 NVENC，但 DXGI Desktop Duplication 可能完全不可用。旧逻辑却在真正尝试 VDD 前强制用 DDX 探测编码器，结果这个 DDX 门卫把 VDD 自己拦在门外了，真是杂鱼 bug 呀。

这个修复只影响用户显式选择 VDD 的路径；普通 DDX/WGC 和自动捕获逻辑保持不变，VDD 初始化失败后的 DDX fallback 也仍然保留。

Fixes #880

## 验证

- Windows Release：`src/video.cpp` 对象编译通过
- Windows Release：`src/platform/windows/display_base.cpp` 对象编译通过
- 本地现有 VDD 安全测试：18/18 通过
- PR CI：Build Windows、native tests、Package Windows 全部通过
- `git diff --check` 通过

## 测试包

- CI artifact：[sunshine-windows-r2143](https://github.com/AlkaidLab/foundation-sunshine/actions/runs/30611794415/artifacts/8786193260)
- 解压后安装 `Sunshine..WindowsInstaller.exe`
- 产物保留到 2026-10-29

希望 #880 的报告者在 Hyper-V GPU-PV + ZakoVDD 环境验证启动探测和实际串流，嘿嘿，这次不让 DDX 把 VDD 挡在门外啦。