### PR TITLE
fix(nvenc): 加固 4:4:4 CUDA 互操作生命周期(probe 绕开 array/共享上下文/去临时设备)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2525,12 +2525,11 @@ editing the `conf` file in a text editor. Use the examples as reference.
             Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear
             device pointer.
             @note{Windows only. Requires a driver exposing NVENC 13.1 or newer; on older drivers Sunshine
-            logs a message and keeps using the device pointer.}
-            @warning{Experimental. Some drivers produce ghosted output, and some stall while Sunshine probes
-            encoders at startup — which happens before the web UI binds, so the UI never becomes reachable and
-            you cannot turn this back off from there. Recover by stopping the Sunshine service, setting
-            `nvenc_cuda_array_input = disabled` in `sunshine.conf`, and starting the service again.
-            Leave it disabled unless you are helping test the 4:4:4 path.}
+            logs a message and keeps using the device pointer. Encoder probing always uses the device
+            pointer, so this option only affects real streaming sessions.}
+            @warning{Experimental. Some drivers produce ghosted output with the array path. Leave it
+            disabled unless you are helping test the 4:4:4 path. If a stream misbehaves, disable
+            `nvenc_cuda_array_input` and restart the stream.}
         </td>
     </tr>
     <tr>

--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
@@ -6,6 +6,11 @@
 
 #include "../../common_impl/nvenc_utils.h"
 
+#include <map>
+#include <memory>
+#include <mutex>
+#include <utility>
+
 #ifdef NVENC_NAMESPACE
 namespace NVENC_NAMESPACE {
 #else
@@ -42,12 +47,12 @@ namespace nvenc {
         destroy_cuda_array_input();
 #endif
       }
-
-      if (cuda_failed(cuda_functions.cuCtxDestroy(cuda_context))) {
-        BOOST_LOG(error) << "NvEnc: cuCtxDestroy() failed: error " << last_cuda_error;
-      }
-      cuda_context = nullptr;
     }
+
+    // The CUDA context is shared per adapter and outlives this encoder; drop
+    // only the reference, the per-adapter cache keeps it alive.
+    interop_context.reset();
+    cuda_context = nullptr;
   }
 
   ID3D11Texture2D *
@@ -55,72 +60,111 @@ namespace nvenc {
     return d3d_input_texture.GetInterfacePtr();
   }
 
