### PR TITLE
fix(apps): restore cover finder keyboard focus

### DIFF
--- a/src_assets/common/assets/web/components/CoverFinder.vue
+++ b/src_assets/common/assets/web/components/CoverFinder.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport :to="teleportTarget">
     <Transition name="finder-fade">
       <div v-if="visible" class="cover-finder-overlay" @click.self="closeFinder">
         <div
@@ -139,7 +139,7 @@
 <script>
 import { searchAllCovers } from '../utils/coverSearch.js'
 import { apiPostJson } from '../utils/apiFetch.js'
-import { getFocusableElements } from '../utils/focus.js'
+import { getFocusableElements, resolveDialogTeleportTarget } from '../utils/focus.js'
 
 const createPlaceholderImage = (label) =>
   'data:image/svg+xml,' +
@@ -178,6 +178,7 @@ export default {
       localSearchTerm: '',
       searchAbortController: null,
       previousFocus: null,
+      teleportTarget: 'body',
     }
   },
   computed: {
@@ -230,6 +231,7 @@ export default {
 
     onOpen() {
       this.previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      this.teleportTarget = resolveDialogTeleportTarget(this.previousFocus)
       this.localSearchTerm = this.searchTerm
       this.$nextTick(() => {
         this.$refs.searchInput?.focus()

--- a/src_assets/common/assets/web/components/CoverFinder.vue
+++ b/src_assets/common/assets/web/components/CoverFinder.vue
@@ -229,6 +229,9 @@ export default {
       return countMap[key] || 0
     },
 
+    /**
+     * Resolve the nested Teleport target before moving focus into the cover finder.
+     */
     onOpen() {
       this.previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null
       this.teleportTarget = resolveDialogTeleportTarget(this.previousFocus)

--- a/src_assets/common/assets/web/tests/focus.test.js
+++ b/src_assets/common/assets/web/tests/focus.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveDialogTeleportTarget } from '../utils/focus.js'
+
+test('dialog overlays stay inside the Bootstrap modal that opened them', () => {
+  const modal = { id: 'editAppModal' }
+  const trigger = {
+    closest(selector) {
+      assert.equal(selector, '.modal')
+      return modal
+    },
+  }
+
+  assert.equal(resolveDialogTeleportTarget(trigger), modal)
+})
+
+test('standalone dialog overlays fall back to the document body target', () => {
+  const trigger = { closest: () => null }
+
+  assert.equal(resolveDialogTeleportTarget(trigger), 'body')
+  assert.equal(resolveDialogTeleportTarget(null), 'body')
+})

--- a/src_assets/common/assets/web/utils/focus.js
+++ b/src_assets/common/assets/web/utils/focus.js
@@ -17,3 +17,8 @@ export function getFocusableElements(container) {
     return style.display !== 'none' && style.visibility !== 'hidden'
   })
 }
+
+export function resolveDialogTeleportTarget(element, fallback = 'body') {
+  if (!element || typeof element.closest !== 'function') return fallback
+  return element.closest('.modal') || fallback
+}

--- a/src_assets/common/assets/web/utils/focus.js
+++ b/src_assets/common/assets/web/utils/focus.js
@@ -7,6 +7,12 @@ export const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(', ')
 
+/**
+ * Collect focusable descendants that are available to a dialog's keyboard trap.
+ *
+ * @param {Element | null | undefined} container Dialog or overlay container.
+ * @returns {Element[]} Visible focusable descendants in document order.
+ */
 export function getFocusableElements(container) {
   if (!container) return []
 
@@ -18,6 +24,13 @@ export function getFocusableElements(container) {
   })
 }
 
+/**
+ * Keep nested overlays inside the closest Bootstrap modal so its focus trap accepts them.
+ *
+ * @param {Element | null | undefined} element Element that opened the overlay.
+ * @param {string | Element} fallback Teleport target when the overlay is not nested in a modal.
+ * @returns {string | Element} A valid Vue Teleport target.
+ */
 export function resolveDialogTeleportTarget(element, fallback = 'body') {
   if (!element || typeof element.closest !== 'function') return fallback
   return element.closest('.modal') || fallback


### PR DESCRIPTION
## 改了啥呀

- 让“查找封面”根据触发按钮自动选择 Teleport 目标
- 从应用编辑器打开时，把封面弹窗留在 Bootstrap Modal 根节点内，避免被外层 focus trap 抢走焦点
- 独立使用时继续回退到 body，不影响其他调用场景
- 给 Teleport 目标解析补了回归测试，免得这只焦点杂鱼又偷偷游回来

## 为啥要改

此前封面弹窗无条件 Teleport 到 body。它从“添加新应用”Bootstrap Modal 中打开时，会跑到外层 Modal 的焦点范围之外，导致搜索框刚获得焦点就被抢回；键盘用户无法进入封面搜索控件，Esc 也无法关闭当前弹窗。

现在封面弹窗仍保留 Teleport 的遮罩和滚动行为，但会挂到触发元素所属的 modal 根节点，既不依赖 Bootstrap 私有 API，也能和现有焦点循环和平相处。

## 验证

- npm run build
- npm run lint:webui
- npm run test:webui（121 passed）
- 浏览器实测：打开“添加新应用”→“图片设置”→“查找封面”后，焦点进入搜索框
- 浏览器实测：Esc 关闭封面弹窗后，焦点恢复到“查找封面”按钮
- 浏览器实测：1280×720 与 390×844 下遮罩覆盖、结果卡片和滚动布局正常