### PR TITLE
feat(ds5): connect per-app selection and harden updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,7 +294,7 @@ jobs:
           # move
           mv ./cpack_artifacts/Sunshine.exe ../artifacts/sunshine-windows-installer.exe
           mv ./cpack_artifacts/Sunshine.zip ../artifacts/sunshine-windows-portable.zip
-          cp ./ds5-sidecar-package/Sunshine.Ds5Sidecar.Windows-x64.zip ../artifacts/
+          cp ./ds5-sidecar-package/Sunshine.Ds5Sidecar.x64.zip ../artifacts/
           cp ./ds5-sidecar-package.json ../artifacts/Sunshine.Ds5Sidecar.manifest.json
 
       - name: Generate Checksums
@@ -328,7 +328,7 @@ jobs:
           path: |
             artifacts/Sunshine.*.WindowsInstaller.exe
             artifacts/Sunshine.*.WindowsPortable.zip
-            artifacts/Sunshine.Ds5Sidecar.Windows-x64.zip
+            artifacts/Sunshine.Ds5Sidecar.x64.zip
             artifacts/Sunshine.Ds5Sidecar.manifest.json
             artifacts/SHA256SUMS.txt
             artifacts/checksums.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,12 +297,6 @@ jobs:
           cp ./ds5-sidecar-package/Sunshine.Ds5Sidecar.x64.zip ../artifacts/
           cp ./ds5-sidecar-package.json ../artifacts/Sunshine.Ds5Sidecar.manifest.json
 
-      - name: Generate Checksums
-        shell: pwsh
-        run: |
-          # Generate SHA256 checksums.
-          .\scripts\generate-checksums.ps1 -Path .\artifacts -Output "SHA256SUMS.txt"
-
       - name: Rename release assets
         shell: msys2 {0}
         run: |
@@ -332,6 +326,12 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Generate Checksums
+        shell: pwsh
+        run: |
+          # Generate SHA256 checksums from the final release asset names.
+          .\scripts\generate-checksums.ps1 -Path .\artifacts -Output "SHA256SUMS.txt"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,7 +319,19 @@ jobs:
 
           # 重命名安装包和便携版
           mv artifacts/sunshine-windows-installer.exe "artifacts/Sunshine.${NEWTAG}.WindowsInstaller.exe"