+  cuda_interop_context::~cuda_interop_context() {
+    if (context) {
+      if (functions.cuCtxDestroy(context) != CUDA_SUCCESS) {
+        BOOST_LOG(error) << "NvEnc: cuCtxDestroy() failed for shared CUDA interop context";
+      }
+      context = nullptr;
+    }
+  }
+
+  // One CUDA interop context per DXGI adapter, kept for the process lifetime.
+  // Encoder probing alone used to cycle through several full create/destroy
+  // lifecycles (one per 4:4:4 candidate, another per session setup), and each
+  // cycle is driver interop churn we have no reason to exercise.
+  static std::shared_ptr<cuda_interop_context>
+  acquire_cuda_interop_context(ID3D11Device *d3d_device) {
+    IDXGIDevicePtr dxgi_device;
+    IDXGIAdapterPtr dxgi_adapter;
+    if (!d3d_device ||
+        FAILED(d3d_device->QueryInterface(IID_PPV_ARGS(&dxgi_device))) ||
+        FAILED(dxgi_device->GetAdapter(&dxgi_adapter))) {
+      BOOST_LOG(error) << "NvEnc: couldn't get DXGI adapter for CUDA interop";
+      return nullptr;
+    }
+
+    DXGI_ADAPTER_DESC adapter_desc {};
+    dxgi_adapter->GetDesc(&adapter_desc);
+    using luid_key_t = std::pair<LONG, DWORD>;
+    const luid_key_t key { adapter_desc.AdapterLuid.HighPart, adapter_desc.AdapterLuid.LowPart };
+
+    static std::mutex cache_mutex;
+    static std::map<luid_key_t, std::shared_ptr<cuda_interop_context>> cache;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    if (auto it = cache.find(key); it != cache.end()) {
+      return it->second;
+    }
+
+    auto interop = std::make_shared<cuda_interop_context>();
+    auto &functions = interop->functions;
+
+    constexpr auto dll_name = "nvcuda.dll";
+    if (!(functions.dll = make_shared_dll(LoadLibraryEx(dll_name, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)))) {
+      BOOST_LOG(debug) << "NvEnc: couldn't load CUDA dynamic library " << dll_name;
+      return nullptr;
+    }
+
+    auto load_function = [&]<typename T>(T &location, auto symbol) -> bool {
+      location = (T) GetProcAddress(functions.dll.get(), symbol);
+      return location != nullptr;
+    };
+    if (!load_function(functions.cuInit, "cuInit") ||
+        !load_function(functions.cuD3D11GetDevice, "cuD3D11GetDevice") ||
+        !load_function(functions.cuCtxCreate, "cuCtxCreate_v2") ||
+        !load_function(functions.cuCtxDestroy, "cuCtxDestroy_v2") ||
+        !load_function(functions.cuCtxPushCurrent, "cuCtxPushCurrent_v2") ||
+        !load_function(functions.cuCtxPopCurrent, "cuCtxPopCurrent_v2") ||
+        !load_function(functions.cuMemAllocPitch, "cuMemAllocPitch_v2") ||
+        !load_function(functions.cuMemFree, "cuMemFree_v2") ||
+        !load_function(functions.cuGraphicsD3D11RegisterResource, "cuGraphicsD3D11RegisterResource") ||
+        !load_function(functions.cuGraphicsUnregisterResource, "cuGraphicsUnregisterResource") ||
+        !load_function(functions.cuGraphicsMapResources, "cuGraphicsMapResources") ||
+        !load_function(functions.cuGraphicsUnmapResources, "cuGraphicsUnmapResources") ||
+        !load_function(functions.cuGraphicsSubResourceGetMappedArray, "cuGraphicsSubResourceGetMappedArray") ||
+        !load_function(functions.cuMemcpy2D, "cuMemcpy2D_v2")) {
+      BOOST_LOG(error) << "NvEnc: missing CUDA functions in " << dll_name;
+      return nullptr;
+    }
+#if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
+    else if (!load_function(functions.cuArray3DCreate, "cuArray3DCreate_v2") ||
+             !load_function(functions.cuArrayDestroy, "cuArrayDestroy") ||
+             !load_function(functions.cuArrayGetPlane, "cuArrayGetPlane")) {
+      BOOST_LOG(info) << "NvEnc: CUDA array input functions unavailable, using CUDA device pointer input";
+      functions.cuArray3DCreate = nullptr;
+      functions.cuArrayDestroy = nullptr;
+      functions.cuArrayGetPlane = nullptr;
+    }
+#endif
+
+    CUresult last_error;
+    CUdevice cuda_device;
+    if ((last_error = functions.cuInit(0)) == CUDA_SUCCESS &&
+        (last_error = functions.cuD3D11GetDevice(&cuda_device, dxgi_adapter)) == CUDA_SUCCESS &&
+        (last_error = functions.cuCtxCreate(&interop->context, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device)) == CUDA_SUCCESS &&
+        (last_error = functions.cuCtxPopCurrent(&interop->context)) == CUDA_SUCCESS) {
+      cache.emplace(key, interop);
+      return interop;
+    }
+
+    BOOST_LOG(error) << "NvEnc: couldn't create CUDA interop context: error " << last_error;
+    // ~cuda_interop_context releases a partially created context, if any
+    return nullptr;
+  }
+
   bool
   nvenc_d3d11_on_cuda::init_library() {
     if (!nvenc_d3d11_base::init_library()) return false;
 
-    constexpr auto dll_name = "nvcuda.dll";
+    interop_context = acquire_cuda_interop_context(d3d_device.GetInterfacePtr());
+    if (!interop_context) return false;
 
-    if ((cuda_functions.dll = make_shared_dll(LoadLibraryEx(dll_name, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)))) {
-      auto load_function = [&]<typename T>(T &location, auto symbol) -> bool {
-        location = (T) GetProcAddress(cuda_functions.dll.get(), symbol);
-        return location != nullptr;
-      };
-      if (!load_function(cuda_functions.cuInit, "cuInit") ||
-          !load_function(cuda_functions.cuD3D11GetDevice, "cuD3D11GetDevice") ||
-          !load_function(cuda_functions.cuCtxCreate, "cuCtxCreate_v2") ||
-          !load_function(cuda_functions.cuCtxDestroy, "cuCtxDestroy_v2") ||
-          !load_function(cuda_functions.cuCtxPushCurrent, "cuCtxPushCurrent_v2") ||
-          !load_function(cuda_functions.cuCtxPopCurrent, "cuCtxPopCurrent_v2") ||
-          !load_function(cuda_functions.cuMemAllocPitch, "cuMemAllocPitch_v2") ||
-          !load_function(cuda_functions.cuMemFree, "cuMemFree_v2") ||
-          !load_function(cuda_functions.cuGraphicsD3D11RegisterResource, "cuGraphicsD3D11RegisterResource") ||
-          !load_function(cuda_functions.cuGraphicsUnregisterResource, "cuGraphicsUnregisterResource") ||
-          !load_function(cuda_functions.cuGraphicsMapResources, "cuGraphicsMapResources") ||
-          !load_function(cuda_functions.cuGraphicsUnmapResources, "cuGraphicsUnmapResources") ||
-          !load_function(cuda_functions.cuGraphicsSubResourceGetMappedArray, "cuGraphicsSubResourceGetMappedArray") ||
-          !load_function(cuda_functions.cuMemcpy2D, "cuMemcpy2D_v2")) {
-        BOOST_LOG(error) << "NvEnc: missing CUDA functions in " << dll_name;
-        cuda_functions = {};
-      }
-#if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
-      else if (!load_function(cuda_functions.cuArray3DCreate, "cuArray3DCreate_v2") ||
-               !load_function(cuda_functions.cuArrayDestroy, "cuArrayDestroy") ||
-               !load_function(cuda_functions.cuArrayGetPlane, "cuArrayGetPlane")) {
-        BOOST_LOG(info) << "NvEnc: CUDA array input functions unavailable, using CUDA device pointer input";
-        cuda_functions.cuArray3DCreate = nullptr;
-        cuda_functions.cuArrayDestroy = nullptr;
-        cuda_functions.cuArrayGetPlane = nullptr;
-      }
-#endif
-    }
-    else {
-      BOOST_LOG(debug) << "NvEnc: couldn't load CUDA dynamic library " << dll_name;
-    }
+    cuda_functions = interop_context->functions;
+    cuda_context = interop_context->context;
+    device = cuda_context;
 
-    if (cuda_functions.dll) {
-      IDXGIDevicePtr dxgi_device;
-      IDXGIAdapterPtr dxgi_adapter;
-      if (d3d_device &&
-          SUCCEEDED(d3d_device->QueryInterface(IID_PPV_ARGS(&dxgi_device))) &&
-          SUCCEEDED(dxgi_device->GetAdapter(&dxgi_adapter))) {
-        CUdevice cuda_device;
-        if (cuda_succeeded(cuda_functions.cuInit(0)) &&
-            cuda_succeeded(cuda_functions.cuD3D11GetDevice(&cuda_device, dxgi_adapter)) &&
-            cuda_succeeded(cuda_functions.cuCtxCreate(&cuda_context, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device)) &&
-            cuda_succeeded(cuda_functions.cuCtxPopCurrent(&cuda_context))) {
-          device = cuda_context;
-        }
-        else {
-          BOOST_LOG(error) << "NvEnc: couldn't create CUDA interop context: error " << last_cuda_error;
-        }
-      }
-      else {
-        BOOST_LOG(error) << "NvEnc: couldn't get DXGI adapter for CUDA interop";
-      }
-    }
-
-    return device != nullptr;
+    return true;
   }
 
   bool
