### PR TITLE
style(webui): align update card transparency

### DIFF
--- a/src_assets/common/assets/web/components/common/VersionCard.vue
+++ b/src_assets/common/assets/web/components/common/VersionCard.vue
@@ -317,7 +317,6 @@ onBeforeUnmount(() => {
   overflow: hidden;
   border: 1px solid var(--ui-border);
   border-radius: var(--ui-radius-lg);
-  background: var(--ui-surface-strong);
   backdrop-filter: blur(24px) saturate(115%);
   box-shadow: var(--ui-shadow-md);
 }


### PR DESCRIPTION
## 改了啥呀

- 移除检查更新卡片对 `--ui-surface-strong` 的局部覆盖。
- 直接继承全局 `.card` 的 `--ui-surface`，浅色和深色主题都与其他主模块保持同一透明度。
- 原有模糊、边框、阴影和布局全部保留，杂鱼卡片这次只修透明度，不乱动别的啦。

## 为啥要改

检查更新卡片此前使用 0.88 的强表面背景，比通用主卡片的浅色 0.62 / 深色 0.58 更实，页面层级看起来不一致。

## 验证

- `npm run lint:webui`
- `npm run test:webui`（119 passed）
- `npm run build`
- Playwright 浅色主题：computed background = `--ui-surface`（`rgba(255, 255, 255, 0.62)`）
- Playwright 深色主题：computed background = `--ui-surface`（`rgba(74, 63, 66, 0.58)`）