-          mv artifacts/sunshine-windows-portable.zip "artifacts/Sunshine.${NEWTAG}.WindowsPortable.zip"
+          mv artifacts/sunshine-windows-portable.zip "artifacts/Sunshine.${NEWTAG}.Portable-x64.zip"
+
+          # Legacy Control Panel builds treat any release asset containing
+          # "Windows" as a full installer. Keep that marker exclusive to the
+          # actual installer so existing users can update to the fixed build.
+          for asset in artifacts/*; do
+            name=$(basename "$asset")
+            lower=${name,,}
+            if [[ "$lower" == *windows* && "$lower" != *windowsinstaller.exe ]]; then
+              echo "Non-installer release asset would confuse legacy updaters: $name"
+              exit 1
+            fi
+          done
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -327,7 +339,7 @@ jobs:
           name: sunshine-windows-r${{ github.run_number }}
           path: |
             artifacts/Sunshine.*.WindowsInstaller.exe
-            artifacts/Sunshine.*.WindowsPortable.zip
+            artifacts/Sunshine.*.Portable-x64.zip
             artifacts/Sunshine.Ds5Sidecar.x64.zip
             artifacts/Sunshine.Ds5Sidecar.manifest.json
             artifacts/SHA256SUMS.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,7 +312,8 @@ jobs:
           fi
 
           # 重命名安装包和便携版
-          mv artifacts/sunshine-windows-installer.exe "artifacts/Sunshine.${NEWTAG}.WindowsInstaller.exe"
+          INSTALLER_NAME="Sunshine.${NEWTAG}.WindowsInstaller.exe"
+          mv artifacts/sunshine-windows-installer.exe "artifacts/${INSTALLER_NAME}"
           mv artifacts/sunshine-windows-portable.zip "artifacts/Sunshine.${NEWTAG}.Portable-x64.zip"
 
           # Legacy Control Panel builds treat any release asset containing
@@ -321,7 +322,7 @@ jobs:
           for asset in artifacts/*; do
             name=$(basename "$asset")
             lower=${name,,}
-            if [[ "$lower" == *windows* && "$lower" != *windowsinstaller.exe ]]; then
+            if [[ "$lower" == *windows* && "$lower" != "${INSTALLER_NAME,,}" ]]; then
               echo "Non-installer release asset would confuse legacy updaters: $name"
               exit 1
             fi

--- a/.github/workflows/sign-and-repackage.yml
+++ b/.github/workflows/sign-and-repackage.yml
@@ -309,10 +309,10 @@ jobs:
           else
             VERSION="v$(date +%Y.%m%d)"
           fi
-          7z a "../../Sunshine-${VERSION}-Windows-Portable-Signed.zip" ./* -y
+          7z a "../../Sunshine-${VERSION}-Portable-x64-Signed.zip" ./* -y
           cd ../..
           echo "Created signed portable package:"
-          ls -lh Sunshine-*-Portable-Signed.zip
+          ls -lh Sunshine-*-Portable-x64-Signed.zip
 
       # 使用签名文件重新打包 Inno Setup 安装包
       - name: Repackage signed Inno Setup installer
@@ -409,7 +409,7 @@ jobs:
         with:
           name: sunshine-windows-fully-signed
           path: |
-            Sunshine-*-Portable-Signed.zip
+            Sunshine-*-Portable-x64-Signed.zip
             final-signed/*.exe
             signed-component/Sunshine.Ds5Sidecar.x64.zip
             signed-component/Sunshine.Ds5Sidecar.manifest.json
@@ -422,7 +422,7 @@ jobs:
           tag_name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release-tag }}
           name: ${{ github.event_name == 'release' && github.event.release.name || github.event.inputs.release-tag }} (Signed)
           files: |
-            Sunshine-*-Portable-Signed.zip
+            Sunshine-*-Portable-x64-Signed.zip
             final-signed/*.exe
             signed-component/Sunshine.Ds5Sidecar.x64.zip
             signed-component/Sunshine.Ds5Sidecar.manifest.json

--- a/.github/workflows/sign-and-repackage.yml
+++ b/.github/workflows/sign-and-repackage.yml
@@ -411,7 +411,7 @@ jobs:
           path: |
             Sunshine-*-Portable-Signed.zip
             final-signed/*.exe
-            signed-component/Sunshine.Ds5Sidecar.Windows-x64.zip
+            signed-component/Sunshine.Ds5Sidecar.x64.zip
             signed-component/Sunshine.Ds5Sidecar.manifest.json
           if-no-files-found: error
 
@@ -424,7 +424,7 @@ jobs:
           files: |
             Sunshine-*-Portable-Signed.zip
             final-signed/*.exe
-            signed-component/Sunshine.Ds5Sidecar.Windows-x64.zip
+            signed-component/Sunshine.Ds5Sidecar.x64.zip
             signed-component/Sunshine.Ds5Sidecar.manifest.json
           draft: true
           prerelease: true

--- a/docs/windows_dualsense_component_lifecycle.md
+++ b/docs/windows_dualsense_component_lifecycle.md
@@ -78,7 +78,7 @@ DS5 不采用按进程名扫描或 `taskkill` 的做法。虚拟 USB 设备涉�
 - 发布 manifest 固定版本、下载地址、文件大小和 SHA-256。
 - GUI 不接受渲染器传入的任意下载 URL。
 - Sunshine 自研 Sidecar 的 `win-x64` 自包含运行时作为独立 Release 资产发布；主安装包只携带同版本 manifest，不再捆绑完整 .NET 运行时。
-- GUI 默认按 manifest 下载 Sidecar，也允许用户从任意本地目录选择匹配的官方 ZIP；放在 Sunshine 根目录或 `tools` 目录、文件名保持 `Sunshine.Ds5Sidecar.x64.zip` 的包会被自动发现。Sidecar 资产名刻意不包含 `Windows`，避免旧版整包更新器把组件 ZIP 误识别成 Sunshine 安装包。提权 helper 不接收调用方路径，只接收 allowlist 操作和随机令牌；本地 ZIP 必须通过 manifest 固定的大小与 SHA-256 校验。
+- GUI 默认按 manifest 下载 Sidecar，也允许用户从任意本地目录选择匹配的官方 ZIP；放在 Sunshine 根目录或 `tools` 目录、文件名保持 `Sunshine.Ds5Sidecar.x64.zip` 的包会被自动发现。Sidecar 与 Portable 资产名刻意不包含 `Windows`，把该标记只留给正式安装器，避免旧版整包更新器第一次升级时误选 ZIP。提权 helper 不接收调用方路径，只接收 allowlist 操作和随机令牌；本地 ZIP 必须通过 manifest 固定的大小与 SHA-256 校验。
 - 当前发布物存在 WDK 工具再分发审查事项，因此不放入 Sunshine 安装包或自有 CDN。
 - GUI 提供上游项目、许可证、来源 URL 和校验结果。
 

--- a/docs/windows_dualsense_component_lifecycle.md
+++ b/docs/windows_dualsense_component_lifecycle.md
@@ -78,7 +78,7 @@ DS5 不采用按进程名扫描或 `taskkill` 的做法。虚拟 USB 设备涉�
 - 发布 manifest 固定版本、下载地址、文件大小和 SHA-256。
 - GUI 不接受渲染器传入的任意下载 URL。
 - Sunshine 自研 Sidecar 的 `win-x64` 自包含运行时作为独立 Release 资产发布；主安装包只携带同版本 manifest，不再捆绑完整 .NET 运行时。
-- GUI 默认按 manifest 下载 Sidecar，也允许用户从任意本地目录选择匹配的官方 ZIP；放在 Sunshine 根目录或 `tools` 目录、文件名保持 `Sunshine.Ds5Sidecar.Windows-x64.zip` 的包会被自动发现。提权 helper 不接收调用方路径，只接收 allowlist 操作和随机令牌；本地 ZIP 必须通过 manifest 固定的大小与 SHA-256 校验。
+- GUI 默认按 manifest 下载 Sidecar，也允许用户从任意本地目录选择匹配的官方 ZIP；放在 Sunshine 根目录或 `tools` 目录、文件名保持 `Sunshine.Ds5Sidecar.x64.zip` 的包会被自动发现。Sidecar 资产名刻意不包含 `Windows`，避免旧版整包更新器把组件 ZIP 误识别成 Sunshine 安装包。提权 helper 不接收调用方路径，只接收 allowlist 操作和随机令牌；本地 ZIP 必须通过 manifest 固定的大小与 SHA-256 校验。
 - 当前发布物存在 WDK 工具再分发审查事项，因此不放入 Sunshine 安装包或自有 CDN。
 - GUI 提供上游项目、许可证、来源 URL 和校验结果。
 

--- a/scripts/package-ds5-sidecar.ps1
+++ b/scripts/package-ds5-sidecar.ps1
@@ -24,7 +24,7 @@ function Resolve-WorkspacePath([string]$Path) {
 $runtime = Resolve-WorkspacePath $RuntimeDirectory
 $packageOutput = Resolve-WorkspacePath $PackageDirectory
 $manifestOutput = Resolve-WorkspacePath $ManifestPath
-$assetName = 'Sunshine.Ds5Sidecar.Windows-x64.zip'
+$assetName = 'Sunshine.Ds5Sidecar.x64.zip'
 
 if (-not (Test-Path -LiteralPath (Join-Path $runtime 'Sunshine.Ds5Sidecar.exe') -PathType Leaf)) {
     throw "DualSense sidecar runtime is incomplete: $runtime"

--- a/src_assets/common/assets/web/components/AppEditor.vue
+++ b/src_assets/common/assets/web/components/AppEditor.vue
@@ -226,10 +226,13 @@
                     class="form-select form-control-enhanced"
                     v-model="formData.gamepad"
                   >
-                    <option value="">{{ t('apps.gamepad_mode_inherit') }}</option>
-                    <option value="auto">{{ t('apps.gamepad_mode_auto') }}</option>
-                    <option value="x360">{{ t('apps.gamepad_mode_x360') }}</option>
-                    <option value="ds4">{{ t('apps.gamepad_mode_ds4') }}</option>
+                    <option
+                      v-for="mode in PER_APP_GAMEPAD_MODES"
+                      :key="mode.value"
+                      :value="mode.value"
+                    >
+                      {{ t(mode.labelKey) }}
+                    </option>
                   </select>
                 </FormField>
 
@@ -328,6 +331,7 @@ import CheckboxField from './CheckboxField.vue'
 import { createFileSelector } from '../utils/fileSelection.js'
 import { apiPostJson } from '../utils/apiFetch.js'
 import { deepClone } from '../utils/helpers.js'
+import { PER_APP_GAMEPAD_MODES } from '../utils/gamepadModes.js'
 
 const DEFAULT_FORM_DATA = Object.freeze({
   name: '',

--- a/src_assets/common/assets/web/services/appService.js
+++ b/src_assets/common/assets/web/services/appService.js
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS, DEFAULT_BUILT_IN_APPS } from '../utils/constants.js';
 import { apiJson, apiPostJson } from '../utils/apiFetch.js';
 import { deepClone, formatError } from '../utils/helpers.js';
+import { normalizePerAppGamepadMode } from '../utils/gamepadModes.js';
 
 const cloneData = deepClone;
 const normalizeAppName = (name) => String(name || '').trim().toLowerCase();
@@ -207,7 +208,7 @@ export class AppService {
       elevated: Boolean(app.elevated),
       'auto-detach': Boolean(app['auto-detach']),
       'wait-all': Boolean(app['wait-all']),
-      gamepad: ['auto', 'x360', 'ds4'].includes(app.gamepad) ? app.gamepad : '',
+      gamepad: normalizePerAppGamepadMode(app.gamepad),
       'exit-timeout': parseInt(app['exit-timeout']) || 5,
       'prep-cmd': filteredPrepCmd,
       'menu-cmd': Array.isArray(app['menu-cmd']) ? app['menu-cmd'] : [],

--- a/src_assets/common/assets/web/tests/appService.test.js
+++ b/src_assets/common/assets/web/tests/appService.test.js
@@ -96,3 +96,12 @@ test('formatAppData rejects unknown per-app gamepad values', () => {
 
   assert.equal(result.gamepad, '')
 })
+
+test('formatAppData preserves a per-app DualSense override', () => {
+  const result = AppService.formatAppData({
+    name: 'Game',
+    gamepad: 'ds5',
+  })
+
+  assert.equal(result.gamepad, 'ds5')
+})

--- a/src_assets/common/assets/web/tests/gamepadModes.test.js
+++ b/src_assets/common/assets/web/tests/gamepadModes.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  PER_APP_GAMEPAD_MODES,
+  normalizePerAppGamepadMode,
+} from '../utils/gamepadModes.js'
+
+test('per-app gamepad choices include DualSense', () => {
+  assert.deepEqual(
+    PER_APP_GAMEPAD_MODES.map(({ value }) => value),
+    ['', 'auto', 'x360', 'ds4', 'ds5'],
+  )
+})
+
+test('per-app gamepad normalization accepts known modes only', () => {
+  for (const { value } of PER_APP_GAMEPAD_MODES) {
+    assert.equal(normalizePerAppGamepadMode(value), value)
+  }
+
+  assert.equal(normalizePerAppGamepadMode('invalid'), '')
+  assert.equal(normalizePerAppGamepadMode(undefined), '')
+})

--- a/src_assets/common/assets/web/utils/gamepadModes.js
+++ b/src_assets/common/assets/web/utils/gamepadModes.js
@@ -1,0 +1,14 @@
+export const PER_APP_GAMEPAD_MODES = Object.freeze([
+  { value: '', labelKey: 'apps.gamepad_mode_inherit' },
+  { value: 'auto', labelKey: 'apps.gamepad_mode_auto' },
+  { value: 'x360', labelKey: 'apps.gamepad_mode_x360' },
+  { value: 'ds4', labelKey: 'apps.gamepad_mode_ds4' },
+  { value: 'ds5', labelKey: 'config.gamepad_ds5' },
+])
+
+const VALID_PER_APP_GAMEPAD_MODES = new Set(
+  PER_APP_GAMEPAD_MODES.map(({ value }) => value),
+)
+
+export const normalizePerAppGamepadMode = (value) =>
+  VALID_PER_APP_GAMEPAD_MODES.has(value) ? value : ''


### PR DESCRIPTION
## 改了啥呀

- 应用设置的手柄类型补上 `DS5 (PS5)`，per-app 选择终于不会和控制器页面各玩各的啦
- 把 UI 选项与保存白名单收敛到同一份定义，避免 `ds5` 被序列化阶段悄悄清空
- 接入控制面板 [qiin2333/sunshine-control-panel#92](https://github.com/qiin2333/sunshine-control-panel/pull/92)：整包更新只接受正式 Windows Installer，Sidecar/Portable ZIP 不再被误装
- Sidecar 与 Portable 资产分别改名为 `Sunshine.Ds5Sidecar.x64.zip`、`Sunshine.<version>.Portable-x64.zip`，让尚未升级的旧更新器第一次更新时也只有正式安装器能命中
- CI 在发布前检查 `Windows` 标记只属于正式安装器，防止这个杂鱼兼容约定以后又漂掉
- 同版本但元数据或能力不匹配会进入“修复组件”，不再显示 `1.1.0 → 1.1.0` 的循环更新

## 为啥要改

后端已经支持 per-app `gamepad: ds5`，但应用编辑器没有入口，服务层还会把这个值过滤掉。Sidecar 拆包后，旧更新器又会因为资产名包含 `Windows` 而优先下载组件 ZIP。只修新 GUI 无法帮助尚未升级的客户端，因此非安装器 Release 资产也移除了 `Windows` 标记，让旧版本能直接自愈。

## 验证

主仓库：

- `npm run test:webui`：115 passed
- `npm run lint:webui`
- `npm run i18n:validate`
- `npm run build`
- `scripts/package-ds5-sidecar.ps1`：生成 `Sunshine.Ds5Sidecar.x64.zip`，manifest 名称、URL、大小和 SHA-256 一致
- 用旧版筛选规则检查新资产集合：唯一匹配项为 `WindowsInstaller.exe`
- GitHub workflow YAML 解析通过
- `git diff --check`

控制面板：

- `npm run build:renderer`
- `npm run test:renderer`：22 passed
- `cargo test --manifest-path src-tauri/Cargo.toml`：125 passed
- `rustfmt --check --edition 2024 src-tauri/src/dualsense.rs src-tauri/src/update.rs`
- `git diff --check`