### PR TITLE
fix(ds5): keep virtual audio from becoming default

### DIFF
--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
@@ -5,10 +5,10 @@ using Microsoft.Win32;
 namespace Sunshine.Ds5Sidecar;
 
 /// <summary>
-/// Fails closed when Windows selects the virtual HIDMaestro DualSense speaker
-/// as a default render endpoint. This is intentionally read-only: changing
-/// Windows audio policy relies on undocumented APIs and would make the helper
-/// responsible for restoring user preferences after crashes or upgrades.
+/// Fails closed when Windows selects a virtual HIDMaestro DualSense audio
+/// endpoint as a default render or capture endpoint. The guard is a read-only
+/// fallback for systems where the documented never-default policy cannot be
+/// applied.
 /// </summary>
 internal sealed class DefaultAudioEndpointGuard : IDisposable
 {
@@ -37,24 +37,31 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
     private async Task MonitorAsync()
     {
         IMMDeviceEnumerator? enumerator = null;
+        EndpointNotificationClient? notification = null;
+        var registered = false;
         try
         {
             var type = Type.GetTypeFromCLSID(MmDeviceEnumeratorClass, throwOnError: true)!;
             enumerator = (IMMDeviceEnumerator)Activator.CreateInstance(type)!;
-            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(400));
-            do
+            notification = new EndpointNotificationClient(OnDefaultDeviceChanged);
+            var registrationResult = enumerator.RegisterEndpointNotificationCallback(notification);
+            registered = registrationResult >= 0;
+
+            // Register before taking the initial snapshot so a default-device
+            // change racing startup is either observed by the callback or by
+            // the snapshot (and harmlessly deduplicated by _reported).
+            CheckCurrentDefaults(enumerator);
+            if (registered)
             {
-                foreach (var role in Enum.GetValues<AudioRole>())
-                {
-                    if (IsDefaultVirtualDualSense(enumerator, role) &&
-                        Interlocked.Exchange(ref _reported, 1) == 0)
-                    {
-                        _onViolation(role);
-                        return;
-                    }
-                }
+                await Task.Delay(Timeout.InfiniteTimeSpan, _stopping.Token);
             }
-            while (await timer.WaitForNextTickAsync(_stopping.Token));
+            else
+            {
+                Console.Error.WriteLine(
+                    $"Unable to register the default audio endpoint monitor (0x{registrationResult:X8}); " +
+                    "falling back to low-frequency polling");
+                await PollDefaultsAsync(enumerator);
+            }
         }
         catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
         {
@@ -68,23 +75,79 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
         }
         finally
         {
+            if (registered && enumerator is not null && notification is not null)
+            {
+                var result = enumerator.UnregisterEndpointNotificationCallback(notification);
+                if (result < 0 && !_stopping.IsCancellationRequested)
+                    Console.Error.WriteLine($"Unable to unregister the default audio endpoint monitor: 0x{result:X8}");
+            }
             if (enumerator is not null && Marshal.IsComObject(enumerator))
                 Marshal.FinalReleaseComObject(enumerator);
+            GC.KeepAlive(notification);
         }
     }
 
