### PR TITLE
feat(ds5): distribute sidecar runtime on demand

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,9 @@ jobs:
 
       - name: Build self-contained DualSense sidecar
         shell: pwsh
-        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag '${{ needs.setup_release.outputs.release_tag }}.杂鱼'
+        env:
+          RELEASE_TAG: ${{ needs.setup_release.outputs.release_tag }}.杂鱼
+        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag $env:RELEASE_TAG
 
       - name: Build Web UI
         shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Build self-contained DualSense sidecar
         shell: pwsh
-        run: .\scripts\build-ds5-sidecar.ps1
+        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag '${{ needs.setup_release.outputs.release_tag }}.杂鱼'
 
       - name: Build Web UI
         shell: pwsh
@@ -272,19 +272,28 @@ jobs:
           # Package the Inno Setup installer and portable ZIP.
           # Install into the staging directory first.
           cmake --install . --prefix ./inno_staging
-          test -f ./inno_staging/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe
+          test -f ./inno_staging/tools/ds5-sidecar-package.json
+          test ! -e ./inno_staging/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe
           
-          # Run the Inno Setup compiler and prove that it consumed the sidecar.
+          # Run the Inno Setup compiler and prove that it consumed only the
+          # lightweight package manifest, not the self-contained runtime.
           "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" sunshine_installer.iss | tee inno-build.log
-          grep -F "Sunshine.Ds5Sidecar.exe" inno-build.log
+          grep -F "ds5-sidecar-package.json" inno-build.log
           
           # Generate the portable ZIP.
           cpack -G ZIP --config ./CPackConfig.cmake --verbose
-          cmake -E tar tf ./cpack_artifacts/Sunshine.zip | tr '\\' '/' | grep -F "Sunshine/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe"
+          cmake -E tar tf ./cpack_artifacts/Sunshine.zip | tr '\\' '/' > portable-files.txt
+          grep -F "Sunshine/tools/ds5-sidecar-package.json" portable-files.txt
+          if grep -F "Sunshine/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe" portable-files.txt; then
+            echo "The optional DualSense runtime leaked into the main portable package"
+            exit 1
+          fi
 
           # move
           mv ./cpack_artifacts/Sunshine.exe ../artifacts/sunshine-windows-installer.exe
           mv ./cpack_artifacts/Sunshine.zip ../artifacts/sunshine-windows-portable.zip
+          cp ./ds5-sidecar-package/Sunshine.Ds5Sidecar.Windows-x64.zip ../artifacts/
+          cp ./ds5-sidecar-package.json ../artifacts/Sunshine.Ds5Sidecar.manifest.json
 
       - name: Generate Checksums
         shell: pwsh
@@ -317,6 +326,8 @@ jobs:
           path: |
             artifacts/Sunshine.*.WindowsInstaller.exe
             artifacts/Sunshine.*.WindowsPortable.zip
+            artifacts/Sunshine.Ds5Sidecar.Windows-x64.zip
+            artifacts/Sunshine.Ds5Sidecar.manifest.json
             artifacts/SHA256SUMS.txt
             artifacts/checksums.json
           if-no-files-found: error

--- a/.github/workflows/sign-and-repackage.yml
+++ b/.github/workflows/sign-and-repackage.yml
@@ -159,7 +159,9 @@ jobs:
 
       - name: Build self-contained DualSense sidecar
         shell: pwsh
-        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag '${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}'
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}
+        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag $env:RELEASE_TAG
 
       - name: Build Windows
         shell: msys2 {0}
@@ -277,12 +279,14 @@ jobs:
 
       - name: Package signed DualSense component
         shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}
         run: |
           .\scripts\package-ds5-sidecar.ps1 `
             -RuntimeDirectory 'signed-files/Sunshine/tools/sunshine-ds5-signing-staging' `
             -PackageDirectory 'signed-component' `
             -ManifestPath 'build/ds5-sidecar-package.json' `