@@ -195,9 +239,10 @@ namespace nvenc {
     }
 
 #if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
-    // Opt-in only. The array path has shipped ghosted output and has been seen to
-    // stall during encoder probing on some drivers, so the pitch-linear device
-    // pointer stays the default until it is confirmed good on real hardware.
+    // Opt-in only, and probing never takes this path (d3d_nvenc_encode_device_t
+    // forces the device pointer when is_probe): the array path has shipped
+    // ghosted output and stalled on some drivers, so it stays experimental for
+    // real sessions until it is confirmed good on real hardware.
     if (encoder_params.cuda_array_input) {
       if (create_and_register_cuda_array_input()) {
         BOOST_LOG(info) << "NvEnc: using block-linear CUDA array input";

--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
@@ -73,6 +73,10 @@ namespace nvenc {
   // Encoder probing alone used to cycle through several full create/destroy
   // lifecycles (one per 4:4:4 candidate, another per session setup), and each
   // cycle is driver interop churn we have no reason to exercise.
+  using cuda_interop_luid_key_t = std::pair<LONG, DWORD>;
+  static std::mutex g_cuda_interop_cache_mutex;
+  static std::map<cuda_interop_luid_key_t, std::shared_ptr<cuda_interop_context>> g_cuda_interop_cache;
+
   static std::shared_ptr<cuda_interop_context>
   acquire_cuda_interop_context(ID3D11Device *d3d_device) {
     IDXGIDevicePtr dxgi_device;
@@ -85,15 +89,16 @@ namespace nvenc {
     }
 
     DXGI_ADAPTER_DESC adapter_desc {};
-    dxgi_adapter->GetDesc(&adapter_desc);
-    using luid_key_t = std::pair<LONG, DWORD>;
-    const luid_key_t key { adapter_desc.AdapterLuid.HighPart, adapter_desc.AdapterLuid.LowPart };
+    if (FAILED(dxgi_adapter->GetDesc(&adapter_desc))) {
+      // A zeroed AdapterLuid would key every failing adapter onto the same
+      // cache entry, i.e. another GPU's CUDA context.
+      BOOST_LOG(error) << "NvEnc: couldn't get DXGI adapter description for CUDA interop";
+      return nullptr;
+    }
+    const cuda_interop_luid_key_t key { adapter_desc.AdapterLuid.HighPart, adapter_desc.AdapterLuid.LowPart };
 
-    static std::mutex cache_mutex;
-    static std::map<luid_key_t, std::shared_ptr<cuda_interop_context>> cache;
-
-    std::lock_guard<std::mutex> lock(cache_mutex);
-    if (auto it = cache.find(key); it != cache.end()) {
+    std::lock_guard<std::mutex> lock(g_cuda_interop_cache_mutex);
+    if (auto it = g_cuda_interop_cache.find(key); it != g_cuda_interop_cache.end()) {
       return it->second;
     }
 
@@ -144,13 +149,40 @@ namespace nvenc {
         (last_error = functions.cuD3D11GetDevice(&cuda_device, dxgi_adapter)) == CUDA_SUCCESS &&
         (last_error = functions.cuCtxCreate(&interop->context, CU_CTX_SCHED_BLOCKING_SYNC, cuda_device)) == CUDA_SUCCESS &&
         (last_error = functions.cuCtxPopCurrent(&interop->context)) == CUDA_SUCCESS) {
-      cache.emplace(key, interop);
+      g_cuda_interop_cache.emplace(key, interop);
       return interop;
     }
 
     BOOST_LOG(error) << "NvEnc: couldn't create CUDA interop context: error " << last_error;
     // ~cuda_interop_context releases a partially created context, if any
     return nullptr;
+  }
+
+  // cuCtxPushCurrent() cannot fail on a healthy context, so a failure means
+  // the shared context is dead (GPU reset, adapter removal). Evict it so the
+  // next encoder object builds a fresh one: the failing session dies once and
+  // the existing session-reinit logic retries with a new context, instead of
+  // the poisoned entry breaking every future 4:4:4 session until service
+  // restart. Worst case (the context was actually fine) this costs one
+  // context re-creation.
+  static void
+  evict_dead_cuda_interop_context(CUcontext context) {
+    std::shared_ptr<cuda_interop_context> evicted;
+    {
+      std::lock_guard<std::mutex> lock(g_cuda_interop_cache_mutex);
+      for (auto it = g_cuda_interop_cache.begin(); it != g_cuda_interop_cache.end(); ++it) {
+        if (it->second && it->second->context == context) {
+          BOOST_LOG(warning) << "NvEnc: evicting dead CUDA interop context from the per-adapter cache";
+          evicted = it->second;
+          g_cuda_interop_cache.erase(it);
+          break;
+        }
+      }
+    }
+    // Drop the cache's reference outside the lock; if this was the last one,
+    // ~cuda_interop_context runs and its cuCtxDestroy() on the dead context
+    // just fails and logs.
+    evicted.reset();
   }
 
   bool
@@ -477,6 +509,9 @@ namespace nvenc {
     }
     else {
       BOOST_LOG(error) << "NvEnc: cuCtxPushCurrent() failed: error " << last_cuda_error;
+      if (cuda_context) {
+        evict_dead_cuda_interop_context(cuda_context);
+      }
       return { *this, nullptr };
     }
   }

--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.h
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.h
@@ -16,6 +16,46 @@ namespace nvenc {
 #endif
 
   /**
+   * @brief Function pointers from nvcuda.dll used by the CUDA interop path.
+   */
+  struct cuda_function_table {
+    tcuInit *cuInit;
+    tcuD3D11GetDevice *cuD3D11GetDevice;
+    tcuCtxCreate_v2 *cuCtxCreate;
+    tcuCtxDestroy_v2 *cuCtxDestroy;
+    tcuCtxPushCurrent_v2 *cuCtxPushCurrent;
+    tcuCtxPopCurrent_v2 *cuCtxPopCurrent;
+    tcuMemAllocPitch_v2 *cuMemAllocPitch;
+    tcuMemFree_v2 *cuMemFree;
+    tcuGraphicsD3D11RegisterResource *cuGraphicsD3D11RegisterResource;
+    tcuGraphicsUnregisterResource *cuGraphicsUnregisterResource;
+    tcuGraphicsMapResources *cuGraphicsMapResources;
+    tcuGraphicsUnmapResources *cuGraphicsUnmapResources;
+    tcuGraphicsSubResourceGetMappedArray *cuGraphicsSubResourceGetMappedArray;
+    tcuMemcpy2D_v2 *cuMemcpy2D;
+#if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
+    tcuArray3DCreate *cuArray3DCreate;
+    tcuArrayDestroy *cuArrayDestroy;
+    tcuArrayGetPlane *cuArrayGetPlane;
+#endif
+    shared_dll dll;
+  };
+
+  /**
+   * @brief CUDA interop context shared by every 4:4:4 encoder on one adapter.
+   *        Creating and destroying a CUDA context per encoder object exercised
+   *        the driver lifecycle several times per probe/session start for no
+   *        benefit, so contexts are cached per adapter for the lifetime of the
+   *        process instead.
+   */
+  struct cuda_interop_context {
+    ~cuda_interop_context();
+
+    cuda_function_table functions = {};
+    CUcontext context = nullptr;
+  };
+
+  /**
    * @brief Interop Direct3D11 on CUDA NVENC encoder.
    *        Input surface is Direct3D11, encoding is performed by CUDA.
    */
@@ -88,28 +128,11 @@ namespace nvenc {
     const ID3D11DevicePtr d3d_device;
     ID3D11Texture2DPtr d3d_input_texture;
 
-    struct {
-      tcuInit *cuInit;
-      tcuD3D11GetDevice *cuD3D11GetDevice;
-      tcuCtxCreate_v2 *cuCtxCreate;
-      tcuCtxDestroy_v2 *cuCtxDestroy;
-      tcuCtxPushCurrent_v2 *cuCtxPushCurrent;
-      tcuCtxPopCurrent_v2 *cuCtxPopCurrent;
-      tcuMemAllocPitch_v2 *cuMemAllocPitch;
-      tcuMemFree_v2 *cuMemFree;
-      tcuGraphicsD3D11RegisterResource *cuGraphicsD3D11RegisterResource;
-      tcuGraphicsUnregisterResource *cuGraphicsUnregisterResource;
-      tcuGraphicsMapResources *cuGraphicsMapResources;
-      tcuGraphicsUnmapResources *cuGraphicsUnmapResources;
-      tcuGraphicsSubResourceGetMappedArray *cuGraphicsSubResourceGetMappedArray;
-      tcuMemcpy2D_v2 *cuMemcpy2D;
-#if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
-      tcuArray3DCreate *cuArray3DCreate;
-      tcuArrayDestroy *cuArrayDestroy;
-      tcuArrayGetPlane *cuArrayGetPlane;
-#endif
-      shared_dll dll;
-    } cuda_functions = {};
+    // Keeps the per-adapter shared CUDA context alive for as long as this
+    // encoder object lives. `cuda_functions` is a copy of the holder's table;
+    // its `shared_dll` member carries its own library reference.
+    std::shared_ptr<cuda_interop_context> interop_context;
+    cuda_function_table cuda_functions = {};
 
     CUresult last_cuda_error = CUDA_SUCCESS;
     CUcontext cuda_context = nullptr;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2830,7 +2830,12 @@ namespace platf::dxgi {
       if (!nvenc_d3d) return false;
 
       hdr_luminance_analysis_available = false;
-      if (!nvenc_d3d->create_encoder(config::video.nv, client_config, colorspace, buffer_format)) return false;
+      auto nvenc_config = config::video.nv;
+      // The block-linear array input is experimental: it has stalled encoder
+      // probing on some drivers and a wedged probe delays every stream start.
+      // Probe the known-good pitch-linear path; only real sessions opt in.
+      nvenc_config.cuda_array_input = nvenc_config.cuda_array_input && !is_probe;
+      if (!nvenc_d3d->create_encoder(nvenc_config, client_config, colorspace, buffer_format)) return false;
 
       base.apply_colorspace(colorspace);
       base.set_client_sdr_white(client_config.hdr_capabilities.sdr_white_nits);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3559,15 +3559,15 @@ namespace video {
       return std::nullopt;
     }
 
-    // Get encode device colorspace for HDR metadata (need to create a temporary device)
-    auto encode_device = make_encode_device(*disp, encoder, ctx.config);
-    if (!encode_device) {
-      return std::nullopt;
-    }
+    // The encode colorspace is fully determined by the client config and the
+    // display's HDR state — building a throwaway encode device here used to
+    // spin up a whole encoder pipeline (including a CUDA interop context for
+    // 4:4:4) just to read that value back.
+    const auto colorspace = colorspace_from_client_config(ctx.config, disp->is_hdr());
 
     // Update client with our current HDR display state
     hdr_info_t hdr_info = std::make_unique<hdr_info_raw_t>(false);
-    if (colorspace_is_hdr(encode_device->colorspace)) {
+    if (colorspace_is_hdr(colorspace)) {
       if (disp->get_hdr_metadata(hdr_info->metadata)) {
         hdr_info->enabled = true;
       }


### PR DESCRIPTION
## 改了啥呀

- **probe 不再走 CUDA array 输入路径**:`d3d_nvenc_encode_device_t::init_encoder` 在 `is_probe` 时强制 `cuda_array_input = false`,probe 一律用已知良好的 pitch-linear 设备指针;array 路径仅真实会话按用户配置生效。
- **CUDA 互操作上下文按 adapter LUID 进程级共享**(`acquire_cuda_interop_context`):首次 4:4:4 编码时创建一次并常驻,各编码器实例只持有 `shared_ptr` 引用;析构只做资源清理(注销 interop 纹理/释放显存/销毁 array),不再销毁上下文。Windows 服务退出走 `TerminateProcess`,无静态析构顺序问题。
- **删除 `make_synced_session` 里的一次性编码设备**:原来每次会话建立都要再建一个完整编码设备(4:4:4 时含 CUDA 互操作上下文)只为读回 colorspace;该值本来就是 `colorspace_from_client_config(config, disp->is_hdr())` 的纯计算,已验证无任何路径在创建后改写设备的 colorspace 成员。
- **文档同步**:configuration.md 的 `nvenc_cuda_array_input` @warning 删掉过时的"probe 卡死锁 UI"描述(#912 已把 confighttp 提前到 probe 之前,该场景不再成立),并注明 probe 不走 array 路径。

## 为啥要改

排查 #998(RTX 5090 开启 `nvenc_cuda_array_input` 后空闲 CPU 飙高)时审计 4:4:4 CUDA interop 生命周期,发现对驱动 teardown 路径的暴露面过大:

- 一次启动 probe,HEVC 444 / AV1 444 每个候选项各自 `cuInit + cuCtxCreate + cuCtxDestroy`;5090 上 AV1 444 的 caps 检查虽必然失败,但 `init_library()` 在 caps 检查**之前**,上下文照样完整建拆一次;
- 每次会话建立还要为读 colorspace 再来一轮完整设备生命周期,NTSC fallback 重试再加一轮;
- array 注册在部分驱动上会卡死 probe(#910 前科),probe 没有理由触碰实验路径。

caps 查询需要先开 NVENC 会话、会话又需要 CUDA 上下文,无法真正"前置";共享上下文是等效替代,且运行期间上下文销毁次数降为零——对 #998 这类疑似驱动残留问题直接砍掉一类暴露面。

## 范围与兼容性

- 不改变默认行为:`cuda_array_input` 仍默认关闭;开启后**真实会话**路径与之前完全一致(probe 与会话从此走不同输入路径,probe 结果仍代表 caps 能力)。
- NV12/P010/8-bit 4:4:4 不走 `d3d11_on_cuda`,不受影响;AMF/软件编码不受影响。
- 多 SDK 版本 factory(13.1/13.0/12/11)各自编译本 TU,缓存按命名空间隔离,互不干扰。
- 双并发 4:4:4 会话共享一个上下文:CUDA 上下文线程安全,push/pop 嵌套语义不变,代价是两会话的 CUDA 拷贝串行化(拷贝极短,可忽略)。

## 验证

- `ninja -C build test_sunshine` 编译链接通过;
- `test_sunshine`:451/463 通过,11 跳过(NVENC/HID 硬件依赖,与既往一致),唯一失败 `DownloadFileTest.Run/1` 为访问 httpbin.org redirect 的外网测试(直连变体 Run/0 通过),与本改动无关;
- 真机 4:4:4 串流 A/B(尤其共享上下文下的逐帧行为)待合并前在 NVIDIA 机器补测。