-    private static bool IsDefaultVirtualDualSense(IMMDeviceEnumerator enumerator, AudioRole role)
+    private void CheckCurrentDefaults(IMMDeviceEnumerator enumerator)
     {
+        foreach (var flow in Enum.GetValues<DataFlow>())
+        {
+            foreach (var role in Enum.GetValues<AudioRole>())
+            {
+                if (TryGetDefaultEndpointId(enumerator, flow, role, out var endpointId))
+                    ReportIfVirtualDualSense(role, endpointId);
+            }
+        }
+    }
+
+    private async Task PollDefaultsAsync(IMMDeviceEnumerator enumerator)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+        while (await timer.WaitForNextTickAsync(_stopping.Token))
+            CheckCurrentDefaults(enumerator);
+    }
+
+    private void OnDefaultDeviceChanged(DataFlow flow, AudioRole role, string? endpointId)
+    {
+        if (endpointId is null || _stopping.IsCancellationRequested)
+            return;
+        try
+        {
+            ReportIfVirtualDualSense(role, endpointId);
+        }
+        catch (Exception error)
+        {
+            // Never let an ownership lookup escape through the Core Audio COM
+            // callback boundary.
+            Console.Error.WriteLine($"Unable to inspect the changed default audio endpoint: {error.Message}");
+        }
+    }
+
+    private void ReportIfVirtualDualSense(AudioRole role, string endpointId)
+    {
+        if (Volatile.Read(ref _reported) != 0 ||
+            !IsVirtualDualSenseEndpoint(endpointId) ||
+            Interlocked.Exchange(ref _reported, 1) != 0)
+        {
+            return;
+        }
+        _onViolation(role);
+    }
+
+    private static bool TryGetDefaultEndpointId(
+        IMMDeviceEnumerator enumerator, DataFlow flow, AudioRole role, out string endpointId)
+    {
+        endpointId = string.Empty;
         IMMDevice? endpoint = null;
         try
         {
             // AUDCLNT_E_DEVICE_INVALIDATED and E_NOTFOUND are normal while an
             // endpoint is being created or removed, so treat any failed lookup
-            // as "not currently default" and retry on the next poll.
-            if (enumerator.GetDefaultAudioEndpoint(DataFlow.Render, role, out endpoint) < 0 || endpoint is null ||
-                endpoint.GetId(out var endpointId) < 0)
+            // as "not currently default". A later notification (or the rare
+            // registration-failure polling fallback) will retry it.
+            if (enumerator.GetDefaultAudioEndpoint(flow, role, out endpoint) < 0 || endpoint is null ||
+                endpoint.GetId(out endpointId) < 0)
                 return false;
-            return IsVirtualDualSenseEndpoint(endpointId);
+            return true;
         }
         finally
         {
@@ -187,6 +250,57 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
     private enum DataFlow
     {
         Render = 0,
+        Capture = 1,
+    }
+
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.None)]
+    private sealed class EndpointNotificationClient : IMMNotificationClient
+    {
+        private readonly Action<DataFlow, AudioRole, string?> _onDefaultDeviceChanged;
+
+        internal EndpointNotificationClient(Action<DataFlow, AudioRole, string?> onDefaultDeviceChanged)
+        {
+            _onDefaultDeviceChanged = onDefaultDeviceChanged;
+        }
+
+        public int OnDeviceStateChanged(string deviceId, uint newState) => 0;
+        public int OnDeviceAdded(string deviceId) => 0;
+        public int OnDeviceRemoved(string deviceId) => 0;
+
+        public int OnDefaultDeviceChanged(DataFlow flow, AudioRole role, string? defaultDeviceId)
+        {
+            _onDefaultDeviceChanged(flow, role, defaultDeviceId);
+            return 0;
+        }
+
+        public int OnPropertyValueChanged(string deviceId, PropertyKey propertyKey) => 0;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct PropertyKey
+    {
+        private readonly Guid _formatId;
+        private readonly uint _propertyId;
+    }
+
+    [ComImport]
+    [Guid("7991EEC9-7E89-4D85-8390-6C703CEC60C0")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMNotificationClient
+    {
+        [PreserveSig]
+        int OnDeviceStateChanged([MarshalAs(UnmanagedType.LPWStr)] string deviceId, uint newState);
+        [PreserveSig]
+        int OnDeviceAdded([MarshalAs(UnmanagedType.LPWStr)] string deviceId);
+        [PreserveSig]
+        int OnDeviceRemoved([MarshalAs(UnmanagedType.LPWStr)] string deviceId);
+        [PreserveSig]
+        int OnDefaultDeviceChanged(DataFlow flow, AudioRole role,
+                                   [MarshalAs(UnmanagedType.LPWStr)] string? defaultDeviceId);
+        [PreserveSig]
+        int OnPropertyValueChanged([MarshalAs(UnmanagedType.LPWStr)] string deviceId,
+                                   PropertyKey propertyKey);
     }
 
     [ComImport]
@@ -201,9 +315,9 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
         [PreserveSig]
         int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice endpoint);
         [PreserveSig]
-        int RegisterEndpointNotificationCallback(IntPtr callback);
+        int RegisterEndpointNotificationCallback(IMMNotificationClient callback);
         [PreserveSig]
-        int UnregisterEndpointNotificationCallback(IntPtr callback);
+        int UnregisterEndpointNotificationCallback(IMMNotificationClient callback);
     }
 
     [ComImport]

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
@@ -101,6 +101,21 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
         if (CM_Locate_DevNodeW(out var node, instanceId, 0) != 0)
             return false;
 