-            -ReleaseTag '${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}'
+            -ReleaseTag $env:RELEASE_TAG
           Copy-Item -LiteralPath 'build/ds5-sidecar-package.json' `
             -Destination 'signed-files/Sunshine/tools/ds5-sidecar-package.json' -Force
           Copy-Item -LiteralPath 'build/ds5-sidecar-package.json' `
@@ -305,7 +309,7 @@ jobs:
           else
             VERSION="v$(date +%Y.%m%d)"
           fi
-          7z a "../../Sunshine-${VERSION}-Windows-Portable-Signed.zip" * -y
+          7z a "../../Sunshine-${VERSION}-Windows-Portable-Signed.zip" ./* -y
           cd ../..
           echo "Created signed portable package:"
           ls -lh Sunshine-*-Portable-Signed.zip

--- a/.github/workflows/sign-and-repackage.yml
+++ b/.github/workflows/sign-and-repackage.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Build self-contained DualSense sidecar
         shell: pwsh
-        run: .\scripts\build-ds5-sidecar.ps1
+        run: .\scripts\build-ds5-sidecar.ps1 -ReleaseTag '${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}'
 
       - name: Build Windows
         shell: msys2 {0}
@@ -224,6 +224,8 @@ jobs:
             echo "Extracting: $PORTABLE"
             mkdir -p unsigned-files
             7z x "$PORTABLE" -o"unsigned-files" -y -aoa
+            mkdir -p unsigned-files/Sunshine/tools/sunshine-ds5-signing-staging
+            cp -a build/ds5-sidecar-runtime/. unsigned-files/Sunshine/tools/sunshine-ds5-signing-staging/
             echo "Extracted files for signing:"
             ls -laR unsigned-files/
           else
@@ -273,11 +275,28 @@ jobs:
           }
           Write-Host "`n✓ All signatures are VALID!" -ForegroundColor Green
 
+      - name: Package signed DualSense component
+        shell: pwsh
+        run: |
+          .\scripts\package-ds5-sidecar.ps1 `
+            -RuntimeDirectory 'signed-files/Sunshine/tools/sunshine-ds5-signing-staging' `
+            -PackageDirectory 'signed-component' `
+            -ManifestPath 'build/ds5-sidecar-package.json' `
+            -ReleaseTag '${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}'
+          Copy-Item -LiteralPath 'build/ds5-sidecar-package.json' `
+            -Destination 'signed-files/Sunshine/tools/ds5-sidecar-package.json' -Force
+          Copy-Item -LiteralPath 'build/ds5-sidecar-package.json' `
+            -Destination 'build/inno_staging/tools/ds5-sidecar-package.json' -Force
+          Copy-Item -LiteralPath 'build/ds5-sidecar-package.json' `
+            -Destination 'signed-component/Sunshine.Ds5Sidecar.manifest.json' -Force
+          Remove-Item -LiteralPath 'signed-files/Sunshine/tools/sunshine-ds5-signing-staging' `
+            -Recurse -Force
+
       # 使用签名后的文件重新打包 ZIP 便携版
       - name: Repackage signed Portable ZIP
         shell: bash
         run: |
-          cd signed-files
+          cd signed-files/Sunshine
           # 使用与输入一致的版本号
           if [ -n "${{ github.event.inputs.release-tag }}" ]; then
             VERSION="${{ github.event.inputs.release-tag }}"
@@ -286,8 +305,8 @@ jobs:
           else
             VERSION="v$(date +%Y.%m%d)"
           fi
-          7z a "../Sunshine-${VERSION}-Windows-Portable-Signed.zip" * -y
-          cd ..
+          7z a "../../Sunshine-${VERSION}-Windows-Portable-Signed.zip" * -y
+          cd ../..
           echo "Created signed portable package:"
           ls -lh Sunshine-*-Portable-Signed.zip
 
@@ -326,9 +345,10 @@ jobs:
 
           # 运行 Inno Setup 编译器重新打包
           echo "Running ISCC to repackage installer..."
-          test -f "$STAGING_DIR/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe"
+          test -f "$STAGING_DIR/tools/ds5-sidecar-package.json"
+          test ! -e "$STAGING_DIR/tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe"
           "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" "build/sunshine_installer.iss" | tee build/inno-signed-build.log
-          grep -F "Sunshine.Ds5Sidecar.exe" build/inno-signed-build.log
+          grep -F "ds5-sidecar-package.json" build/inno-signed-build.log
 
           # 使用与 Portable ZIP 一致的版本号
           if [ -n "${{ github.event.inputs.release-tag }}" ]; then
@@ -387,6 +407,8 @@ jobs:
           path: |
             Sunshine-*-Portable-Signed.zip
             final-signed/*.exe
+            signed-component/Sunshine.Ds5Sidecar.Windows-x64.zip
+            signed-component/Sunshine.Ds5Sidecar.manifest.json
           if-no-files-found: error
 
       # 发布到 GitHub Release
@@ -398,6 +420,8 @@ jobs:
           files: |
             Sunshine-*-Portable-Signed.zip
             final-signed/*.exe
+            signed-component/Sunshine.Ds5Sidecar.Windows-x64.zip
+            signed-component/Sunshine.Ds5Sidecar.manifest.json
           draft: true
           prerelease: true
           allowUpdates: true

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -195,9 +195,8 @@ Source: "{#MySourceDir}\tools\qiin-tabtip.exe"; DestDir: "{app}\tools"; Flags: i
 Source: "{#MySourceDir}\tools\nefconw.exe"; DestDir: "{app}\tools"; Flags: ignoreversion; Components: application
 Source: "{#MySourceDir}\tools\stylus-input-probe.exe"; DestDir: "{app}\tools"; Flags: ignoreversion; Components: application
 
-; First-party self-contained DualSense sidecar runtime. Keep this mandatory so
-; packaging fails instead of producing a GUI that cannot install the component.
-Source: "{#MySourceDir}\tools\sunshine-ds5-sidecar\*"; DestDir: "{app}\tools\sunshine-ds5-sidecar"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: application
+; Pinned manifest for the separately distributed first-party DualSense runtime.
+Source: "{#MySourceDir}\tools\ds5-sidecar-package.json"; DestDir: "{app}\tools"; Flags: ignoreversion; Components: application
 
 ; Portable scripts (will be deleted during install, but needed for layout)
 Source: "{#MySourceDir}\install_portable.bat"; DestDir: "{app}"; Flags: ignoreversion; Components: application

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -17,17 +17,17 @@ install(TARGETS sunshinesvc RUNTIME DESTINATION "tools" COMPONENT application)
 install(TARGETS qiin-tabtip RUNTIME DESTINATION "tools" COMPONENT application)
 install(TARGETS stylus-input-probe RUNTIME DESTINATION "tools" COMPONENT application)
 
-# The optional DualSense runtime is first-party and self-contained. HIDMaestro
-# itself is downloaded and digest-verified by the Control Panel when the user
-# opts in, so it is intentionally absent from this directory.
-set(DS5_SIDECAR_RUNTIME_DIR "${CMAKE_BINARY_DIR}/ds5-sidecar-runtime" CACHE PATH
-    "Path to the published self-contained Sunshine DualSense sidecar runtime")
-if(EXISTS "${DS5_SIDECAR_RUNTIME_DIR}/Sunshine.Ds5Sidecar.exe")
-  install(DIRECTORY "${DS5_SIDECAR_RUNTIME_DIR}/"
-          DESTINATION "tools/sunshine-ds5-sidecar"
+# The optional self-contained runtime is a separate release asset. The main
+# package carries only its pinned download manifest, keeping the feature
+# installable without adding the complete .NET runtime to every Sunshine copy.
+set(DS5_SIDECAR_PACKAGE_MANIFEST "${CMAKE_BINARY_DIR}/ds5-sidecar-package.json" CACHE FILEPATH
+    "Path to the pinned Sunshine DualSense sidecar package manifest")
+if(EXISTS "${DS5_SIDECAR_PACKAGE_MANIFEST}")
+  install(FILES "${DS5_SIDECAR_PACKAGE_MANIFEST}"
+          DESTINATION "tools"
           COMPONENT application)
 else()
-  message(STATUS "Self-contained DualSense sidecar was not published; optional component install will be unavailable")
+  message(STATUS "DualSense sidecar package manifest was not generated; optional component install will be unavailable")
 endif()
 
 # Shared tool: nefconw.exe (used by VDD and vmouse install scripts)

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -25,9 +25,12 @@ set(DS5_SIDECAR_PACKAGE_MANIFEST "${CMAKE_BINARY_DIR}/ds5-sidecar-package.json" 
 if(EXISTS "${DS5_SIDECAR_PACKAGE_MANIFEST}")
   install(FILES "${DS5_SIDECAR_PACKAGE_MANIFEST}"
           DESTINATION "tools"
+          RENAME "ds5-sidecar-package.json"
           COMPONENT application)
+  set(SUNSHINE_DS5_SIDECAR_PACKAGE_AVAILABLE ON)
 else()
   message(STATUS "DualSense sidecar package manifest was not generated; optional component install will be unavailable")
+  set(SUNSHINE_DS5_SIDECAR_PACKAGE_AVAILABLE OFF)
 endif()
 
 # Shared tool: nefconw.exe (used by VDD and vmouse install scripts)
@@ -230,7 +233,11 @@ set(CPACK_COMPONENT_GAMEPAD_DESCRIPTION "Scripts to install and uninstall Virtua
 set(CPACK_COMPONENT_GAMEPAD_GROUP "Scripts")
 
 # include specific packaging
-include(${CMAKE_MODULE_PATH}/packaging/windows_innosetup.cmake)
+if(SUNSHINE_DS5_SIDECAR_PACKAGE_AVAILABLE)
+  include(${CMAKE_MODULE_PATH}/packaging/windows_innosetup.cmake)
+else()
+  message(STATUS "Inno Setup targets are disabled because the DualSense sidecar package manifest is missing")
+endif()
 # Legacy NSIS/WiX (kept for reference, no longer used)
 # include(${CMAKE_MODULE_PATH}/packaging/windows_nsis.cmake)
 # include(${CMAKE_MODULE_PATH}/packaging/windows_wix.cmake)

--- a/docs/windows_dualsense_component_lifecycle.md
+++ b/docs/windows_dualsense_component_lifecycle.md
@@ -77,6 +77,8 @@ DS5 不采用按进程名扫描或 `taskkill` 的做法。虚拟 USB 设备涉�
 - 后端只接受内置 allowlist 中的官方仓库和资产命名规则。
 - 发布 manifest 固定版本、下载地址、文件大小和 SHA-256。
 - GUI 不接受渲染器传入的任意下载 URL。
+- Sunshine 自研 Sidecar 的 `win-x64` 自包含运行时作为独立 Release 资产发布；主安装包只携带同版本 manifest，不再捆绑完整 .NET 运行时。
+- GUI 默认按 manifest 下载 Sidecar，也允许用户从任意本地目录选择匹配的官方 ZIP；放在 Sunshine 根目录或 `tools` 目录、文件名保持 `Sunshine.Ds5Sidecar.Windows-x64.zip` 的包会被自动发现。提权 helper 不接收调用方路径，只接收 allowlist 操作和随机令牌；本地 ZIP 必须通过 manifest 固定的大小与 SHA-256 校验。
 - 当前发布物存在 WDK 工具再分发审查事项，因此不放入 Sunshine 安装包或自有 CDN。
 - GUI 提供上游项目、许可证、来源 URL 和校验结果。
 
@@ -511,6 +513,8 @@ Core 维护引用计数，按 session ID 管理多客户端。第一阶段可以
 | `DS5-PKG-001` | 下载摘要不匹配 | 删除下载并重试 |
 | `DS5-PKG-002` | 发布包结构无效 | 停止安装并查看日志 |
 | `DS5-PKG-003` | Sidecar probe 失败 | 回滚或修复 |
+| `DS5-PKG-004` | 提权 helper 启动、授权或 IPC 失败 | 重试 UAC；不修改现有组件 |
+| `DS5-PKG-005` | 本地 Sidecar 包与当前 manifest 不匹配 | 下载同一 Sunshine Release 的组件 ZIP |
 | `DS5-DRV-001` | USB 传输缺失 | 提示安装 |
 | `DS5-DRV-002` | 用户取消 UAC | 保留组件，稍后安装 |
 | `DS5-USB-001` | attach 失败 | 清理测试会话后重试 |
@@ -651,7 +655,7 @@ UX 验收：
 
 1. Sidecar 调用 HIDMaestro v1.6.1 的公共 `HIDMaestro.Core.dll` API，不复制其实现，也不调用 HIDMaestroTest UI。
 2. HIDMaestro 使用官方发布物 `HIDMaestro-v1.6.1.zip`，固定下载地址和 SHA-256 `00145c23d9838be6089389ce58b3fd2b6766fa9bc0f1f3c60a3c885361b53c34`。发布物大小为 118,879,222 bytes。
-3. Sunshine 安装包仅携带自研 Sidecar 的 `win-x64` 自包含 .NET 运行时，不携带 HIDMaestro DLL。GUI 在用户明确选择安装时下载第三方发布物，校验后只提取 Core、许可证、README 和第三方通知。
+3. Sunshine 主安装包仅携带自研 Sidecar 组件包的固定 manifest，不携带完整 .NET 运行时或 HIDMaestro DLL。Sidecar 自包含 ZIP 作为同一 Release 的独立资产发布；GUI 在用户明确选择安装时下载或读取用户选择的匹配 ZIP，并继续单独下载、校验 HIDMaestro 后只提取 Core、许可证、README 和第三方通知。
 4. 首期每个 Sunshine 进程只允许一个虚拟 DualSense。Xbox 360、DualShock 4 和既有自动模式继续走 ViGEm，不改变成熟驱动支持范围。
 5. 客户端只选择 `physical` 或 `emulated`。前者预检 USB DualSense 四声道端点后声明 `ML_FF_DS5_HAPTICS_PCM`；后者声明 `ML_FF_DS5_HAPTICS_IR_V2`。两位互斥且不在运行中自动切换。
 6. `0x550A` v1 固定承载 48 kHz、双声道、S16LE 原始 PCM；`0x550B` v2 固定承载 72-byte 双 lane IR。两者均按 5 ms 节拍使用不可靠有序传输，断序/`DISCONTINUITY` 重置客户端状态。
@@ -664,10 +668,10 @@ UX 验收：
 - 提权复合 profile 自测通过，HID、四声道音频端点和设备清理均成功。
 - 强端到端环路通过：Moonlight 实际 WASAPI 渲染器写入 HIDMaestro 48 kHz 四声道端点，Sidecar 从 channel 3/4 收到 960 bytes 非静音触觉 PCM。
 - Moonlight Qt 6.9.2 / MSVC Release 完整链接通过；客户端使用自适应端点容量的 15 ms 上限预缓冲，20 ms 饥饿或序号不连续时重置。
-- Sidecar `win-x64` 自包含发布通过，产物约 107 MB 且确认不包含 `HIDMaestro.Core.dll`；把官方校验 DLL 放入 staging 后，probe 返回协议 1、standard/composite profile、驱动及 USB/IP 均可用。
+- Sidecar `win-x64` 自包含发布通过，未压缩产物约 107 MB 且确认不包含 `HIDMaestro.Core.dll`；该运行时被压缩为独立、固定 SHA-256 的组件资产，把官方校验 DLL 放入 staging 后，probe 返回协议 1、standard/composite profile、驱动及 USB/IP 均可用。
 - Control Panel 已同步 Sunshine master 使用的 VDD/HDR 基线；3 项 DualSense Rust 单测、Vue production build 和 12 项 renderer 测试通过。完整配置读取失败会中止保存，USB/IP 不可用时后端拒绝 composite profile，页面仍允许用户切回 HID-only。
 - Core 的 DS5 命名管道改用 overlapped I/O；独立 fake-sidecar 回归测试覆盖 `alloc -> reader blocked -> free`，本机在 93 ms 内完成，避免同步 `ReadFile` 与 owner EOF 相互等待。
-- Windows `application` 组件的隔离安装烟测通过：自包含 Sidecar 被安装到 `tools/sunshine-ds5-sidecar`，且安装目录中不含 `HIDMaestro.Core.dll`，保持由 GUI 下载并校验第三方运行时的边界。
+- Windows `application` 组件的隔离安装烟测通过：主包只安装 `tools/ds5-sidecar-package.json`，不再出现 `tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.exe`；GUI 下载或选择本地组件包后才把 Sidecar 与经校验的 HIDMaestro Core 激活到组件目录。
 - `moonlight-audio-haptics` authored/ABI 测试、common-c IR v2 golden parser 和 Moonlight IR-to-rumble renderer 测试通过。
 - Sunshine 合成 PCM -> SDK 双 lane IR -> 72-byte 小端序列化 -> common-c 解析的跨仓库测试通过；空流结束会产生静音 `STREAM_END`。
 

--- a/scripts/build-ds5-sidecar.ps1
+++ b/scripts/build-ds5-sidecar.ps1
@@ -1,6 +1,8 @@
 param(
     [string]$OutputDirectory = "build/ds5-sidecar-runtime",
-    [string]$PackageCache = "build/ds5-sidecar-cache"
+    [string]$PackageCache = "build/ds5-sidecar-cache",
+    [string]$ReleaseTag = "",
+    [string]$Repository = "AlkaidLab/foundation-sunshine"
 )
 
 $ErrorActionPreference = 'Stop'
@@ -120,7 +122,7 @@ if ($LASTEXITCODE -ne 0) {
 # package. Excluding it here keeps the Sunshine installer first-party-only.
 Remove-Item -LiteralPath (Join-Path $output 'HIDMaestro.Core.dll') -Force
 @{
-    component_version = '1.0.0-build-runtime'
+    component_version = '1.1.0'
     protocol = 1
     target = 'win-x64-self-contained'
     hidmaestro_build_version = $version
@@ -128,3 +130,11 @@ Remove-Item -LiteralPath (Join-Path $output 'HIDMaestro.Core.dll') -Force
 } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $output 'runtime.json') -Encoding utf8
 
 Write-Host "Published self-contained DualSense sidecar to $output"
+
+& (Join-Path $PSScriptRoot 'package-ds5-sidecar.ps1') `
+    -RuntimeDirectory $OutputDirectory `
+    -ReleaseTag $ReleaseTag `
+    -Repository $Repository
+if ($LASTEXITCODE -ne 0) {
+    throw "DualSense sidecar packaging failed with exit code $LASTEXITCODE"
+}

--- a/scripts/package-ds5-sidecar.ps1
+++ b/scripts/package-ds5-sidecar.ps1
@@ -3,7 +3,9 @@ param(
     [string]$PackageDirectory = "build/ds5-sidecar-package",
     [string]$ManifestPath = "build/ds5-sidecar-package.json",
     [string]$ReleaseTag = "",
-    [string]$Repository = "AlkaidLab/foundation-sunshine"
+    [string]$Repository = "AlkaidLab/foundation-sunshine",
+    [ValidateSet('GPL-3.0-only')]
+    [string]$License = 'GPL-3.0-only'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -50,6 +52,7 @@ New-Item -ItemType Directory -Force -Path $manifestDirectory | Out-Null
     component_version = $componentVersion
     protocol = $protocolVersion
     target = 'win-x64-self-contained'
+    license = $License
     asset_name = $assetName
     download_url = $downloadUrl
     sha256 = $sha256

--- a/scripts/package-ds5-sidecar.ps1
+++ b/scripts/package-ds5-sidecar.ps1
@@ -25,12 +25,35 @@ $runtime = Resolve-WorkspacePath $RuntimeDirectory
 $packageOutput = Resolve-WorkspacePath $PackageDirectory
 $manifestOutput = Resolve-WorkspacePath $ManifestPath
 $assetName = 'Sunshine.Ds5Sidecar.Windows-x64.zip'
-$componentVersion = '1.1.0'
-$protocolVersion = 1
 
 if (-not (Test-Path -LiteralPath (Join-Path $runtime 'Sunshine.Ds5Sidecar.exe') -PathType Leaf)) {
     throw "DualSense sidecar runtime is incomplete: $runtime"
 }
+$runtimeMetadataPath = Join-Path $runtime 'runtime.json'
+if (-not (Test-Path -LiteralPath $runtimeMetadataPath -PathType Leaf)) {
+    throw "DualSense sidecar runtime metadata is missing: $runtimeMetadataPath"
+}
+try {
+    $runtimeMetadata = Get-Content -LiteralPath $runtimeMetadataPath -Raw | ConvertFrom-Json -ErrorAction Stop
+}
+catch {
+    throw "DualSense sidecar runtime metadata is invalid: $runtimeMetadataPath"
+}
+if ($runtimeMetadata.component_version -isnot [string] -or
+    [string]::IsNullOrWhiteSpace($runtimeMetadata.component_version)) {
+    throw 'DualSense sidecar runtime metadata has an invalid component_version'
+}
+[uint32]$protocolVersion = 0
+if (-not [uint32]::TryParse([string]$runtimeMetadata.protocol, [ref]$protocolVersion) -or
+    $protocolVersion -eq 0) {
+    throw 'DualSense sidecar runtime metadata has an invalid protocol'
+}
+if ($runtimeMetadata.target -isnot [string] -or
+    [string]::IsNullOrWhiteSpace($runtimeMetadata.target)) {
+    throw 'DualSense sidecar runtime metadata has an invalid target'
+}
+$componentVersion = $runtimeMetadata.component_version
+$runtimeTarget = $runtimeMetadata.target
 
 New-Item -ItemType Directory -Force -Path $packageOutput | Out-Null
 $archive = Join-Path $packageOutput $assetName
@@ -51,7 +74,7 @@ New-Item -ItemType Directory -Force -Path $manifestDirectory | Out-Null
     schema = 1
     component_version = $componentVersion
     protocol = $protocolVersion
-    target = 'win-x64-self-contained'
+    target = $runtimeTarget
     license = $License
     asset_name = $assetName
     download_url = $downloadUrl

--- a/scripts/package-ds5-sidecar.ps1
+++ b/scripts/package-ds5-sidecar.ps1
@@ -54,6 +54,9 @@ if ($runtimeMetadata.target -isnot [string] -or
 }
 $componentVersion = $runtimeMetadata.component_version
 $runtimeTarget = $runtimeMetadata.target
+if ($runtimeTarget -ne 'win-x64-self-contained') {
+    throw "DualSense sidecar runtime metadata has an unsupported target: $runtimeTarget"
+}
 
 New-Item -ItemType Directory -Force -Path $packageOutput | Out-Null
 $archive = Join-Path $packageOutput $assetName

--- a/scripts/package-ds5-sidecar.ps1
+++ b/scripts/package-ds5-sidecar.ps1
@@ -1,0 +1,60 @@
+param(
+    [string]$RuntimeDirectory = "build/ds5-sidecar-runtime",
+    [string]$PackageDirectory = "build/ds5-sidecar-package",
+    [string]$ManifestPath = "build/ds5-sidecar-package.json",
+    [string]$ReleaseTag = "",
+    [string]$Repository = "AlkaidLab/foundation-sunshine"
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$workspaceRoot = [System.IO.Path]::GetFullPath($root).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+$workspacePrefix = $workspaceRoot + [System.IO.Path]::DirectorySeparatorChar
+
+function Resolve-WorkspacePath([string]$Path) {
+    $resolved = [System.IO.Path]::GetFullPath((Join-Path $root $Path))
+    if (-not $resolved.StartsWith($workspacePrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to use a DualSense package path outside $workspaceRoot`: $resolved"
+    }
+    return $resolved
+}
+
+$runtime = Resolve-WorkspacePath $RuntimeDirectory
+$packageOutput = Resolve-WorkspacePath $PackageDirectory
+$manifestOutput = Resolve-WorkspacePath $ManifestPath
+$assetName = 'Sunshine.Ds5Sidecar.Windows-x64.zip'
+$componentVersion = '1.1.0'
+$protocolVersion = 1
+
+if (-not (Test-Path -LiteralPath (Join-Path $runtime 'Sunshine.Ds5Sidecar.exe') -PathType Leaf)) {
+    throw "DualSense sidecar runtime is incomplete: $runtime"
+}
+
+New-Item -ItemType Directory -Force -Path $packageOutput | Out-Null
+$archive = Join-Path $packageOutput $assetName
+Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue
+Compress-Archive -Path (Join-Path $runtime '*') -DestinationPath $archive -CompressionLevel Optimal
+
+$sha256 = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+$size = (Get-Item -LiteralPath $archive).Length
+$downloadUrl = ''
+if (-not [string]::IsNullOrWhiteSpace($ReleaseTag)) {
+    $escapedTag = [System.Uri]::EscapeDataString($ReleaseTag)
+    $downloadUrl = "https://github.com/$Repository/releases/download/$escapedTag/$assetName"
+}
+
+$manifestDirectory = Split-Path -Parent $manifestOutput
+New-Item -ItemType Directory -Force -Path $manifestDirectory | Out-Null
+[ordered]@{
+    schema = 1
+    component_version = $componentVersion
+    protocol = $protocolVersion
+    target = 'win-x64-self-contained'
+    asset_name = $assetName
+    download_url = $downloadUrl
+    sha256 = $sha256
+    size = $size
+} | ConvertTo-Json | Set-Content -LiteralPath $manifestOutput -Encoding utf8
+
+Write-Host "Packaged DualSense sidecar: $archive ($size bytes, SHA-256 $sha256)"
+Write-Host "Wrote DualSense package manifest: $manifestOutput"


### PR DESCRIPTION
## 做了什么

杂鱼主包减负完成：把可选的自包含 DualSense Sidecar 从 Sunshine 安装包拆成同版本 Release 的独立资产。

- 生成 `Sunshine.Ds5Sidecar.Windows-x64.zip` 和带版本、协议、大小、SHA-256、固定下载地址的 manifest
- Windows 安装包与便携包只携带约 423 B 的 manifest，不再内置约 102 MiB 的解压运行时
- 普通 CI 与 SignPath 发布流程都会产出独立组件 ZIP；签名流程先签 Sidecar，再重新计算 ZIP 哈希并回写主包 manifest
- CI 明确检查主包内存在 manifest、且没有 Sidecar 可执行文件泄漏
- 接入 GUI 的在线按需安装、本地文件选择和同目录自动发现
- 生命周期文档补充独立分发、本地包、提权边界和错误码

GUI 配套：qiin2333/sunshine-control-panel#91

## 体积

- 原内置运行时：约 102.3 MiB / 194 files
- 独立压缩组件：约 41.9 MiB
- 主包新增内容：约 423 B manifest

## 验证

- Sidecar 完整 publish/package：passed
- 隔离 `cmake --install`：manifest present，embedded Sidecar absent
- PowerShell parser：passed
- workflow YAML lint：passed
- GUI Rust DualSense tests：16 passed
- GUI renderer tests：20 passed
- GUI production build：passed
- `git diff --check`：passed