### PR TITLE
feat(ds5): add compatibility identity and component upgrades

### DIFF
--- a/docs/windows_dualsense_component_lifecycle.md
+++ b/docs/windows_dualsense_component_lifecycle.md
@@ -40,8 +40,11 @@
 |---|---|---:|---:|---|---|
 | `dualsense` | UMDF2 | 是 | 否 | HIDMaestro 动态生成并安装的 UMDF2 驱动/本机自签名证书 | 输入、触摸板、运动、自适应扳机验证与无 HD Haptics 的降级模式 |
 | `dualsense-composite` | USB/IP | 是 | 是 | 内嵌 usbip-win2 0.9.7.7 | 需要游戏识别 DS5 四声道端点并产出 authored haptics 的完整模式 |
+| `dualsense-composite-genshin` | USB/IP | 是 | 是 | 与完整模式相同 | 实验性《原神》兼容身份；只把 USB product string 改为首发版 `Wireless Controller` |
 
 复合 profile 的音频输出固定为 48 kHz、16-bit、4 声道，角色依次为 `speakerLeft`、`speakerRight`、`hapticLeft`、`hapticRight`。HIDMaestro 公共 API 可以直接交付游戏写入该端点的 PCM 帧，Sidecar 不需要从混合后的桌面音频重新猜测第 3/4 声道。