+        return IsVirtualDualSenseDeviceNode(node);
+    }
+
+    internal static bool IsVirtualDualSenseDeviceNode(string instanceId, bool includePhantom)
+    {
+        if (CM_Locate_DevNodeW(out var node, instanceId, 0) != 0 &&
+            (!includePhantom || CM_Locate_DevNodeW(out node, instanceId, 1) != 0))
+        {
+            return false;
+        }
+        return IsVirtualDualSenseDeviceNode(node);
+    }
+
+    private static bool IsVirtualDualSenseDeviceNode(uint node)
+    {
         var chain = new List<DeviceNodeIdentity>();
         for (var depth = 0; depth < 12; ++depth)
         {

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
@@ -13,6 +13,9 @@ namespace Sunshine.Ds5Sidecar;
 /// </summary>
 internal sealed class DefaultAudioEndpointGuard : IDisposable
 {
+    private const int DataFlowCount = 2;
+    private const int AudioRoleCount = 3;
+
     internal enum AudioRole
     {
         Console = 0,
@@ -25,11 +28,17 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
     private static readonly Guid MmDeviceEnumeratorClass =
         new("BCDE0395-E52F-467C-8E3D-C4579291692E");
     private readonly CancellationTokenSource _stopping = new();
-    private readonly Channel<DefaultEndpointChange> _endpointChanges =
-        Channel.CreateUnbounded<DefaultEndpointChange>(new UnboundedChannelOptions
+    // Each flow/role pair owns one atomic latest-value slot. The capacity-one
+    // channel is only a non-blocking wakeup, so notification bursts coalesce
+    // without allowing a backlog to grow.
+    private readonly DefaultEndpointChange?[] _pendingEndpointChanges =
+        new DefaultEndpointChange?[DataFlowCount * AudioRoleCount];
+    private readonly Channel<bool> _endpointChangeSignal =
+        Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
         {
             SingleReader = true,
             SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite,
         });
     private readonly Action<AudioRole> _onViolation;
     private readonly Task _worker;
@@ -115,25 +124,52 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
 
     private async Task ProcessEndpointChangesAsync()
     {
-        await foreach (var change in _endpointChanges.Reader.ReadAllAsync(_stopping.Token))
+        while (await _endpointChangeSignal.Reader.WaitToReadAsync(_stopping.Token))
         {
-            try
+            _endpointChangeSignal.Reader.TryRead(out _);
+            for (var slot = 0; slot < _pendingEndpointChanges.Length; ++slot)
             {
-                ReportIfVirtualDualSense(change.Role, change.EndpointId);
-            }
-            catch (Exception error)
-            {
-                Console.Error.WriteLine(
-                    $"Unable to inspect the changed {change.Flow} default audio endpoint: {error.Message}");
+                var change = Interlocked.Exchange(ref _pendingEndpointChanges[slot], null);
+                if (change is null)
+                    continue;
+                try
+                {
+                    ReportIfVirtualDualSense(change.Role, change.EndpointId);
+                }
+                catch (Exception error)
+                {
+                    Console.Error.WriteLine(
+                        $"Unable to inspect the changed {change.Flow} default audio endpoint: {error.Message}");
+                }
+                if (Volatile.Read(ref _reported) != 0)
+                    return;
             }
         }
     }
 
     private void OnDefaultDeviceChanged(DataFlow flow, AudioRole role, string? endpointId)
     {
-        if (endpointId is null || _stopping.IsCancellationRequested)
+        if (endpointId is null || _stopping.IsCancellationRequested ||
+            Volatile.Read(ref _reported) != 0 || !TryGetEndpointSlot(flow, role, out var slot))
+        {
             return;
-        _endpointChanges.Writer.TryWrite(new DefaultEndpointChange(flow, role, endpointId));
+        }
+        Interlocked.Exchange(
+            ref _pendingEndpointChanges[slot], new DefaultEndpointChange(flow, role, endpointId));
+        _endpointChangeSignal.Writer.TryWrite(true);
+    }
+
+    private static bool TryGetEndpointSlot(DataFlow flow, AudioRole role, out int slot)
+    {
+        var flowIndex = (int)flow;
+        var roleIndex = (int)role;
+        if ((uint)flowIndex >= DataFlowCount || (uint)roleIndex >= AudioRoleCount)
+        {
+            slot = -1;
+            return false;
+        }
+        slot = flowIndex * AudioRoleCount + roleIndex;
+        return true;
     }
 
     private void ReportIfVirtualDualSense(AudioRole role, string endpointId)
@@ -267,7 +303,7 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
         Capture = 1,
     }
 
-    private readonly record struct DefaultEndpointChange(
+    private sealed record DefaultEndpointChange(
         DataFlow Flow, AudioRole Role, string EndpointId);
 
     [ComVisible(true)]

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Channels;
 using Microsoft.Win32;
 
 namespace Sunshine.Ds5Sidecar;
@@ -12,7 +13,7 @@ namespace Sunshine.Ds5Sidecar;
 /// </summary>
 internal sealed class DefaultAudioEndpointGuard : IDisposable
 {
-    internal enum AudioRole : byte
+    internal enum AudioRole
     {
         Console = 0,
         Multimedia = 1,
@@ -24,6 +25,12 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
     private static readonly Guid MmDeviceEnumeratorClass =
         new("BCDE0395-E52F-467C-8E3D-C4579291692E");
     private readonly CancellationTokenSource _stopping = new();
+    private readonly Channel<DefaultEndpointChange> _endpointChanges =
+        Channel.CreateUnbounded<DefaultEndpointChange>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
     private readonly Action<AudioRole> _onViolation;
     private readonly Task _worker;
     private int _reported;
@@ -53,7 +60,7 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
             CheckCurrentDefaults(enumerator);
             if (registered)
             {
-                await Task.Delay(Timeout.InfiniteTimeSpan, _stopping.Token);
+                await ProcessEndpointChangesAsync();
             }
             else
             {
@@ -106,20 +113,27 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
             CheckCurrentDefaults(enumerator);
     }
 
+    private async Task ProcessEndpointChangesAsync()
+    {
+        await foreach (var change in _endpointChanges.Reader.ReadAllAsync(_stopping.Token))
+        {
+            try
+            {
+                ReportIfVirtualDualSense(change.Role, change.EndpointId);
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine(
+                    $"Unable to inspect the changed {change.Flow} default audio endpoint: {error.Message}");
+            }
+        }
+    }
+
     private void OnDefaultDeviceChanged(DataFlow flow, AudioRole role, string? endpointId)
     {
         if (endpointId is null || _stopping.IsCancellationRequested)
             return;
-        try
-        {
-            ReportIfVirtualDualSense(role, endpointId);
-        }
-        catch (Exception error)
-        {
-            // Never let an ownership lookup escape through the Core Audio COM
-            // callback boundary.
-            Console.Error.WriteLine($"Unable to inspect the changed default audio endpoint: {error.Message}");
-        }
+        _endpointChanges.Writer.TryWrite(new DefaultEndpointChange(flow, role, endpointId));
     }
 
     private void ReportIfVirtualDualSense(AudioRole role, string endpointId)
@@ -252,6 +266,9 @@ internal sealed class DefaultAudioEndpointGuard : IDisposable
         Render = 0,
         Capture = 1,
     }
+
+    private readonly record struct DefaultEndpointChange(
+        DataFlow Flow, AudioRole Role, string EndpointId);
 
     [ComVisible(true)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointPolicy.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointPolicy.cs
@@ -1,0 +1,93 @@
+using Microsoft.Win32;
+
+namespace Sunshine.Ds5Sidecar;
+
+/// <summary>
+/// Applies Windows' documented never-default policy to HIDMaestro-backed
+/// DualSense audio interfaces. The policy is scoped to the concrete virtual
+/// device instance, so a physical DualSense with the same VID/PID is untouched.
+/// </summary>
+internal static class DefaultAudioEndpointPolicy
+{
+    private const string AudioInterfaceClass =
+        @"SYSTEM\CurrentControlSet\Control\DeviceClasses\{6994ad04-93ef-11d0-a3cc-00a0c9223196}";
+    private const string EndpointAssociation =
+        "{1DA5D803-D492-4EDD-8C23-E0C0FFEE7F0E},2";
+    private const string NeverSetAsDefaultEndpoint =
+        "{F3E80BEF-1723-4FF2-BCC4-7F83DC5E46D4},3";
+    private const string AnyKsNodeType = "{00000000-0000-0000-0000-000000000000}";
+    private const int AllRolesAndFlows = 0x00000307;
+
+    /// <summary>
+    /// Finds the virtual DualSense KS audio interface and applies the endpoint
+    /// policy. A short poll is needed because the USB audio child appears
+    /// asynchronously after HIDMaestro creates the composite device.
+    /// </summary>
+    /// <returns>True when a matching interface was found.</returns>
+    internal static bool EnsureNeverDefault(TimeSpan timeout, bool includePhantom, out bool changed)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        do
+        {
+            if (EnsureOnce(includePhantom, out changed))
+                return true;
+            if (DateTime.UtcNow >= deadline)
+                break;
+            Thread.Sleep(50);
+        }
+        while (true);
+
+        changed = false;
+        return false;
+    }
+
+    private static bool EnsureOnce(bool includePhantom, out bool changed)
+    {
+        changed = false;
+        var matched = false;
+        using var audioInterfaces = Registry.LocalMachine.OpenSubKey(AudioInterfaceClass, writable: false);
+        if (audioInterfaces is null)
+            return false;
+
+        foreach (var interfaceName in audioInterfaces.GetSubKeyNames())
+        {
+            var interfacePath = AudioInterfaceClass + "\\" + interfaceName;
+            using var interfaceKey = Registry.LocalMachine.OpenSubKey(interfacePath, writable: false);
+            if (interfaceKey?.GetValue("DeviceInstance") is not string deviceInstance ||
+                !DefaultAudioEndpointGuard.IsVirtualDualSenseDeviceNode(deviceInstance, includePhantom))
+            {
+                continue;
+            }
+
+            foreach (var referenceName in interfaceKey.GetSubKeyNames())
+            {
+                var parametersPath = interfacePath + "\\" + referenceName + "\\Device Parameters";
+                using var parameters = Registry.LocalMachine.OpenSubKey(parametersPath, writable: true);
+                if (parameters is null)
+                    continue;
+
+                using var endpoint = parameters.CreateSubKey(@"EP\0", writable: true);
+                if (endpoint is null)
+                    continue;
+
+                matched = true;
+                if (NeedsUpdate(endpoint.GetValue(EndpointAssociation), endpoint.GetValue(NeverSetAsDefaultEndpoint)))
+                {
+                    endpoint.SetValue(EndpointAssociation, AnyKsNodeType, RegistryValueKind.String);
+                    endpoint.SetValue(NeverSetAsDefaultEndpoint, AllRolesAndFlows, RegistryValueKind.DWord);
+                    changed = true;
+                }
+            }
+        }
+
+        return matched;
+    }
+
+    internal static bool NeedsUpdate(object? association, object? policy)
+    {
+        return association is not string associationText ||
+               !associationText.Equals(AnyKsNodeType, StringComparison.OrdinalIgnoreCase) ||
+               policy is not int policyMask ||
+               (policyMask & AllRolesAndFlows) != AllRolesAndFlows;
+    }
+}

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointPolicy.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointPolicy.cs
@@ -16,6 +16,7 @@ internal static class DefaultAudioEndpointPolicy
     private const string NeverSetAsDefaultEndpoint =
         "{F3E80BEF-1723-4FF2-BCC4-7F83DC5E46D4},3";
     private const string AnyKsNodeType = "{00000000-0000-0000-0000-000000000000}";
+    // FLOW_MASK_RENDER | FLOW_MASK_CAPTURE | every default-device role.
     private const int AllRolesAndFlows = 0x00000307;
 
     /// <summary>

--- a/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
+++ b/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
@@ -150,6 +150,7 @@ internal static class ProtocolSelfTest
         VerifyBundledCompositeProfile();
         VerifyHapticsChannelIsolation();
         VerifyDefaultAudioEndpointClassification();
+        VerifyDefaultAudioEndpointPolicy();
     }
 
     private static void VerifyDefaultAudioEndpointClassification()
@@ -174,6 +175,18 @@ internal static class ProtocolSelfTest
             new DefaultAudioEndpointGuard.DeviceNodeIdentity(
                 @"ROOT\USB\0000", new[] { @"ROOT\HIDMAESTRO_UDE" }),
         }), "unrelated HIDMaestro endpoint exclusion");
+    }
+
+    private static void VerifyDefaultAudioEndpointPolicy()
+    {
+        Require(DefaultAudioEndpointPolicy.NeedsUpdate(null, null),
+            "missing default audio endpoint policy");
+        Require(DefaultAudioEndpointPolicy.NeedsUpdate(
+                "{00000000-0000-0000-0000-000000000000}", 0x00000101),
+            "partial default audio endpoint policy");
+        Require(!DefaultAudioEndpointPolicy.NeedsUpdate(
+                "{00000000-0000-0000-0000-000000000000}", 0x00000307),
+            "complete default audio endpoint policy");
     }
 
     private static void VerifyBundledCompositeProfile()

