### PR TITLE
fix(vdd): detect producer reconfigure on cursor-only wakes

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -727,6 +727,16 @@ namespace platf::dxgi {
     vdd_frame_channel::channel_selection frame_channel_selection() const { return m_frameChannelSelection; }
     bool legacy_named_channel() const { return m_legacyNamedChannel; }
 
+    /**
+     * @brief The producer state this consumer is currently attached to.
+     * @details Compared against a fresh metadata snapshot on every wake-up path
+     *          so a producer resize or channel recreation is detected no matter
+     *          which event woke the consumer.
+     */
+    vdd_frame_channel::producer_channel_identity current_channel_identity() const {
+      return {m_channelGeneration, m_width, m_height, m_format};
+    }
+
   private:
     enum class sealed_channel_attempt {
       skipped,

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 
 namespace platf {
@@ -250,6 +251,38 @@ namespace platf::dxgi {
   static bool
   vdd_metadata_is_probe_valid(const SharedFrameMetadata &meta) {
     return static_cast<bool>(vdd_frame_channel::validate_metadata_for_probe(meta));
+  }
+
+  /**
+   * @brief Report whether the producer recreated or resized the channel.
+   * @details Shared by every consumer wake-up path. Keeping the comparison in one
+   *          place is deliberate: when only the frame-ready branch performed it, a
+   *          cursor-only wake could spin forever on an orphaned slot because the
+   *          old FrameReady event is never signalled again after a reconfigure.
+   */
+  static bool
+  vdd_producer_channel_changed(const SharedFrameMetadata &meta,
+                               const vdd_frame_channel::producer_channel_identity &known,
+                               std::string_view context) {
+    switch (vdd_frame_channel::detect_producer_channel_change(meta, known)) {
+      case vdd_frame_channel::producer_channel_change::generation:
+        BOOST_LOG(info) << "[vdd_capture] producer channel generation changed ("sv << context
+                        << "): old="sv << known.generation
+                        << " new="sv << vdd_frame_channel::metadata_channel_generation(meta.MetadataSequence)
+                        << "; requesting reinit"sv;
+        return true;
+      case vdd_frame_channel::producer_channel_change::resolution_or_format:
+        BOOST_LOG(info) << "[vdd_capture] producer resolution/format changed ("sv << context
+                        << "): "sv << known.width << "x"sv << known.height
+                        << " fmt="sv << static_cast<int>(known.format)
+                        << " -> "sv << meta.Width << "x"sv << meta.Height
+                        << " fmt="sv << meta.DxgiFormat
+                        << "; requesting reinit"sv;
+        return true;
+      case vdd_frame_channel::producer_channel_change::none:
+        break;
+    }
+    return false;
   }
 
   static bool
@@ -799,6 +832,24 @@ namespace platf::dxgi {
     }
 
     auto acquire_cursor_frame = [&]() -> capture_e {
+      // A cursor-only wake never consumes the frame-ready event, so it must
+      // validate the producer itself. After the producer recreates the channel
+      // the old FrameReady event is never signalled again: without these checks
+      // every subsequent wake would come from the cursor event, re-copy an
+      // orphaned slot and pin the encoder to a stale frame until the session is
+      // torn down and rebuilt.
+      SharedFrameMetadata cursor_meta {};
+      if (!vdd_frame_channel::read_stable_metadata(meta, cursor_meta)) {
+        BOOST_LOG(warning) << "[vdd_capture] unable to read stable metadata on a cursor-only wake; requesting reinit"sv;
+        return capture_e::reinit;
+      }
+      if (!vdd_metadata_is_attachable(cursor_meta, m_adapterLuid)) {
+        return capture_e::reinit;
+      }
+      if (vdd_producer_channel_changed(cursor_meta, current_channel_identity(), "cursor-only wake"sv)) {
+        return capture_e::reinit;
+      }
+
       // The last consumed producer slot is available as key 0 while the
       // desktop is static. Reacquire it briefly so cursor-only updates retain
       // the normal single-copy/zero-copy cost on actual desktop frames.
@@ -893,11 +944,9 @@ namespace platf::dxgi {
     if (!vdd_metadata_is_attachable(meta_snapshot, m_adapterLuid)) {
       return capture_e::reinit;
     }
-    const UINT16 frame_generation = vdd_frame_channel::metadata_channel_generation(meta_snapshot.MetadataSequence);
-    if (frame_generation != m_channelGeneration) {
-      BOOST_LOG(info) << "[vdd_capture] producer channel generation changed: old="sv
-                      << m_channelGeneration << " new="sv << frame_generation
-                      << "; requesting reinit"sv;
+    // Detect producer-side resize / channel recreation before taking the slot:
+    // the metadata block can change any time the swap chain is re-created.
+    if (vdd_producer_channel_changed(meta_snapshot, current_channel_identity(), "frame-ready"sv)) {
       return capture_e::reinit;
     }
 
@@ -926,18 +975,6 @@ namespace platf::dxgi {
     m_holdsKey = true;
     m_heldSlot = slot;
     m_cursorUpdatePending = false;
-
-    // Detect producer-side resize / format change: the metadata block can change
-    // any time the swap chain is re-created. If so, signal reinit so the upper
-    // layer reopens the shared texture.
-    if (meta_snapshot.Width != m_width || meta_snapshot.Height != m_height ||
-        static_cast<DXGI_FORMAT>(meta_snapshot.DxgiFormat) != m_format) {
-      BOOST_LOG(info) << "[vdd_capture] producer resolution/format changed, requesting reinit"sv;
-      m_keyedMutex[m_heldSlot]->ReleaseSync(0);
-      m_holdsKey = false;
-      m_heldSlot = 0;
-      return capture_e::reinit;
-    }
 
     const auto previous_replaced = m_replacedUnreadFrames;
     const auto previous_held = m_droppedConsumerHeldFrames;

--- a/src/platform/windows/display_vdd_vram.cpp
+++ b/src/platform/windows/display_vdd_vram.cpp
@@ -137,18 +137,16 @@ namespace platf::dxgi {
                              now;
 
     D3D11_TEXTURE2D_DESC desc {};
-    if (!cursor_only) {
-      current_frame->GetDesc(&desc);
-      if (desc.Width != static_cast<UINT>(width_before_rotation) ||
-          desc.Height != static_cast<UINT>(height_before_rotation) ||
-          desc.Format != capture_format) {
-        BOOST_LOG(info) << "[vdd] producer reconfigured: "sv
-                        << width_before_rotation << "x"sv << height_before_rotation
-                        << " " << dxgi_format_to_string(capture_format)
-                        << " -> "sv << desc.Width << "x"sv << desc.Height
-                        << " " << dxgi_format_to_string(desc.Format);
-        return capture_e::reinit;
-      }
+    current_frame->GetDesc(&desc);
+    if (desc.Width != static_cast<UINT>(width_before_rotation) ||
+        desc.Height != static_cast<UINT>(height_before_rotation) ||
+        desc.Format != capture_format) {
+      BOOST_LOG(info) << "[vdd] producer reconfigured: "sv
+                      << width_before_rotation << "x"sv << height_before_rotation
+                      << " " << dxgi_format_to_string(capture_format)
+                      << " -> "sv << desc.Width << "x"sv << desc.Height
+                      << " " << dxgi_format_to_string(desc.Format);
+      return capture_e::reinit;
     }
 
     auto composite_cursor = [&](ID3D11RenderTargetView *capture_rt) {

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -247,6 +247,36 @@ namespace platf::dxgi::vdd_frame_channel {
     return (metadata_sequence_counter(metadata_sequence) & metadata_sequence_write_bit) == 0;
   }
 
+  // Producer state the consumer latched when it attached to the channel. Every
+  // wake-up path must compare a fresh metadata snapshot against this, otherwise
+  // a producer reconfigure stays invisible and the consumer keeps re-reading an
+  // orphaned slot forever.
+  struct producer_channel_identity {
+    UINT16 generation = 0;
+    UINT32 width = 0;
+    UINT32 height = 0;
+    DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
+  };
+
+  enum class producer_channel_change {
+    none,
+    generation,
+    resolution_or_format,
+  };
+
+  inline producer_channel_change
+  detect_producer_channel_change(const shared_frame_metadata_t &meta,
+                                 const producer_channel_identity &known) {
+    if (metadata_channel_generation(meta.MetadataSequence) != known.generation) {
+      return producer_channel_change::generation;
+    }
+    if (meta.Width != known.width || meta.Height != known.height ||
+        static_cast<DXGI_FORMAT>(meta.DxgiFormat) != known.format) {
+      return producer_channel_change::resolution_or_format;
+    }
+    return producer_channel_change::none;
+  }
+
   inline bool
   read_stable_metadata(const shared_frame_metadata_t *source,
                        shared_frame_metadata_t &snapshot,

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -208,6 +208,81 @@ TEST(VddFrameChannelSafety, PrioritizesDesktopFrameOverPendingCursorRetry) {
             pending_cursor_action::wait_for_events);
 }
 
+TEST(VddFrameChannelSafety, DetectsProducerChannelRecreation) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  meta.MetadataSequence = 0x00070000u;  // generation 7, stable counter
+
+  producer_channel_identity attached {};
+  attached.generation = 7;
+  attached.width = meta.Width;
+  attached.height = meta.Height;
+  attached.format = static_cast<DXGI_FORMAT>(meta.DxgiFormat);
+
+  EXPECT_EQ(detect_producer_channel_change(meta, attached),
+            producer_channel_change::none);
+
+  // The producer bumps the generation whenever it recreates the exported
+  // channel. Missing this leaves the consumer bound to an orphaned slot.
+  auto recreated = meta;
+  recreated.MetadataSequence = 0x00080000u;
+  EXPECT_EQ(detect_producer_channel_change(recreated, attached),
+            producer_channel_change::generation);
+}
+
+TEST(VddFrameChannelSafety, DetectsProducerResizeAndFormatChange) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  meta.MetadataSequence = 0x00020000u;
+
+  producer_channel_identity attached {};
+  attached.generation = 2;
+  attached.width = meta.Width;
+  attached.height = meta.Height;
+  attached.format = static_cast<DXGI_FORMAT>(meta.DxgiFormat);
+
+  auto resized = meta;
+  resized.Width = 2560;
+  EXPECT_EQ(detect_producer_channel_change(resized, attached),
+            producer_channel_change::resolution_or_format);
+
+  auto shortened = meta;
+  shortened.Height = 1440;
+  EXPECT_EQ(detect_producer_channel_change(shortened, attached),
+            producer_channel_change::resolution_or_format);
+
+  auto reformatted = meta;
+  reformatted.DxgiFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+  EXPECT_EQ(detect_producer_channel_change(reformatted, attached),
+            producer_channel_change::resolution_or_format);
+
+  // A generation bump wins over the dimension comparison so the log names the
+  // stronger reason.
+  auto both = resized;
+  both.MetadataSequence = 0x00030000u;
+  EXPECT_EQ(detect_producer_channel_change(both, attached),
+            producer_channel_change::generation);
+}
+
+TEST(VddFrameChannelSafety, IgnoresSeqlockCounterWhenComparingGeneration) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  producer_channel_identity attached {};
+  attached.generation = 4;
+  attached.width = meta.Width;
+  attached.height = meta.Height;
+  attached.format = static_cast<DXGI_FORMAT>(meta.DxgiFormat);
+
+  // Low 16 bits are the seqlock counter and advance on every publish; they must
+  // not be mistaken for a channel recreation.
+  meta.MetadataSequence = 0x0004BEEEu;
+  EXPECT_EQ(detect_producer_channel_change(meta, attached),
+            producer_channel_change::none);
+}
+
 TEST(VddModeRefreshSafety, MatchesAdvertisedModesWithRefreshTolerance) {
   using namespace display_device;
 


### PR DESCRIPTION
## Problem

`vdd_capture_t::next_frame()` validated the producer's channel identity **only** on the frame-ready branch. The cursor-only wake path added in #887 acquired `m_sharedTex[m_slotIndex]` and returned `capture_e::ok` without reading metadata at all, so `capture_e::reinit` could never fire there.

The trigger is a mid-session producer reconfigure — the VDD recreates the exported channel (mode/resolution change, HDR toggle, driver re-arm) and bumps `ChannelGeneration`. When that happens the consumer is left holding the previous channel's objects, and neither wake path notices:

- The frame-ready branch *does* check, but it never runs. A recreated channel means a new FrameReady kernel object, so the handle this consumer waits on is never signalled again.
- The cursor-only branch is the only one that still wakes, and it did not check.

So every subsequent wake re-acquires the orphaned slot and hands the encoder a texture nobody writes to anymore. The upper layer is never told to reopen the channel, and the picture stays **frozen until the session is torn down and rebuilt** — only a client reconnect recovers it.

The consumer side had the matching asymmetry: `display_vdd_vram_t::snapshot()` skipped its texture-desc cross-check under `if (!cursor_only)`.

### Scope

Worth being precise about what this does and does not fix.

**This is not a #887 regression.** Before #887 the same producer-reconfigure left `WaitForSingleObject(m_hEvent)` returning `WAIT_TIMEOUT` forever, i.e. `capture_e::timeout` in a loop with no reinit either. #887 changed the failure from "times out forever" to "serves a stale frame forever"; both are a frozen picture that only a reconnect clears. The underlying hole — no reinit path when FrameReady goes silent — predates it.

**Exposure is mainly the sealed channel.** In `legacy_named` mode `m_hEvent` comes from `OpenEventW` on a well-known name, and this consumer's handle keeps that kernel object (and its name) alive, so the producer's `CreateEventW` reopens the same object and continues to signal. The frame-ready branch then fires and the pre-existing check catches the change. Under `attach_sealed_channel()` the handle is duplicated from the driver per channel instance, so a recreated channel really is a new object and the wait goes silent for good.

## Fix

- Extract the comparison into `vdd_frame_channel::detect_producer_channel_change()` (generation, then resolution/format) and call it from **both** wake paths via `vdd_producer_channel_changed()`.
- The cursor-only path now also performs the stable-metadata read and adapter validation the frame-ready path already did.
- The frame-ready branch runs the dimension check *before* acquiring the slot instead of after, which removes the manual `ReleaseSync` on that reinit path.
- Drop the `if (!cursor_only)` guard around the texture-desc cross-check. Both paths hand the same slot texture to the encoder, so the guard was never justified — and that asymmetry is what let this class of bug through.

The `[vdd_capture] producer channel generation changed (cursor-only wake)` log line this adds is also the cheapest way to confirm from a user log whether a given host ever hits the condition at all.

## Tests

Three new cases in `tests/unit/test_vdd_safety.cpp` covering channel recreation, resize/format change, generation-wins-over-dimensions, and that the low 16 seqlock bits are not mistaken for a generation bump.

> Verified: the extracted comparison logic was compiled and exercised standalone. The full Windows build was **not** run — this was authored on macOS, so CI is the first real compile of the touched translation units.

## Notes

Found while investigating a separate NVENC-host corruption report. It is not the cause of that report: this path is vendor-agnostic (plain D3D11 shared textures, no NVENC involvement), the symptom it produces is a frozen frame rather than the garbled picture described there, and as noted above it is not new in the reported regression window. Filing it on its own merits instead of folding it into that investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
