### PR TITLE
feat(input): honor client DualSense preference

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -129,7 +129,7 @@ namespace input {
   }
   struct gamepad_t {
     gamepad_t():
-        gamepad_state {}, back_timeout_id {}, id { -1 }, back_button_state { button_state_e::NONE } {}
+        gamepad_state {}, back_timeout_id {}, id { -1 }, back_button_state { button_state_e::NONE }, arrival {} {}
     ~gamepad_t() {
       if (id >= 0) {
         task_pool.push([id = this->id]() {
@@ -150,7 +150,20 @@ namespace input {
     // Sunshine forces the button to be in a specific state until the gamepad state matches that of
     // Moonlight once more.
     button_state_e back_button_state;
+
+    std::optional<platf::gamepad_arrival_t> arrival;
   };
+
+  void
+  reset_gamepad_runtime_state(gamepad_t &gamepad) {
+    if (gamepad.back_timeout_id) {
+      task_pool.cancel(gamepad.back_timeout_id);
+      gamepad.back_timeout_id = nullptr;
+    }
+    gamepad.gamepad_state = {};
+    gamepad.back_button_state = button_state_e::NONE;
+    gamepad.arrival.reset();
+  }
 
   struct input_t {
     enum shortkey_e {
@@ -960,20 +973,29 @@ namespace input {
       return;
     }
 
-    if (input->gamepads[packet->controllerNumber].id >= 0) {
-      // A client may intentionally re-declare a controller to change its emulated type or
-      // capabilities at runtime. Recreate it so the new arrival metadata takes effect.
-      BOOST_LOG(info) << "Reallocating ControllerNumber with updated metadata ["sv
-                      << packet->controllerNumber << ']';
-      free_gamepad(platf_input, input->gamepads[packet->controllerNumber].id);
-      input->gamepads[packet->controllerNumber].id = -1;
-    }
-
     platf::gamepad_arrival_t arrival {
       packet->type,
       util::endian::little(packet->capabilities),
       util::endian::little(packet->supportedButtonFlags),
     };
+
+    auto &gamepad = input->gamepads[packet->controllerNumber];
+    if (gamepad.id >= 0) {
+      if (gamepad.arrival &&
+          gamepad.arrival->type == arrival.type &&
+          gamepad.arrival->capabilities == arrival.capabilities &&
+          gamepad.arrival->supportedButtons == arrival.supportedButtons) {
+        return;
+      }
+
+      // A client may intentionally re-declare a controller to change its emulated type or
+      // capabilities at runtime. Recreate it so the new arrival metadata takes effect.
+      BOOST_LOG(info) << "Reallocating ControllerNumber with updated metadata ["sv
+                      << packet->controllerNumber << ']';
+      reset_gamepad_runtime_state(gamepad);
+      free_gamepad(platf_input, gamepad.id);
+      gamepad.id = -1;
+    }
 
     auto id = alloc_id(gamepadMask);
     if (id < 0) {
@@ -986,7 +1008,8 @@ namespace input {
       return;
     }
 
-    input->gamepads[packet->controllerNumber].id = id;
+    gamepad.id = id;
+    gamepad.arrival = arrival;
   }
 
   /**
@@ -1318,6 +1341,7 @@ namespace input {
     }
     else if (!(packet->activeGamepadMask & (1 << packet->controllerNumber)) && gamepad.id >= 0) {
       // If this is the final event for a gamepad being removed, free the gamepad and return.
+      reset_gamepad_runtime_state(gamepad);
       free_gamepad(platf_input, gamepad.id);
       gamepad.id = -1;
       return;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -961,8 +961,12 @@ namespace input {
     }
 
     if (input->gamepads[packet->controllerNumber].id >= 0) {
-      BOOST_LOG(warning) << "ControllerNumber already allocated ["sv << packet->controllerNumber << ']';
-      return;
+      // A client may intentionally re-declare a controller to change its emulated type or
+      // capabilities at runtime. Recreate it so the new arrival metadata takes effect.
+      BOOST_LOG(info) << "Reallocating ControllerNumber with updated metadata ["sv
+                      << packet->controllerNumber << ']';
+      free_gamepad(platf_input, input->gamepads[packet->controllerNumber].id);
+      input->gamepads[packet->controllerNumber].id = -1;
     }
 
     platf::gamepad_arrival_t arrival {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -981,15 +981,21 @@ namespace input {
 
     auto &gamepad = input->gamepads[packet->controllerNumber];
     if (gamepad.id >= 0) {
-      if (gamepad.arrival &&
+      if (gamepad.arrival) {
+        const auto selection_unchanged =
           gamepad.arrival->type == arrival.type &&
-          gamepad.arrival->capabilities == arrival.capabilities &&
-          gamepad.arrival->supportedButtons == arrival.supportedButtons) {
-        return;
+          ((gamepad.arrival->capabilities ^ arrival.capabilities) &
+           platf::GAMEPAD_TYPE_SELECTION_CAPS) == 0;
+        if (selection_unchanged) {
+          // The update cannot change the emulated device type; remember the
+          // refreshed metadata without disturbing the active virtual device.
+          gamepad.arrival = arrival;
+          return;
+        }
       }
 
-      // A client may intentionally re-declare a controller to change its emulated type or
-      // capabilities at runtime. Recreate it so the new arrival metadata takes effect.
+      // A client may intentionally re-declare a controller to change its emulated type
+      // at runtime. Recreate it so the new arrival metadata takes effect.
       BOOST_LOG(info) << "Reallocating ControllerNumber with updated metadata ["sv
                       << packet->controllerNumber << ']';
       reset_gamepad_runtime_state(gamepad);

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -92,8 +92,17 @@ namespace platf {
   constexpr std::uint32_t MISC_BUTTON = 0x200000;
 
   // Foundation client extension carried in SS_CONTROLLER_ARRIVAL_PACKET::capabilities.
-  // Requests a native DualSense device rather than the generic PS/DS4 fallback.
-  constexpr std::uint16_t GAMEPAD_CAP_PREFER_DS5 = 0x0100;
+  // Best-effort preference for a native DualSense device; the host may still fall
+  // back to DualShock 4 when the optional sidecar is unavailable. Upstream
+  // moonlight-common-c owns the low capability bits (currently 0x00FF), so
+  // Foundation extensions claim the top bit.
+  constexpr std::uint16_t GAMEPAD_CAP_PREFER_DS5 = 0x8000;
+
+  // Arrival fields that can change which emulated device type a platform selects
+  // (LI_CCAP_TOUCHPAD | LI_CCAP_ACCEL | LI_CCAP_GYRO plus the Foundation
+  // preference bit). Arrival updates touching only other fields are recorded
+  // without reallocating the active virtual device.
+  constexpr std::uint16_t GAMEPAD_TYPE_SELECTION_CAPS = 0x0038 | GAMEPAD_CAP_PREFER_DS5;
 
   struct supported_gamepad_t {
     std::string name;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -91,6 +91,10 @@ namespace platf {
   constexpr std::uint32_t TOUCHPAD_BUTTON = 0x100000;
   constexpr std::uint32_t MISC_BUTTON = 0x200000;
 
+  // Foundation client extension carried in SS_CONTROLLER_ARRIVAL_PACKET::capabilities.
+  // Requests a native DualSense device rather than the generic PS/DS4 fallback.
+  constexpr std::uint16_t GAMEPAD_CAP_PREFER_DS5 = 0x0100;
+
   struct supported_gamepad_t {
     std::string name;
     bool is_enabled;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1912,7 +1912,10 @@ namespace platf {
     const auto gamepad_mode = effective_gamepad_mode();
     const auto per_app_override = current_gamepad_mode.load(std::memory_order_relaxed) != 0;
 
-    const auto client_prefers_ds5 = gamepad_mode == 1 &&
+    // A client that needs DualSense-only input (such as a screen-backed
+    // touchpad) must be able to override the global controller default. Keep
+    // an explicit per-app controller selection authoritative.
+    const auto client_prefers_ds5 = !per_app_override &&
                                     (metadata.capabilities & GAMEPAD_CAP_PREFER_DS5);
     auto fallback_to_ds4 = false;
     if (gamepad_mode == 4 || client_prefers_ds5) {

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1914,6 +1914,7 @@ namespace platf {
 
     const auto client_prefers_ds5 = gamepad_mode == 1 &&
                                     (metadata.capabilities & GAMEPAD_CAP_PREFER_DS5);
+    auto fallback_to_ds4 = false;
     if (gamepad_mode == 4 || client_prefers_ds5) {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualSense controller ("
                       << (client_prefers_ds5 ? "requested by client" :
@@ -1924,6 +1925,7 @@ namespace platf {
           return -1;
         }
         BOOST_LOG(warning) << "Client requested DualSense emulation, but its optional sidecar component is unavailable; falling back to DualShock 4"sv;
+        fallback_to_ds4 = true;
       }
       else {
         const auto result = raw->ds5_sidecar->alloc(id, feedback_queue, config::input.ds5_audio_haptics);
@@ -1931,7 +1933,11 @@ namespace platf {
           feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
           feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
         }
-        return result;
+        if (result == 0 || !client_prefers_ds5) {
+          return result;
+        }
+        BOOST_LOG(warning) << "Client-requested DualSense allocation failed; falling back to DualShock 4"sv;
+        fallback_to_ds4 = true;
       }
     }
 
@@ -1941,7 +1947,11 @@ namespace platf {
 
     VIGEM_TARGET_TYPE selectedGamepadType;
 
-    if (gamepad_mode == 2) {
+    if (fallback_to_ds4) {
+      BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualShock 4 controller (DualSense fallback)"sv;
+      selectedGamepadType = DualShock4Wired;
+    }
+    else if (gamepad_mode == 2) {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be Xbox 360 controller ("sv << (per_app_override ? "per-app selection" : "global selection") << ')';
       selectedGamepadType = Xbox360Wired;
     }

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1912,19 +1912,27 @@ namespace platf {
     const auto gamepad_mode = effective_gamepad_mode();
     const auto per_app_override = current_gamepad_mode.load(std::memory_order_relaxed) != 0;
 
-    if (gamepad_mode == 4) {
+    const auto client_prefers_ds5 = gamepad_mode == 1 &&
+                                    (metadata.capabilities & GAMEPAD_CAP_PREFER_DS5);
+    if (gamepad_mode == 4 || client_prefers_ds5) {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualSense controller ("
-                      << (per_app_override ? "per-app selection" : "global selection") << ')';
+                      << (client_prefers_ds5 ? "requested by client" :
+                          per_app_override ? "per-app selection" : "global selection") << ')';
       if (!raw->ds5_sidecar || !raw->ds5_sidecar->configured()) {
-        BOOST_LOG(error) << "DualSense emulation is selected but its optional sidecar component is unavailable"sv;
-        return -1;
+        if (!client_prefers_ds5) {
+          BOOST_LOG(error) << "DualSense emulation is selected but its optional sidecar component is unavailable"sv;
+          return -1;
+        }
+        BOOST_LOG(warning) << "Client requested DualSense emulation, but its optional sidecar component is unavailable; falling back to DualShock 4"sv;
       }
-      const auto result = raw->ds5_sidecar->alloc(id, feedback_queue, config::input.ds5_audio_haptics);
-      if (result == 0) {
-        feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
-        feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
+      else {
+        const auto result = raw->ds5_sidecar->alloc(id, feedback_queue, config::input.ds5_audio_haptics);
+        if (result == 0) {
+          feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
+          feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
+        }
+        return result;
       }
-      return result;
     }
 
     if (!raw->vigem) {

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1919,6 +1919,10 @@ namespace platf {
                                     (metadata.capabilities & GAMEPAD_CAP_PREFER_DS5);
     auto fallback_to_ds4 = false;
     if (gamepad_mode == 4 || client_prefers_ds5) {
+      if (client_prefers_ds5 && gamepad_mode != 1) {
+        BOOST_LOG(warning) << "Client DualSense preference overrides the host gamepad mode for gamepad "sv
+                           << id.globalIndex;
+      }
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualSense controller ("
                       << (client_prefers_ds5 ? "requested by client" :
                           per_app_override ? "per-app selection" : "global selection") << ')';

--- a/src/process.h
+++ b/src/process.h
@@ -70,7 +70,7 @@ namespace proc {
     bool auto_detach;
     bool wait_all;
     int mouse_mode;  ///< 0=auto (use global config), 1=force virtual mouse, 2=force SendInput
-    int gamepad_mode;  ///< 0=inherit global, 1=auto, 2=Xbox 360, 3=DualShock 4
+    int gamepad_mode;  ///< 0=inherit global, 1=auto, 2=Xbox 360, 3=DualShock 4, 4=DualSense
     std::chrono::seconds exit_timeout;
   };
 


### PR DESCRIPTION
## What changed

- adds a Foundation controller-arrival capability requesting native DualSense emulation. It claims the top bit (`0x8000`) of the arrival capabilities field — upstream moonlight-common-c owns the low bits (currently `0x00FF`), Foundation extensions stay out of that range
- a client preference overrides the global gamepad default (including explicit DS4/Xbox 360, logged with a warning); an explicit per-app controller selection stays authoritative
- falls back to DS4 with a warning when the optional sidecar is unavailable. The preference is best-effort: clients must not assume success or switch to DualSense-exclusive UI on it
- reallocates an existing controller only when arrival fields that can change the emulated type change (controller type, touchpad/accel/gyro caps, the preference bit); other metadata updates are recorded in place without recreating the virtual device

## Why

Windows automatic mode maps generic PlayStation metadata to DS4, and duplicate arrival packets were ignored after a legacy Xbox or DS4 device had already been allocated. This prevented a client from enabling DS5 touchpad emulation during an active stream.

## Impact

Foundation clients can request DS5 dynamically. Host precedence: per-app selection > client preference > global config. Existing clients and unknown capability bits retain the previous behavior.

## Validation

- `git diff --check`
- verified controller-touch routing through the generic input layer and DualSense sidecar's two-contact 1920x1080 touchpad mapping
- full CMake build was unavailable because the existing build directory is incomplete and has no generated Makefile

## Related change

- Android client: https://github.com/qiin2333/moonlight-vplus/pull/503 — needs the capability bit updated from `0x0100` to `0x8000` to match