### PR TITLE
fix(ds5): encode motion timestamps in DualSense ticks

### DIFF
--- a/tools/sunshine-ds5-sidecar/ControllerSession.cs
+++ b/tools/sunshine-ds5-sidecar/ControllerSession.cs
@@ -234,9 +234,16 @@ internal sealed class ControllerSession : IDisposable
             {
                 throw new InvalidDataException("Unsupported motion type");
             }
-            _state.SensorTimestamp = unchecked((uint)ElapsedMicroseconds());
+            _state.SensorTimestamp = EncodeSensorTimestamp(ElapsedMicroseconds());
             QueueStateSubmissionLocked();
         }
+    }
+
+    internal static uint EncodeSensorTimestamp(long elapsedMicroseconds)
+    {
+        // A standard DualSense report stores sensor time in 1/3 microsecond
+        // ticks. The 32-bit counter is expected to wrap naturally.
+        return unchecked((uint)(elapsedMicroseconds * 3L));
     }
 
     internal void SubmitBattery(ReadOnlySpan<byte> payload)

--- a/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
+++ b/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
@@ -157,6 +157,17 @@ internal static class ProtocolSelfTest
         VerifyDefaultAudioEndpointClassification();
         VerifyDefaultAudioEndpointPolicy();
         VerifyControllerStateSubmissionPolicy();
+        VerifySensorTimestampEncoding();
+    }
+
+    private static void VerifySensorTimestampEncoding()
+    {
+        Require(ControllerSession.EncodeSensorTimestamp(0) == 0,
+            "DualSense sensor timestamp origin");
+        Require(ControllerSession.EncodeSensorTimestamp(1_000_000) == 3_000_000,
+            "DualSense sensor timestamp tick rate");
+        Require(ControllerSession.EncodeSensorTimestamp(0x55555556) == 2,
+            "DualSense sensor timestamp rollover");
     }
 
     private static void VerifyProfileSelection()


### PR DESCRIPTION
## 改了啥呀

- 将 sidecar 的单调时钟微秒值转换为 DualSense 的 1/3 微秒传感器 tick
- 保持 32 位计数器自然回绕
- 给起点、1 秒 tick 速率和回绕行为补上确定性检查，杂鱼时间戳这次跑不掉啦

## 为啥要改

标准 DualSense 增强输入报告里的传感器时间戳不是“1 tick = 1 μs”，而是约“3 ticks = 1 μs”。SDL 对真实 DualSense 报告的处理同样把该计数除以 3 后换算为时间：
https://github.com/libsdl-org/SDL/blob/main/src/joystick/hidapi/SDL_hidapi_ps5.c

原实现直接把 elapsed microseconds 写进 HID 报告，导致虚拟 DS5 的传感器时钟只按真实速率的三分之一前进。这个 PR 只校正时间基准；陀螺仪/加速度计 raw scale 和客户端上报值保持不变，不用不相干的缩放去掩盖偏置问题，哼。

## 验证

- `dotnet build tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj --configuration Release -p:HIDMaestroCorePath=<local runtime DLL>`
- `Sunshine.Ds5Sidecar.exe --self-check`