--- a/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
+++ b/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
@@ -155,6 +155,8 @@ internal static class ProtocolSelfTest
 
     private static void VerifyDefaultAudioEndpointClassification()
     {
+        Require(Enum.GetUnderlyingType(typeof(DefaultAudioEndpointGuard.AudioRole)) == typeof(int),
+            "default audio role COM width");
         var virtualDualSense = new[]
         {
             new DefaultAudioEndpointGuard.DeviceNodeIdentity(

--- a/tools/sunshine-ds5-sidecar/SidecarServer.cs
+++ b/tools/sunshine-ds5-sidecar/SidecarServer.cs
@@ -205,7 +205,26 @@ internal sealed class SidecarServer : IAsyncDisposable
                       ?? throw new InvalidOperationException($"HIDMaestro profile '{profileId}' is missing");
         if (!profile.RequiresUsbipBackend)
             _context.InstallDriver();
+
+        if (profile.RequiresUsbipBackend)
+        {
+            try
+            {
+                // Seed a previously seen virtual interface before it becomes
+                // present. This avoids even a transient default-device switch
+                // on every attach after the first one.
+                DefaultAudioEndpointPolicy.EnsureNeverDefault(
+                    TimeSpan.Zero, includePhantom: true, out _);
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine($"Unable to preseed the DualSense audio endpoint policy: {error.Message}");
+            }
+        }
+
         var controller = _context.CreateController(profile);
+        if (profile.RequiresUsbipBackend)
+            controller = ApplyDefaultAudioEndpointPolicy(controller, profile);
         ControllerSession session;
         try
         {
@@ -236,6 +255,46 @@ internal sealed class SidecarServer : IAsyncDisposable
         // endpoint is already default, Core can finish attaching and enter its
         // normal one-shot recovery path before we close this composite session.
         session.StartDefaultAudioEndpointGuard();
+    }
+
+    private HMController ApplyDefaultAudioEndpointPolicy(HMController controller, HMProfile profile)
+    {
+        const int recreationLimit = 2;
+        for (var recreation = 0; recreation <= recreationLimit; ++recreation)
+        {
+            bool changed;
+            try
+            {
+                if (!DefaultAudioEndpointPolicy.EnsureNeverDefault(
+                        TimeSpan.FromSeconds(3), includePhantom: false, out changed))
+                {
+                    Console.Error.WriteLine(
+                        "Unable to find the virtual DualSense audio interface; runtime default-device guard remains active");
+                    return controller;
+                }
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine(
+                    $"Unable to apply the DualSense audio endpoint policy: {error.Message}; " +
+                    "runtime default-device guard remains active");
+                return controller;
+            }
+
+            if (!changed)
+                return controller;
+
+            // AudioEndpointBuilder consumes the EP properties when it creates
+            // the MMDevice endpoint. Once disposal begins, creation failures
+            // must propagate rather than returning a disposed controller.
+            controller.Dispose();
+            controller = _context.CreateController(profile);
+        }
+
+        Console.Error.WriteLine(
+            "DualSense audio endpoint identity did not stabilize after policy provisioning; " +
+            "runtime default-device guard remains active");
+        return controller;
     }
 
     private void Detach(uint requestId, ReadOnlySpan<byte> payload)


### PR DESCRIPTION
## 改了啥呀

- 给 HIDMaestro 虚拟 DualSense 音频接口写入 Windows 官方的 `PKEY_AudioDevice_NeverSetAsDefaultEndpoint` 与端点关联属性，覆盖 Console、Multimedia、Communications 以及 Render、Capture，默认设备别再乱抢啦。
- 只匹配同时具有 Sony DualSense VID/PID 和 `ROOT\HIDMAESTRO_UDE` 父链的接口，实体 DualSense 不会被碰到。
- 首次配置后重建一次复合设备，让 AudioEndpointBuilder 在创建 MMDevice 时读取策略；之后会预置已存在的 phantom 接口，避免短暂切换。
- 把 #984 的 400ms 轮询兜底改成 `IMMNotificationClient.OnDefaultDeviceChanged`：先注册、再初检 Render/Capture × 三种 role，之后只在默认端点真正变化时检查；注册失败才退回 2 秒低频轮询。
- Core Audio 回调只做非阻塞合并：六个固定原子槽分别保存每个 flow/role 的最新变化，容量 1 的 Channel 只负责唤醒后台单读者，通知风暴也不会形成无界积压。
- 设备树、注册表和恢复通知全部由 guard 后台处理；`AudioRole` 按原生 `ERole` 使用 32 位 COM 编排。
- 任一 Render 或 Capture 默认映射意外指向虚拟 DS5 时，继续复用现有 HID-only 恢复；给策略完整性和 COM 枚举宽度补上确定性自检。

## 为啥要改

#984 的只读 fail-closed 防线能阻止普通游戏音频污染触觉 PCM，但虚拟端点一旦被 Windows 自动选成默认设备，就只能降级为 HID-only，于是原生四声道触觉也一起没了。

这次把主要防线前移到 Windows 文档化的端点策略：虚拟 DS5 音频仍可被支持游戏显式打开，却不能成为系统默认播放、录音或通信设备。事件驱动 guard 只负责异常兜底，正常会话不再每 400ms 唤醒检查；音频系统回调也不会被杂鱼设备树查询或无界队列堵住啦。

- Never-default 策略：<https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/pkey-audiodevice-neversetasdefaultendpoint>
- Core Audio 默认端点通知：<https://learn.microsoft.com/en-us/windows/win32/api/mmdeviceapi/nf-mmdeviceapi-immnotificationclient-ondefaultdevicechanged>

## 验证

- `dotnet format tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj --verify-no-changes --no-restore`：通过
- `dotnet build tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj -c Release -p:HIDMaestroCorePath=...`：0 warning / 0 error
- `Sunshine.Ds5Sidecar.exe --self-check`：音频布局、声道隔离、端点归属、策略完整性与 32 位 COM role 编排通过
- 提权运行 `Sunshine.Ds5Sidecar.exe --self-test composite`：复合端点创建、输入、触摸、运动、电量、扳机、detach、owner 断开及清理通过
- `ds5_sidecar_client_unit_tests.exe`：10/10 passed
- 本机删除预置策略后提权创建 composite DS5：sidecar 自动写入 `EP\0` 的 Association 与 `0x307`；虚拟 DualSense 扬声器存在，Windows Console 默认播放设备保持原设备，`DualSenseIsDefault=false`
- `git diff --check`：通过