+
+兼容 profile 不维护第二份 USB 描述符：Sidecar 启动时从已校验的 `dualsense-composite` 动态派生，只修改 profile ID、显示名和 product string。GUI 默认关闭该模式，并只在 DualSense、HD Haptics、USB/IP 与新 Sidecar 能力均可用时允许启用。切换后需要重新创建虚拟手柄，用户应先开始串流，再完全退出并重新启动《原神》。该模式不修改 Windows 默认播放或录音设备，现有 never-default 防线保持不变。
 
 官方发布物当前未做 Authenticode 签名，并携带运行时、usbip-win2 安装器及 WDK 工具。第一阶段只从上游固定版本 URL 下载、校验固定 SHA-256，不随 Sunshine 安装包或自有 CDN 再分发。目前只把 Windows 11 24H2 build 26100 记为“已验证”；Windows 10 与其他 Windows 11 build 仍属于实验范围，GUI 不宣称已受支持。这里不把程序集的 `windows10.0.26100.0` API target 误当作已证明的最低 OS 版本；正式分发前必须完成真实 OS build 矩阵并据此决定拒绝安装还是显示实验性警告。
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -555,6 +555,7 @@ namespace config {
     true,  // ds5_inputtino_randomize_mac
     false,  // ds5_enabled
     true,  // ds5_audio_haptics (native authored Channel 3/4 passthrough)
+    false,  // ds5_genshin_compatibility (legacy Wireless Controller identity)
     {},  // ds5_sidecar_path
     false, // enable_dsu_server - disabled by default
     26760, // dsu_server_port - default DSU server port
@@ -1553,6 +1554,7 @@ namespace config {
     bool_f(vars, "touchpad_as_ds4", input.touchpad_as_ds4);
     bool_f(vars, "ds5_enabled", input.ds5_enabled);
     bool_f(vars, "ds5_audio_haptics", input.ds5_audio_haptics);
+    bool_f(vars, "ds5_genshin_compatibility", input.ds5_genshin_compatibility);
     if (const auto path = vars.find("ds5_sidecar_path");
         path != vars.end() && !path->second.empty()) {
       path_f(vars, "ds5_sidecar_path", input.ds5_sidecar_path);

--- a/src/config.h
+++ b/src/config.h
@@ -214,6 +214,7 @@ namespace config {
     bool ds5_inputtino_randomize_mac;
     bool ds5_enabled;
     bool ds5_audio_haptics;
+    bool ds5_genshin_compatibility;
     std::string ds5_sidecar_path;
     bool enable_dsu_server;
     uint16_t dsu_server_port;

--- a/src/platform/windows/ds5/ds5_sidecar_client.cpp
+++ b/src/platform/windows/ds5/ds5_sidecar_client.cpp
@@ -40,6 +40,8 @@ namespace platf::ds5 {
     constexpr std::uint16_t VERSION = 1;
     constexpr std::size_t HEADER_SIZE = 16;
     constexpr std::uint32_t MAX_PAYLOAD = 1024 * 1024;
+    constexpr std::uint32_t CAP_GENSHIN_COMPATIBILITY_IDENTITY = 1u << 8;
+    constexpr std::uint8_t ATTACH_FLAG_GENSHIN_COMPATIBILITY = 1u << 0;
     // The sidecar protocol identifies devices with a single byte.
     static_assert(platf::MAX_GAMEPADS <= 256, "DS5 device ids must fit the wire format");
 
@@ -275,6 +277,7 @@ namespace platf::ds5 {
     std::atomic_int global_index { -1 };
     std::uint8_t client_index = 0;
     bool audio_haptics_requested = false;
+    bool genshin_compatibility_requested = false;
     bool force_hid_fallback = false;
     feedback_queue_t feedback_queue;
     std::uint32_t next_request_id = 1;
@@ -497,7 +500,9 @@ namespace platf::ds5 {
       return false;
     }
 
-    bool connect_and_attach(const gamepad_id_t &id, bool audio_haptics) {
+    bool connect_and_attach(const gamepad_id_t &id, bool audio_haptics,
+                            bool genshin_compatibility) {
+      const bool use_genshin_identity = audio_haptics && genshin_compatibility;
       if (!launch_and_connect()) {
         return false;
       }
@@ -508,12 +513,18 @@ namespace platf::ds5 {
       if (!transact(message_e::hello, hello, message_e::hello_reply, reply)) {
         return false;
       }
+      const auto capabilities = reply.payload.size() == 4 ? read_u32(reply.payload.data()) : 0;
+      if (use_genshin_identity &&
+          (capabilities & CAP_GENSHIN_COMPATIBILITY_IDENTITY) == 0) {
+        BOOST_LOG(error) << "The installed DualSense sidecar does not support Genshin compatibility mode"sv;
+        return false;
+      }
 
       std::array<std::uint8_t, 4> attach_payload {
         static_cast<std::uint8_t>(id.globalIndex),
         id.clientRelativeIndex,
         static_cast<std::uint8_t>(audio_haptics ? 1 : 0),
-        0,
+        static_cast<std::uint8_t>(use_genshin_identity ? ATTACH_FLAG_GENSHIN_COMPATIBILITY : 0),
       };
       // Claim ownership before the transaction so feedback interleaved ahead
       // of the attach reply is routed to the queue instead of dropped.
@@ -529,13 +540,15 @@ namespace platf::ds5 {
 
       client_index = id.clientRelativeIndex;
       audio_haptics_requested = audio_haptics && !force_hid_fallback;
+      genshin_compatibility_requested = use_genshin_identity && audio_haptics_requested;
       online = true;
       BOOST_LOG(info) << "DualSense sidecar attached controller "sv << id.globalIndex
-                      << (reply.payload[1] ? " with native four-channel haptics" : " (HID only)");
+                      << (reply.payload[1] ? " with native four-channel haptics" : " (HID only)")
+                      << (genshin_compatibility_requested ? " using Genshin compatibility identity" : "");
       return true;
     }
 
-    bool attach(const gamepad_id_t &id, bool audio_haptics) {
+    bool attach(const gamepad_id_t &id, bool audio_haptics, bool genshin_compatibility) {
       // A failed recovery releases global_index from the reader thread before
       // that thread object stops being joinable. Reap it before reusing the
       // same client for a later allocation; assigning over a joinable
@@ -546,7 +559,7 @@ namespace platf::ds5 {
       // A new allocation is an explicit user/session request. Only the
       // automatic recovery of the current allocation inherits the fallback.
       force_hid_fallback = false;
-      if (!connect_and_attach(id, audio_haptics)) {
+      if (!connect_and_attach(id, audio_haptics, genshin_compatibility)) {
         return false;
       }
       reader = std::thread([this] { read_loop(); });
@@ -596,7 +609,7 @@ namespace platf::ds5 {
           global_index.load(),
           client_index,
         };
-        if (!connect_and_attach(id, audio_haptics_requested)) {
+        if (!connect_and_attach(id, audio_haptics_requested, genshin_compatibility_requested)) {
           close_transport();
           break;
         }
@@ -640,12 +653,13 @@ namespace platf::ds5 {
     return global_index >= 0 && _impl->global_index == global_index;
   }
 
-  int sidecar_client_t::alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue, bool audio_haptics) {
+  int sidecar_client_t::alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue,
+                              bool audio_haptics, bool genshin_compatibility) {
     if (!configured() || _impl->global_index >= 0) {
       return -1;
     }
     _impl->feedback_queue = std::move(feedback_queue);
-    if (_impl->attach(id, audio_haptics)) {
+    if (_impl->attach(id, audio_haptics, genshin_compatibility && audio_haptics)) {
       return 0;
     }
     _impl = std::make_unique<impl_t>();

--- a/src/platform/windows/ds5/ds5_sidecar_client.h
+++ b/src/platform/windows/ds5/ds5_sidecar_client.h
@@ -19,7 +19,8 @@ namespace platf::ds5 {
 
     bool configured() const;
     bool owns(int global_index) const;
-    int alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue, bool audio_haptics);
+    int alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue, bool audio_haptics,
+              bool genshin_compatibility = false);
     void free(int global_index);
     void submit_input(int global_index, const gamepad_state_t &state);
     void submit_touch(const gamepad_touch_t &touch);

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -1919,7 +1919,9 @@ namespace platf {
         BOOST_LOG(error) << "DualSense emulation is selected but its optional sidecar component is unavailable"sv;
         return -1;
       }
-      const auto result = raw->ds5_sidecar->alloc(id, feedback_queue, config::input.ds5_audio_haptics);
+      const auto result = raw->ds5_sidecar->alloc(
+        id, feedback_queue, config::input.ds5_audio_haptics,
+        config::input.ds5_genshin_compatibility);
       if (result == 0) {
         feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
         feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));

--- a/tests/tools/ds5_fake_sidecar.cpp
+++ b/tests/tools/ds5_fake_sidecar.cpp
@@ -82,6 +82,8 @@ int main(int argc, char **argv) {
   const auto interleave = GetEnvironmentVariableW(L"SUNSHINE_DS5_TEST_INTERLEAVE", nullptr, 0) > 0;
   const auto audio_policy_fallback =
     GetEnvironmentVariableW(L"SUNSHINE_DS5_TEST_AUDIO_POLICY_FALLBACK", nullptr, 0) > 0;
+  const auto genshin_compatibility =
+    GetEnvironmentVariableW(L"SUNSHINE_DS5_TEST_GENSHIN_COMPATIBILITY", nullptr, 0) > 0;
   const auto policy_once_name = L"Local\\sunshine-ds5-test-policy-once-" + event_suffix;
   const auto policy_once_event = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE,
                                             policy_once_name.c_str());
@@ -104,6 +106,10 @@ int main(int argc, char **argv) {
                                                recovery_wait_name.c_str());
   const auto marker_name = L"Local\\sunshine-ds5-test-marker-" + event_suffix;
   const auto marker_event = OpenEventW(EVENT_MODIFY_STATE, FALSE, marker_name.c_str());
+  const auto genshin_compatibility_name =
+    L"Local\\sunshine-ds5-test-genshin-compatibility-" + event_suffix;
+  const auto genshin_compatibility_event = OpenEventW(
+    EVENT_MODIFY_STATE, FALSE, genshin_compatibility_name.c_str());
 
   // A crash-once test can hold the replacement process before it creates its
   // pipe, exposing the Core client's assigned-but-offline recovery window.
@@ -132,7 +138,9 @@ int main(int argc, char **argv) {
     const auto type = read_u16(header.data() + 6);
     const auto request_id = read_u32(header.data() + 12);
     if (type == 1) {
-      if (!reply(pipe, 2, request_id, std::vector<std::uint8_t>(4))) break;
+      std::vector<std::uint8_t> capabilities(4);
+      if (genshin_compatibility) write_u32(capabilities.data(), 1u << 8);
+      if (!reply(pipe, 2, request_id, capabilities)) break;
     } else if (type == 3 && payload.size() == 4) {
       if (interleave) {
         std::vector<std::uint8_t> early(6);
@@ -141,10 +149,14 @@ int main(int argc, char **argv) {
       }
       std::vector<std::uint8_t> response(8);
       response[0] = payload[0];
-      if (audio_policy_fallback && payload[2] == 1) {
+      if ((audio_policy_fallback || genshin_compatibility) && payload[2] == 1) {
         response[1] = 1;
       }
       if (!reply(pipe, 4, request_id, response)) break;
+      if (genshin_compatibility && payload[2] == 1 && (payload[3] & 1) != 0 &&
+          genshin_compatibility_event) {
+        SetEvent(genshin_compatibility_event);
+      }
       if (audio_policy_fallback && policy_once_event &&
           WaitForSingleObject(policy_once_event, 0) == WAIT_TIMEOUT) {
         // The first process accepts the composite attach, then reports the
@@ -187,6 +199,7 @@ int main(int argc, char **argv) {
     }
   }
 
+  if (genshin_compatibility_event) CloseHandle(genshin_compatibility_event);
   if (marker_event) CloseHandle(marker_event);
   if (hid_fallback_event) CloseHandle(hid_fallback_event);
   if (policy_once_event) CloseHandle(policy_once_event);

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -302,6 +302,47 @@ TEST(Ds5SidecarClientTests, RejectsCompositeAttachWithoutAudioEndpoint) {
   EXPECT_FALSE(client.owns(0));
 }
 
+TEST(Ds5SidecarClientTests, SendsNegotiatedGenshinCompatibilityAttachFlag) {
+  config_scope_t restore_config;
+  config::input.ds5_enabled = true;
+  config::input.ds5_sidecar_path = SUNSHINE_DS5_FAKE_SIDECAR_PATH;
+
+  event_namespace_scope_t events(L"genshin-compatibility");
+  environment_scope_t enable_compatibility(
+    L"SUNSHINE_DS5_TEST_GENSHIN_COMPATIBILITY", L"1");
+  const auto continue_name = L"Local\\sunshine-ds5-test-continue-" + events.suffix;
+  const auto compatibility_name =
+    L"Local\\sunshine-ds5-test-genshin-compatibility-" + events.suffix;
+  handle_scope_t continue_event(CreateEventW(nullptr, FALSE, TRUE, continue_name.c_str()));
+  handle_scope_t compatibility_event(CreateEventW(nullptr, FALSE, FALSE, compatibility_name.c_str()));
+  ASSERT_NE(continue_event.handle, nullptr);
+  ASSERT_NE(compatibility_event.handle, nullptr);
+
+  auto mail = std::make_shared<safe::mail_raw_t>();
+  auto feedback = mail->queue<platf::gamepad_feedback_msg_t>("ds5-genshin-compatibility-test");
+  platf::ds5::sidecar_client_t client;
+  ASSERT_EQ(client.alloc({ 0, 0 }, std::move(feedback), true, true), 0);
+  EXPECT_EQ(WaitForSingleObject(compatibility_event.handle, 2000), WAIT_OBJECT_0);
+  client.free(0);
+}
+
+TEST(Ds5SidecarClientTests, RejectsGenshinCompatibilityWithoutSidecarCapability) {
+  config_scope_t restore_config;
+  config::input.ds5_enabled = true;
+  config::input.ds5_sidecar_path = SUNSHINE_DS5_FAKE_SIDECAR_PATH;
+
+  event_namespace_scope_t events(L"genshin-capability-required");
+  const auto continue_name = L"Local\\sunshine-ds5-test-continue-" + events.suffix;
+  handle_scope_t continue_event(CreateEventW(nullptr, FALSE, TRUE, continue_name.c_str()));
+  ASSERT_NE(continue_event.handle, nullptr);
+
+  auto mail = std::make_shared<safe::mail_raw_t>();
+  auto feedback = mail->queue<platf::gamepad_feedback_msg_t>("ds5-genshin-capability-test");
+  platf::ds5::sidecar_client_t client;
+  EXPECT_EQ(client.alloc({ 0, 0 }, std::move(feedback), true, true), -1);
+  EXPECT_FALSE(client.owns(0));
+}
+
 TEST(Ds5SidecarClientTests, RelaunchesOnceAfterUnexpectedExit) {
   config_scope_t restore_config;
   config::input.ds5_enabled = true;

--- a/tools/sunshine-ds5-sidecar/ControllerSession.cs
+++ b/tools/sunshine-ds5-sidecar/ControllerSession.cs
@@ -68,7 +68,7 @@ internal sealed class ControllerSession : IDisposable
         };
 
         _controller.OutputDecoded += OnOutputDecoded;
-        if (profile.Id == DualSenseHapticsAudio.CompositeProfileId)
+        if (DualSenseHapticsAudio.IsCompositeProfile(profile.Id))
         {
             _audioOutput = _controller.UsbAudio?.Output
                 ?? throw new InvalidDataException("Composite DualSense did not expose its audio output");

--- a/tools/sunshine-ds5-sidecar/DualSenseHapticsAudio.cs
+++ b/tools/sunshine-ds5-sidecar/DualSenseHapticsAudio.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using HIDMaestro;
 
 namespace Sunshine.Ds5Sidecar;
@@ -6,6 +7,9 @@ namespace Sunshine.Ds5Sidecar;
 internal static class DualSenseHapticsAudio
 {
     internal const string CompositeProfileId = "dualsense-composite";
+    internal const string GenshinCompatibilityProfileId = "dualsense-composite-genshin";
+    internal const string CompositeProductString = "DualSense Wireless Controller";
+    internal const string GenshinCompatibilityProductString = "Wireless Controller";
     internal const int InputChannels = 4;
     internal const int OutputChannels = 2;
     internal const int BitsPerSample = 16;
@@ -25,9 +29,34 @@ internal static class DualSenseHapticsAudio
 
     internal static void ValidateCompositeProfile(ReadOnlyMemory<byte> json)
     {
+        ValidateCompositeProfile(json, CompositeProfileId, CompositeProductString);
+    }
+
+    internal static byte[] CreateGenshinCompatibilityProfile(ReadOnlyMemory<byte> compositeJson)
+    {
+        var root = JsonNode.Parse(compositeJson.Span)?.AsObject()
+                   ?? throw new InvalidDataException("Composite profile is not a JSON object");
+        root["id"] = GenshinCompatibilityProfileId;
+        root["name"] = "DualSense (PS5) — Genshin compatibility";
+        root["productString"] = GenshinCompatibilityProductString;
+        var derived = JsonSerializer.SerializeToUtf8Bytes(root);
+        ValidateCompositeProfile(
+            derived, GenshinCompatibilityProfileId, GenshinCompatibilityProductString);
+        return derived;
+    }
+
+    internal static bool IsCompositeProfile(string profileId)
+    {
+        return profileId is CompositeProfileId or GenshinCompatibilityProfileId;
+    }
+
+    private static void ValidateCompositeProfile(
+        ReadOnlyMemory<byte> json, string expectedId, string expectedProductString)
+    {
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
-        RequireString(root, "id", CompositeProfileId);
+        RequireString(root, "id", expectedId);
+        RequireString(root, "productString", expectedProductString);
         RequireString(root, "backend", "usbip");
 
         if (!root.TryGetProperty("usbConfiguration", out var configuration) ||

--- a/tools/sunshine-ds5-sidecar/Program.cs
+++ b/tools/sunshine-ds5-sidecar/Program.cs
@@ -36,12 +36,14 @@ if (selfCheck)
         audio_layout = true,
         channel_isolation = true,
         default_endpoint_classification = true,
+        genshin_compatibility_identity = true,
     }));
     return 0;
 }
 
 if (probe)
 {
+    ProtocolSelfTest.RunDeterministicChecks();
     using var context = new HMContext();
     context.LoadDefaultProfiles();
     var standard = context.GetProfile("dualsense");
@@ -53,6 +55,7 @@ if (probe)
         elevated = IsElevated(),
         standard = standard is not null,
         composite = composite is not null,
+        genshin_compatibility_identity = true,
         driver_installed = context.IsDriverInstalled,
         usbip_available = HMContext.IsUsbipBackendAvailable,
     }));

--- a/tools/sunshine-ds5-sidecar/Protocol.cs
+++ b/tools/sunshine-ds5-sidecar/Protocol.cs
@@ -20,6 +20,14 @@ internal static class Protocol
         Motion = 1u << 5,
         Battery = 1u << 6,
         AdaptiveTriggers = 1u << 7,
+        GenshinCompatibilityIdentity = 1u << 8,
+    }
+
+    [Flags]
+    internal enum AttachFlags : byte
+    {
+        None = 0,
+        GenshinCompatibilityIdentity = 1 << 0,
     }
 
     internal enum MessageType : ushort

--- a/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
+++ b/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
@@ -26,6 +26,8 @@ internal static class ProtocolSelfTest
         var helloCapabilities = (Protocol.Capability)BinaryPrimitives.ReadUInt32LittleEndian(hello.Payload);
         Require(helloCapabilities.HasFlag(Protocol.Capability.Hid), "hello HID capability");
         Require(helloCapabilities.HasFlag(Protocol.Capability.AdaptiveTriggers), "hello adaptive trigger capability");
+        Require(helloCapabilities.HasFlag(Protocol.Capability.GenshinCompatibilityIdentity),
+            "hello Genshin compatibility identity capability");
 
         await SendAsync(client, new Protocol.Message(
             Protocol.MessageType.Attach, 2, new byte[] { 0, 0, composite ? (byte)1 : (byte)0, 0 }), stopping.Token);
@@ -148,10 +150,33 @@ internal static class ProtocolSelfTest
     internal static void RunDeterministicChecks()
     {
         VerifyBundledCompositeProfile();
+        VerifyProfileSelection();
         VerifyHapticsChannelIsolation();
         VerifyDefaultAudioEndpointClassification();
         VerifyDefaultAudioEndpointPolicy();
         VerifyControllerStateSubmissionPolicy();
+    }
+
+    private static void VerifyProfileSelection()
+    {
+        Require(SidecarServer.SelectProfileId(
+                1, Protocol.AttachFlags.GenshinCompatibilityIdentity, true, true) ==
+                DualSenseHapticsAudio.GenshinCompatibilityProfileId,
+            "Genshin compatibility attach profile selection");
+        Require(SidecarServer.SelectProfileId(
+                1, Protocol.AttachFlags.None, true, true) ==
+                DualSenseHapticsAudio.CompositeProfileId,
+            "standard composite attach profile selection");
+        try
+        {
+            SidecarServer.SelectProfileId(
+                0, Protocol.AttachFlags.GenshinCompatibilityIdentity, true, true);
+            Require(false, "Genshin compatibility HID attach rejection");
+        }
+        catch (InvalidDataException)
+        {
+            // Expected.
+        }
     }
 
     private static void VerifyControllerStateSubmissionPolicy()
@@ -212,6 +237,20 @@ internal static class ProtocolSelfTest
         stream.CopyTo(memory);
         var profileJson = memory.ToArray();
         DualSenseHapticsAudio.ValidateCompositeProfile(profileJson);
+        var compatibilityProfile = DualSenseHapticsAudio.CreateGenshinCompatibilityProfile(profileJson);
+        using (var compatibilityDocument = JsonDocument.Parse(compatibilityProfile))
+        {
+            var root = compatibilityDocument.RootElement;
+            Require(root.GetProperty("id").GetString() ==
+                    DualSenseHapticsAudio.GenshinCompatibilityProfileId,
+                "Genshin compatibility profile id");
+            Require(root.GetProperty("productString").GetString() ==
+                    DualSenseHapticsAudio.GenshinCompatibilityProductString,
+                "Genshin compatibility product string");
+            Require(root.GetProperty("vid").GetString() == "0x054C" &&
+                    root.GetProperty("pid").GetString() == "0x0CE6",
+                "Genshin compatibility profile preserves Sony identity");
+        }
 
         var profileText = System.Text.Encoding.UTF8.GetString(profileJson);
         RequireProfileRejected(profileText.Replace("\"channels\":4", "\"channels\":2", StringComparison.Ordinal),

--- a/tools/sunshine-ds5-sidecar/README.md
+++ b/tools/sunshine-ds5-sidecar/README.md
@@ -31,6 +31,12 @@ ending the sidecar.
 Disconnecting the owning pipe disposes every device created by
 that connection. Standard `dualsense` uses UMDF2; `dualsense-composite`
 enables the USB composite HID/audio profile and authored haptics PCM.
+The optional Genshin compatibility attach flag derives a third profile from
+`dualsense-composite` at runtime. It preserves the Sony VID/PID, descriptors,
+and four-channel layout while changing only the USB product string from
+`DualSense Wireless Controller` to the launch-model `Wireless Controller`.
+The sidecar advertises this support through a protocol capability bit so an
+older runtime cannot silently accept an ineffective setting.
 The composite session monitors the three Windows default render roles. If
 Windows selects the HIDMaestro-backed virtual DualSense speaker as a default,
 the helper reports the policy violation and exits; Sunshine then performs its

--- a/tools/sunshine-ds5-sidecar/SidecarServer.cs
+++ b/tools/sunshine-ds5-sidecar/SidecarServer.cs
@@ -11,6 +11,7 @@ internal sealed class SidecarServer : IAsyncDisposable
     private readonly HMContext _context = new();
     private readonly Dictionary<byte, ControllerSession> _controllers = new();
     private readonly bool _authoredHapticsAvailable;
+    private readonly bool _genshinCompatibilityAvailable;
     private readonly Channel<Protocol.Message> _controlOutgoing;
     private readonly Channel<Protocol.Message> _realtimeOutgoing;
     private readonly SemaphoreSlim _outgoingSignal = new(0, 1);
@@ -25,6 +26,9 @@ internal sealed class SidecarServer : IAsyncDisposable
         _authoredHapticsAvailable = compositeProfileValidated &&
                                     _context.GetProfile(DualSenseHapticsAudio.CompositeProfileId) is not null &&
                                     HMContext.IsUsbipBackendAvailable;
+        _genshinCompatibilityAvailable = _authoredHapticsAvailable &&
+                                         _context.GetProfile(
+                                             DualSenseHapticsAudio.GenshinCompatibilityProfileId) is not null;
         _controlOutgoing = Channel.CreateUnbounded<Protocol.Message>(new UnboundedChannelOptions
         {
             SingleReader = true,
@@ -145,6 +149,9 @@ internal sealed class SidecarServer : IAsyncDisposable
                                                    Protocol.Capability.Motion |
                                                    Protocol.Capability.Battery |
                                                    Protocol.Capability.AdaptiveTriggers |
+                                                   (_genshinCompatibilityAvailable
+                                                       ? Protocol.Capability.GenshinCompatibilityIdentity
+                                                       : 0) |
                                                    (_authoredHapticsAvailable
                                                        ? Protocol.Capability.AudioFourChannel |
                                                          Protocol.Capability.AuthoredHapticsPcm
@@ -187,20 +194,16 @@ internal sealed class SidecarServer : IAsyncDisposable
 
     private void Attach(uint requestId, ReadOnlySpan<byte> payload)
     {
-        // id:u8, controller:u8, profile:u8 (0 HID, 1 composite), reserved:u8
+        // id:u8, controller:u8, profile:u8 (0 HID, 1 composite), flags:u8
         if (payload.Length != 4)
             throw new InvalidDataException("Invalid attach payload");
         var deviceId = payload[0];
         if (_controllers.ContainsKey(deviceId))
             throw new InvalidOperationException("The requested DS5 device already exists");
 
-        var profileId = payload[2] switch
-        {
-            0 => "dualsense",
-            1 when _authoredHapticsAvailable => DualSenseHapticsAudio.CompositeProfileId,
-            1 => throw new InvalidOperationException("Validated DualSense four-channel audio is unavailable"),
-            _ => throw new InvalidDataException("Unsupported DS5 profile mode"),
-        };
+        var profileId = SelectProfileId(
+            payload[2], (Protocol.AttachFlags)payload[3],
+            _authoredHapticsAvailable, _genshinCompatibilityAvailable);
         var profile = _context.GetProfile(profileId)
                       ?? throw new InvalidOperationException($"HIDMaestro profile '{profileId}' is missing");
         if (!profile.RequiresUsbipBackend)
@@ -247,6 +250,9 @@ internal sealed class SidecarServer : IAsyncDisposable
                    Protocol.Capability.Motion |
                    Protocol.Capability.Battery |
                    Protocol.Capability.AdaptiveTriggers |
+                   (_genshinCompatibilityAvailable
+                       ? Protocol.Capability.GenshinCompatibilityIdentity
+                       : 0) |
                    (session.HasAudio
                        ? Protocol.Capability.AudioFourChannel | Protocol.Capability.AuthoredHapticsPcm
                        : 0)));
@@ -255,6 +261,30 @@ internal sealed class SidecarServer : IAsyncDisposable
         // endpoint is already default, Core can finish attaching and enter its
         // normal one-shot recovery path before we close this composite session.
         session.StartDefaultAudioEndpointGuard();
+    }
+
+    internal static string SelectProfileId(
+        byte profileMode, Protocol.AttachFlags flags,
+        bool authoredHapticsAvailable, bool genshinCompatibilityAvailable)
+    {
+        if ((flags & ~Protocol.AttachFlags.GenshinCompatibilityIdentity) != 0)
+            throw new InvalidDataException("Unsupported DS5 attach flags");
+        var genshinCompatibility = flags.HasFlag(
+            Protocol.AttachFlags.GenshinCompatibilityIdentity);
+        if (genshinCompatibility && profileMode != 1)
+            throw new InvalidDataException("Genshin compatibility requires the composite profile");
+
+        return profileMode switch
+        {
+            0 => "dualsense",
+            1 when genshinCompatibility && genshinCompatibilityAvailable =>
+                DualSenseHapticsAudio.GenshinCompatibilityProfileId,
+            1 when genshinCompatibility =>
+                throw new InvalidOperationException("Genshin compatibility identity is unavailable"),
+            1 when authoredHapticsAvailable => DualSenseHapticsAudio.CompositeProfileId,
+            1 => throw new InvalidOperationException("Validated DualSense four-channel audio is unavailable"),
+            _ => throw new InvalidDataException("Unsupported DS5 profile mode"),
+        };
     }
 
     private HMController ApplyDefaultAudioEndpointPolicy(HMController controller, HMProfile profile)
@@ -333,8 +363,16 @@ internal sealed class SidecarServer : IAsyncDisposable
                 if (id == DualSenseHapticsAudio.CompositeProfileId)
                     DualSenseHapticsAudio.ValidateCompositeProfile(profileBytes);
                 File.WriteAllBytes(Path.Combine(directory, id + ".json"), profileBytes);
+                if (id == DualSenseHapticsAudio.CompositeProfileId)
+                {
+                    var compatibilityProfile =
+                        DualSenseHapticsAudio.CreateGenshinCompatibilityProfile(profileBytes);
+                    File.WriteAllBytes(
+                        Path.Combine(directory, DualSenseHapticsAudio.GenshinCompatibilityProfileId + ".json"),
+                        compatibilityProfile);
+                }
             }
-            if (_context.LoadProfilesFromDirectory(directory) < 2)
+            if (_context.LoadProfilesFromDirectory(directory) < 3)
                 throw new InvalidOperationException("Patched DualSense profiles did not fully register");
             return true;
         }


### PR DESCRIPTION
## 改了啥呀

- 新增 `ds5_genshin_compatibility`，只在四声道 HD Haptics 模式下生效
- Sidecar 从已校验的 `dualsense-composite` 动态派生 `dualsense-composite-genshin`
- 保留 Sony VID/PID、USB 描述符和四声道布局，只把 product string 改成首发版 `Wireless Controller`
- 为协议增加能力位和 attach flag；旧 Sidecar 不支持时明确拒绝，别让杂鱼配置静悄悄失效
- never-default 音频策略保持不变，不会替用户切换 Windows 默认播放或录音设备
- GUI 现在读取已安装 manifest、识别旧组件，并提供保留设置、校验后替换、失败回滚的升级入口
- 更新控制面板到 qiin2333/sunshine-control-panel#90 最新提交

## 为啥要改

社区案例表明，《原神》在部分 Windows 环境可能仍按首发 DualSense 的 `Wireless Controller` 名称发现设备，而当前硬件和 HIDMaestro 使用 `DualSense Wireless Controller`。这个实验模式把身份差异单独做成显式开关，用来验证是否能恢复原生四声道触觉，同时不放宽现有音频安全防线。

旧组件无法提供这项身份能力，因此同步补齐了可发现、可回滚的组件升级路径。

依赖 GUI PR：qiin2333/sunshine-control-panel#90

## 验证

- `dotnet build tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj --no-restore -p:HIDMaestroCorePath=...`：通过，0 warnings / 0 errors
- Sidecar `--self-check`：`genshin_compatibility_identity=true`
- Sidecar `--probe`：声明兼容身份能力
- `cmake --build build --target ds5_sidecar_client_unit_tests -j 2`：编译、链接通过
- GUI `npm run test:renderer`：20 passed
- GUI `npm run build:renderer`：通过
- GUI `cargo test --manifest-path src-tauri/Cargo.toml dualsense::tests::`：14 passed
- GUI 定向 rustfmt 校验：通过
- Playwright 本地交互：兼容开关保存、提示显示以及关闭 HD Haptics 后自动清理均通过

## 已知测试环境问题

本机 MinGW 生成的 C++ 单测程序仍在进入 `main()` 前触发既有的 `atexit/_onexit` 无限递归；GDB 回溯确认位于 MinGW CRT 初始化路径。本次新增目标能够正常编译和链接，Sidecar 与 GUI 测试不受影响。