### PR TITLE
fix(webui): update Foundation legal links

### DIFF
--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -258,7 +258,7 @@
                   <ResourceLink
                     v-for="resource in FEATURED_RESOURCES"
                     :key="resource.id"
-                    :href="resource.href"
+                    :href="resourceHref(resource)"
                     :title="resourceTitle(resource)"
                     :description="resourceDescription(resource)"
                     :image-src="resource.imageSrc"
@@ -429,6 +429,7 @@ import {
   CLIENT_RESOURCES,
   FEATURED_RESOURCES,
   HARMONY_CLIENT_URL,
+  resolveResourceHref,
   resolveResourceText,
 } from '../config/resources.js'
 
@@ -607,11 +608,13 @@ export default {
     },
     setupClientResources() {
       const resourcesById = new Map(CLIENT_RESOURCES.map((resource) => [resource.id, resource]))
+      const locale = this.selectedLocale || this.$i18n.locale
       return SETUP_CLIENT_RESOURCE_ORDER
         .map((id) => resourcesById.get(id))
         .filter(Boolean)
         .map((resource) => ({
           ...resource,
+          href: resolveResourceHref(resource, locale),
           icon: SETUP_CLIENT_ICON_OVERRIDES[resource.id] || resource.icon,
         }))
     }
@@ -627,6 +630,9 @@ export default {
     },
     resourceDescription(resource) {
       return resolveResourceText(this.$t, resource, 'description')
+    },
+    resourceHref(resource) {
+      return resolveResourceHref(resource, this.selectedLocale || this.$i18n.locale)
     },
     handleResourceActivate(resource, event) {
       if (resource.action !== 'harmony') return

--- a/src_assets/common/assets/web/components/common/ResourceCard.vue
+++ b/src_assets/common/assets/web/components/common/ResourceCard.vue
@@ -7,15 +7,17 @@ import {
   HARMONY_CLIENT_URL,
   HOME_RESOURCE_GROUPS,
   LEGAL_RESOURCES,
+  resolveResourceHref,
   resolveResourceText,
 } from '../../config/resources.js'
 import { openExternalUrl } from '../../utils/helpers.js'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const showHarmonyModal = ref(false)
 
 const resourceTitle = (resource) => resolveResourceText(t, resource, 'title')
 const resourceDescription = (resource) => resolveResourceText(t, resource, 'description')
+const resourceHref = (resource) => resolveResourceHref(resource, locale.value)
 
 const handleResourceActivate = (resource, event) => {
   if (resource.action !== 'harmony') return
@@ -53,7 +55,7 @@ const confirmHarmonyLink = async () => {
           <div v-for="resource in group.items" :key="resource.id" class="resource-item">
             <ResourceLink
               compact
-              :href="resource.href"
+              :href="resourceHref(resource)"
               :target="resource.action ? '' : '_blank'"
               :action="resource.action === 'harmony'"
               :title="resourceTitle(resource)"

--- a/src_assets/common/assets/web/config/resources.js
+++ b/src_assets/common/assets/web/config/resources.js
@@ -1,9 +1,15 @@
 export const HARMONY_CLIENT_URL = 'https://github.com/AlkaidLab/moonlight-harmony'
 
+const ALKAIDLAB_WEBSITE_URL = 'https://www.alkaidlab.com/'
+const ALKAIDLAB_WEBSITE_ZH_URL = 'https://www.alkaidlab.cn/'
+const VOIDLINK_APP_STORE_URL = 'https://apps.apple.com/us/app/voidlink-extreme/id6755103808'
+const VOIDLINK_APP_STORE_ZH_URL = 'https://apps.apple.com/cn/app/voidlink/id6747717070'
+
 export const OFFICIAL_RESOURCES = [
   {
     id: 'official-website',
-    href: 'https://www.alkaidlab.com/',
+    href: ALKAIDLAB_WEBSITE_URL,
+    zhHref: ALKAIDLAB_WEBSITE_ZH_URL,
     icon: 'fas fa-globe',
     titleKey: 'resource_card.official_website_title',
     variant: 'accent',
@@ -76,7 +82,8 @@ export const CLIENT_RESOURCES = [
   },
   {
     id: 'voidlink',
-    href: 'https://apps.apple.com/cn/app/voidlink/id6747717070',
+    href: VOIDLINK_APP_STORE_URL,
+    zhHref: VOIDLINK_APP_STORE_ZH_URL,
     icon: 'fab fa-apple',
     titleKey: 'resource_card.voidlink_title',
     description: 'iOS / iPadOS',
@@ -152,7 +159,8 @@ export const LEGAL_RESOURCES = [
 export const FEATURED_RESOURCES = [
   {
     id: 'alkaidlab',
-    href: 'https://www.alkaidlab.com/',
+    href: ALKAIDLAB_WEBSITE_URL,
+    zhHref: ALKAIDLAB_WEBSITE_ZH_URL,
     imageSrc: '/images/logo-alkaidlab.png',
     imageAlt: 'AlkaidLab',
     titleKey: 'resource_card.official_website_title',
@@ -173,4 +181,8 @@ export const FEATURED_RESOURCES = [
 export function resolveResourceText(translate, resource, field) {
   const key = resource[`${field}Key`]
   return key ? translate(key) : resource[field] || ''
+}
+
+export function resolveResourceHref(resource, locale) {
+  return locale === 'zh' ? resource.zhHref || resource.href : resource.href
 }

--- a/src_assets/common/assets/web/config/resources.js
+++ b/src_assets/common/assets/web/config/resources.js
@@ -133,7 +133,7 @@ export const HOME_RESOURCE_GROUPS = [
 export const LEGAL_RESOURCES = [
   {
     id: 'license',
-    href: 'https://github.com/qiin2333/Sunshine/blob/master/LICENSE',
+    href: 'https://github.com/AlkaidLab/foundation-sunshine/blob/master/LICENSE',
     icon: 'fas fa-file-alt',
     titleKey: 'resource_card.license',
     descriptionKey: 'resource_card.view_license',
@@ -141,7 +141,7 @@ export const LEGAL_RESOURCES = [
   },
   {
     id: 'third-party-notice',
-    href: 'https://github.com/qiin2333/Sunshine/blob/master/NOTICE',
+    href: 'https://github.com/AlkaidLab/foundation-sunshine/blob/master/NOTICE',
     icon: 'fas fa-exclamation-triangle',
     titleKey: 'resource_card.third_party_notice',
     descriptionKey: 'resource_card.third_party_desc',

--- a/src_assets/common/assets/web/tests/externalLinks.test.js
+++ b/src_assets/common/assets/web/tests/externalLinks.test.js
@@ -5,6 +5,20 @@ import {
   isAllowedExternalUrl,
   openExternalUrl,
 } from '../utils/helpers.js'
+import { LEGAL_RESOURCES } from '../config/resources.js'
+
+test('legal resources target the current Foundation repository', () => {
+  const resources = Object.fromEntries(LEGAL_RESOURCES.map((resource) => [resource.id, resource.href]))
+
+  assert.equal(
+    resources.license,
+    'https://github.com/AlkaidLab/foundation-sunshine/blob/master/LICENSE',
+  )
+  assert.equal(
+    resources['third-party-notice'],
+    'https://github.com/AlkaidLab/foundation-sunshine/blob/master/NOTICE',
+  )
+})
 
 test('external URL allowlist matches the control panel command', () => {
   assert.equal(isAllowedExternalUrl('https://www.alkaidlab.com/'), true)

--- a/src_assets/common/assets/web/tests/resources.test.js
+++ b/src_assets/common/assets/web/tests/resources.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CLIENT_RESOURCES,
+  OFFICIAL_RESOURCES,
+  resolveResourceHref,
+} from '../config/resources.js'
+
+test('uses mainland links only for simplified Chinese', () => {
+  const website = OFFICIAL_RESOURCES.find((resource) => resource.id === 'official-website')
+  const voidlink = CLIENT_RESOURCES.find((resource) => resource.id === 'voidlink')
+
+  assert.equal(resolveResourceHref(website, 'zh'), 'https://www.alkaidlab.cn/')
+  assert.equal(
+    resolveResourceHref(voidlink, 'zh'),
+    'https://apps.apple.com/cn/app/voidlink/id6747717070',
+  )
+})
+
+test('uses international links for every other locale', () => {
+  const website = OFFICIAL_RESOURCES.find((resource) => resource.id === 'official-website')
+  const voidlink = CLIENT_RESOURCES.find((resource) => resource.id === 'voidlink')
+
+  for (const locale of ['en', 'en_US', 'zh_TW', 'ja']) {
+    assert.equal(resolveResourceHref(website, locale), 'https://www.alkaidlab.com/')
+    assert.equal(
+      resolveResourceHref(voidlink, locale),
+      'https://apps.apple.com/us/app/voidlink-extreme/id6755103808',
+    )
+  }
+})


### PR DESCRIPTION
## 说明

资源页的“许可协议”和“第三方通知”仍指向旧的 qiin2333/Sunshine 仓库，部分官网和 iOS 下载链接也没有根据界面语言选择对应区域。

## 修改

- 将许可协议和第三方通知改为 AlkaidLab/foundation-sunshine 的 LICENSE、NOTICE。
- 简体中文使用 alkaidlab.cn 和中国区 VoidLink；其他语言使用 alkaidlab.com 和海外区 VoidLink Extreme。
- 首页资源卡片和新手引导统一通过当前语言解析链接。
- 增加法律文件及区域链接的回归断言。
