### PR TITLE
fix(hdr): AMF 编码设备开启亮度分析器

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1145,6 +1145,10 @@ namespace platf::dxgi {
       if (hdr_format && config::video.hdr_luminance_analysis != "off") {
         if (!dynamic_metadata_supported) {
           hdr_analysis_failure_reason = "encoder_unsupported";
+          // Without this the analyzer simply never appears in the log, which reads
+          // exactly like a working setup that produces no metadata.
+          BOOST_LOG(info) << "HDR luminance analysis requested but this encode device does not "
+                             "carry dynamic metadata; static metadata only";
         }
         else if (init_hdr_luminance_analyzer() != 0) {
           hdr_analysis_failure_reason = "analysis_setup_failed";
@@ -2660,7 +2664,11 @@ namespace platf::dxgi {
   public:
     bool
     init_device(std::shared_ptr<platf::display_t> display, adapter_t::pointer adapter_p, pix_fmt_e pix_fmt) {
-      if (base.init(display, adapter_p, pix_fmt, false)) return false;
+      // The AMF path splices HDR10+ / HDR Vivid into the bitstream itself, so the
+      // luminance analyzer that feeds it has to be switched on here — the same as the
+      // avcodec and NVENC devices. This was false while AMF could only carry static
+      // metadata, and running the analyzer then would have burned GPU time for nothing.
+      if (base.init(display, adapter_p, pix_fmt, true)) return false;
 
       amf_d3d = ::amf::create_amf_d3d11(base.device.get());
       if (!amf_d3d) return false;


### PR DESCRIPTION
## 现场

AMF 主机（Radeon 780M），配置里 `hdr_luminance_analysis: on`，编码器日志明确打印：

```
AMF: dynamic HDR metadata enabled (HDR10+), spliced into the encoded bitstream
```

但客户端拿不到任何动态元数据。整份日志里既没有 `HDR luminance analyzer initialized (two-pass)`，也没有任何一条分析器相关的 warning。

## 原因

`d3d_amf_encode_device_t::init_device()` 给 `base.init()` 传的是 `supports_dynamic_metadata=false`：

```cpp
if (base.init(display, adapter_p, pix_fmt, false)) return false;
```

对比同文件的另两条路径——`d3d_avcodec_encode_device_t::init` 和 `d3d_nvenc_encode_device_t::init_device` 传的都是 `true`。

这个标志唯一的作用是 `display_vram.cpp:1144` 那道门：

```cpp
if (hdr_format && config::video.hdr_luminance_analysis != "off") {
  if (!dynamic_metadata_supported) {
    hdr_analysis_failure_reason = "encoder_unsupported";   // 静默
  }
  else if (init_hdr_luminance_analyzer() != 0) { ... }
}
```

于是 `init_hdr_luminance_analyzer()` 从来没被调用过，`hdr_analysis_enabled` 恒为 false → 转换着色器不写快照 → 两级归约不跑 → `hdr_frame_luminance_stats_t::valid` 永远是 false → `hdr_luminance_ema_t` 永远不 `initialized` → HDR10+ 和 Vivid 的组包点全部跳过。

编码器侧那句 "dynamic HDR metadata enabled" 说的是拼接器就绪，不是有东西可拼。两边对不上，日志里看不出来。

这个 `false` 在 #939 之前是正确的：那时 AMF 只能承载静态元数据，跑分析器是白烧 GPU。#939 补上了注入能力，漏了这道开关。

## 改动

1. `init_device()` 传 `true`，与 avcodec / NVENC 一致。
2. `encoder_unsupported` 那条静默分支补一行 info 日志——这次排查完全依赖读代码，日志里"什么都没有"和"一切正常但没有元数据"长得一模一样。

## 影响面

`dynamic_metadata_supported` 全代码库只有这一处消费点，所以本改动只有"AMF 路径上分析器开始运行"这一个效果。

分析器成本（供参考）：网格上限 1920x1080（`HDR_ANALYSIS_MAX_WIDTH/HEIGHT`），每 4 帧一次（`HDR_ANALYSIS_INTERVAL`），4K 捕获下缩放到 1920x1080 网格、8160 个线程组。回读走 `D3D11_MAP_FLAG_DO_NOT_WAIT`，不阻塞捕获线程。

🤖 Generated with [Claude Code](https://claude.com/claude-code)