### PR TITLE
build(ds5): pin HIDMaestro to v1.6.2

### DIFF
--- a/docs/windows_dualsense_component_lifecycle.md
+++ b/docs/windows_dualsense_component_lifecycle.md
@@ -34,7 +34,7 @@
 
 ### 3.1 已验证的 HIDMaestro 能力边界
 
-以 HIDMaestro v1.6.1 官方发布物和同标签源码为准，Sunshine 必须区分两类 profile，不把 USB/IP 当作所有 DS5 模拟的必需条件：
+以 HIDMaestro v1.6.2 官方发布物和同标签源码为准，Sunshine 必须区分两类 profile，不把 USB/IP 当作所有 DS5 模拟的必需条件：
 
 | Profile | 后端 | 虚拟 HID | 四声道扬声器/触觉 | 系统级依赖 | 第一阶段用途 |
 |---|---|---:|---:|---|---|
@@ -646,8 +646,8 @@ UX 验收：
 
 截至 2026-08-14（Asia/Hong_Kong），首期实现已经冻结以下决策：
 
-1. Sidecar 调用 HIDMaestro v1.6.1 的公共 `HIDMaestro.Core.dll` API，不复制其实现，也不调用 HIDMaestroTest UI。
-2. HIDMaestro 使用官方发布物 `HIDMaestro-v1.6.1.zip`，固定下载地址和 SHA-256 `00145c23d9838be6089389ce58b3fd2b6766fa9bc0f1f3c60a3c885361b53c34`。发布物大小为 118,879,222 bytes。
+1. Sidecar 调用 HIDMaestro v1.6.2 的公共 `HIDMaestro.Core.dll` API，不复制其实现，也不调用 HIDMaestroTest UI。
+2. HIDMaestro 使用官方发布物 `HIDMaestro-v1.6.2.zip`，固定下载地址和 SHA-256 `6ae8df0cf317baf7e65777e2929f618916a67831b5ff1162205310f2c08b80ff`。发布物大小为 118,881,819 bytes。
 3. Sunshine 安装包仅携带自研 Sidecar 的 `win-x64` 自包含 .NET 运行时，不携带 HIDMaestro DLL。GUI 在用户明确选择安装时下载第三方发布物，校验后只提取 Core、许可证、README 和第三方通知。
 4. 首期每个 Sunshine 进程只允许一个虚拟 DualSense。Xbox 360、DualShock 4 和既有自动模式继续走 ViGEm，不改变成熟驱动支持范围。
 5. 客户端只选择 `physical` 或 `emulated`。前者预检 USB DualSense 四声道端点后声明 `ML_FF_DS5_HAPTICS_PCM`；后者声明 `ML_FF_DS5_HAPTICS_IR_V2`。两位互斥且不在运行中自动切换。

--- a/scripts/build-ds5-sidecar.ps1
+++ b/scripts/build-ds5-sidecar.ps1
@@ -4,8 +4,8 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$version = 'v1.6.1'
-$expectedSha256 = '00145c23D9838BE6089389CE58B3FD2B6766FA9BC0F1F3C60A3C885361B53C34'
+$version = 'v1.6.2'
+$expectedSha256 = '6ae8df0cf317baf7e65777e2929f618916a67831b5ff1162205310f2c08b80ff'
 $url = "https://github.com/hifihedgehog/HIDMaestro/releases/download/$version/HIDMaestro-$version.zip"
 $root = Split-Path -Parent $PSScriptRoot
 $buildRoot = [System.IO.Path]::GetFullPath((Join-Path $root 'build'))

--- a/tools/sunshine-ds5-sidecar/README.md
+++ b/tools/sunshine-ds5-sidecar/README.md
@@ -4,7 +4,7 @@ This optional Windows helper isolates Sunshine from the third-party
 HIDMaestro runtime. It owns virtual DS5 devices and exposes the versioned
 `SDS5` named-pipe protocol. The helper does not contain HIDMaestro binaries.
 
-Build against the pinned upstream v1.6.1 runtime:
+Build against the pinned upstream v1.6.2 runtime:
 
 ```powershell
 dotnet build -c Release `

--- a/tools/sunshine-ds5-sidecar/SidecarServer.cs
+++ b/tools/sunshine-ds5-sidecar/SidecarServer.cs
@@ -243,7 +243,7 @@ internal sealed class SidecarServer : IAsyncDisposable
 
     private void LoadPatchedProfiles()
     {
-        // Upstream v1.6.1 USB DualSense profiles leave extendedReport unarmed,
+        // Upstream USB DualSense profiles leave extendedReport unarmed,
         // so the vendor-blob encoder never runs and the Sony tail of report
         // 0x01 (touch fingers at bytes 33/37, rolling counter, sensors,
         // battery) idles at 0x00. Windows and raw HID consumers decode byte

--- a/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj
+++ b/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <Target Name="RequireHIDMaestro" BeforeTargets="ResolveReferences"
           Condition="!Exists('$(HIDMaestroCorePath)')">
-    <Error Text="HIDMaestro.Core.dll was not found. Set HIDMaestroCorePath to the pinned upstream v1.6.1 runtime." />
+    <Error Text="HIDMaestro.Core.dll was not found. Set HIDMaestroCorePath to the pinned upstream v1.6.2 runtime." />
   </Target>
   <ItemGroup>
     <Reference Include="HIDMaestro.Core">
@@ -19,7 +19,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <!-- Upstream v1.6.1 USB DualSense profiles with extendedReport.alwaysArmed
+    <!-- Upstream v1.6.2 USB DualSense profiles with extendedReport.alwaysArmed
          added. The stock profiles never arm the vendor-blob encoder, so the
          Sony-specific tail of report 0x01 (touch fingers at bytes 33/37 among
          others) is never written and idles at 0x00, which every raw consumer


### PR DESCRIPTION
## Summary
- Bump the pinned HIDMaestro release from v1.6.1 to v1.6.2 (SHA-256 `6ae8df0c…80ff`, 118,881,819 bytes) in the sidecar build script, the control-panel installer constants, docs, and i18n install-confirm strings.
- Upstream v1.6.2 is a drop-in replacement: UMDF2 driver unchanged (`DriverVer` 1.4.7), no managed API changes — only VR legacy-input bindings. Our alwaysArmed DualSense profile patch is unaffected and still required.

## Test plan
- [ ] `scripts/build-ds5-sidecar.ps1` downloads and digest-verifies `HIDMaestro-v1.6.2.zip` against the new pinned hash.
- [ ] Control panel install flow downloads v1.6.2 and passes verification.