### PR TITLE
feat(audio): confirm output changes during streaming

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -683,6 +683,11 @@ namespace audio {
       return;
     }
 
+    if (!ctx.control->should_restore_sink()) {
+      BOOST_LOG(info) << "Keeping the audio output approved during streaming"sv;
+      return;
+    }
+
     // Change back to the host sink, unless there was none
     const std::string &sink = ctx.sink.host.empty() ? config::audio.sink : ctx.sink.host;
     if (!sink.empty()) {

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -753,6 +753,15 @@ namespace platf {
     virtual int
     set_sink(const std::string &sink) = 0;
 
+    /**
+     * @brief Whether Sunshine should restore the output selected before streaming.
+     * @details A platform may preserve an output change explicitly approved by the user.
+     */
+    virtual bool
+    should_restore_sink() const {
+      return true;
+    }
+
     virtual std::unique_ptr<mic_t>
     microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous) = 0;
 

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -8,11 +8,14 @@
 #include <audioclient.h>
 #include <avrt.h>
 #include <chrono>
+#include <memory>
 #include <mmdeviceapi.h>
 #include <mutex>
 #include <newdev.h>
+#include <optional>
 #include <roapi.h>
 #include <synchapi.h>
+#include <utility>
 
 // local includes
 #include "mic_write.h"
@@ -280,6 +283,166 @@ namespace platf::audio {
     HRESULT status;
   };
 
+  struct output_change_state_t {
+    std::mutex mutex;
+    bool active = false;
+    std::uint64_t generation = 0;
+    std::uint64_t notification_id = 0;
+    std::wstring protected_output_id;
+    std::wstring pending_target_id;
+    std::wstring transition_output_id;
+    bool keep_capture_session = false;
+    bool approved_output_selected = false;
+  };
+
+  int
+  set_default_endpoint_roles(IPolicyConfig *policy, const std::wstring &endpoint_id) {
+    int failures = 0;
+    for (int role = 0; role < (int) ERole_enum_count; ++role) {
+      const auto status = policy->SetDefaultEndpoint(endpoint_id.c_str(), (ERole) role);
+      if (FAILED(status)) {
+        BOOST_LOG(warning) << "Couldn't set audio endpoint ["sv << to_utf8(endpoint_id)
+                           << "] to role ["sv << role << "]: 0x"sv
+                           << util::hex(status).to_string_view();
+        ++failures;
+      }
+    }
+    return failures;
+  }
+
+  bool
+  endpoint_is_active(IMMDeviceEnumerator *device_enum, const std::wstring &endpoint_id) {
+    device_t device;
+    if (FAILED(device_enum->GetDevice(endpoint_id.c_str(), &device)) || !device) {
+      return false;
+    }
+
+    DWORD state = 0;
+    return SUCCEEDED(device->GetState(&state)) && (state & DEVICE_STATE_ACTIVE) != 0;
+  }
+
+  void
+  apply_approved_output_change(
+    const std::weak_ptr<output_change_state_t> &weak_state,
+    const std::uint64_t generation) {
+    const auto state = weak_state.lock();
+    if (!state) {
+      return;
+    }
+
+    std::wstring target_id;
+    std::wstring previous_id;
+    bool previous_keep_capture = false;
+    {
+      std::lock_guard lock { state->mutex };
+      if (!state->active || state->generation != generation || state->pending_target_id.empty()) {
+        return;
+      }
+
+      target_id = state->pending_target_id;
+      previous_id = state->protected_output_id;
+      previous_keep_capture = state->keep_capture_session;
+      state->transition_output_id = target_id;
+      state->keep_capture_session = true;
+    }
+
+    co_init_t co_init;
+    if (!co_init.initialized()) {
+      BOOST_LOG(warning) << "Couldn't initialize COM to apply an approved audio output change: 0x"sv
+                         << util::hex(co_init.result()).to_string_view();
+      std::lock_guard lock { state->mutex };
+      if (state->generation == generation) {
+        state->transition_output_id.clear();
+        state->keep_capture_session = previous_keep_capture;
+        state->pending_target_id.clear();
+        state->notification_id = 0;
+      }
+      return;
+    }
+
+    policy_t policy;
+    device_enum_t device_enum;
+    const auto policy_status = CoCreateInstance(
+      CLSID_CPolicyConfigClient,
+      nullptr,
+      CLSCTX_ALL,
+      IID_IPolicyConfig,
+      (void **) &policy);
+    const auto enum_status = CoCreateInstance(
+      CLSID_MMDeviceEnumerator,
+      nullptr,
+      CLSCTX_ALL,
+      IID_IMMDeviceEnumerator,
+      (void **) &device_enum);
+
+    const bool target_active = SUCCEEDED(policy_status) &&
+                               SUCCEEDED(enum_status) &&
+                               endpoint_is_active(device_enum.get(), target_id);
+    const bool applied = target_active && set_default_endpoint_roles(policy.get(), target_id) == 0;
+
+    std::wstring restore_id;
+    {
+      std::lock_guard lock { state->mutex };
+      if (!state->active || state->generation != generation) {
+        restore_id = state->protected_output_id;
+        if (state->transition_output_id == target_id) {
+          state->transition_output_id.clear();
+        }
+      }
+      else if (applied) {
+        state->protected_output_id = target_id;
+        state->transition_output_id.clear();
+        state->pending_target_id.clear();
+        state->notification_id = 0;
+        state->approved_output_selected = true;
+        BOOST_LOG(info) << "Applied approved audio output change to ["sv << to_utf8(target_id) << ']';
+      }
+      else {
+        restore_id = previous_id;
+        state->transition_output_id.clear();
+        state->pending_target_id.clear();
+        state->notification_id = 0;
+        state->keep_capture_session = previous_keep_capture;
+      }
+    }
+
+    if (!restore_id.empty() && policy) {
+      set_default_endpoint_roles(policy.get(), restore_id);
+    }
+
+    if (!applied) {
+      BOOST_LOG(warning) << "Failed to apply approved audio output change; keeping the previous output"sv;
+    }
+  }
+
+  void
+  record_output_change_decision(
+    const std::weak_ptr<output_change_state_t> &weak_state,
+    const std::uint64_t generation,
+    const bool accepted) {
+    const auto state = weak_state.lock();
+    if (!state) {
+      return;
+    }
+
+    {
+      std::lock_guard lock { state->mutex };
+      if (!state->active || state->generation != generation || state->pending_target_id.empty()) {
+        return;
+      }
+
+      if (!accepted) {
+        state->pending_target_id.clear();
+        state->notification_id = 0;
+        return;
+      }
+    }
+
+    task_pool.push([weak_state, generation]() {
+      apply_approved_output_change(weak_state, generation);
+    });
+  }
+
   class prop_var_t {
   public:
     prop_var_t() {
@@ -440,8 +603,9 @@ namespace platf::audio {
     // IMMNotificationClient
     HRESULT STDMETHODCALLTYPE
     OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDeviceId) {
-      if (flow == eRender) {
-        default_render_device_changed_flag.store(true);
+      if (flow == eRender && pwstrDeviceId) {
+        std::lock_guard lock { default_render_device_changed_mutex };
+        default_render_device_changed = pwstrDeviceId;
       }
       return S_OK;
     }
@@ -471,16 +635,18 @@ namespace platf::audio {
     }
 
     /**
-     * @brief Checks if the default rendering device changed and resets the change flag
-     * @return `true` if the device changed since last call
+     * @brief Takes the most recent default rendering endpoint change.
+     * @return The new endpoint ID, or `std::nullopt` when no change is pending.
      */
-    bool
-    check_default_render_device_changed() {
-      return default_render_device_changed_flag.exchange(false);
+    std::optional<std::wstring>
+    take_default_render_device_changed() {
+      std::lock_guard lock { default_render_device_changed_mutex };
+      return std::exchange(default_render_device_changed, std::nullopt);
     }
 
   private:
-    std::atomic_bool default_render_device_changed_flag;
+    std::mutex default_render_device_changed_mutex;
+    std::optional<std::wstring> default_render_device_changed;
   };
 
   class mic_wasapi_t: public mic_t {
@@ -653,14 +819,18 @@ namespace platf::audio {
       } block_aligned;
 
       // Check if the default audio device has changed
-      if (endpt_notification.check_default_render_device_changed()) {
+      if (auto endpoint_id = endpt_notification.take_default_render_device_changed()) {
+        bool reinitialize_capture = true;
+
         // Invoke the audio_control_t's callback if it wants one
         if (default_endpt_changed_cb) {
-          (*default_endpt_changed_cb)();
+          reinitialize_capture = (*default_endpt_changed_cb)(*endpoint_id);
         }
 
-        // Reinitialize to pick up the new default device
-        return capture_e::reinit;
+        if (reinitialize_capture) {
+          // Reinitialize to pick up the new default device
+          return capture_e::reinit;
+        }
       }
 
       status = WaitForSingleObjectEx(audio_event.get(), default_latency_ms, FALSE);
@@ -740,7 +910,7 @@ namespace platf::audio {
     audio_capture_t audio_capture;
 
     audio_notification_t endpt_notification;
-    std::optional<std::function<void()>> default_endpt_changed_cb;
+    std::optional<std::function<bool(const std::wstring &)>> default_endpt_changed_cb;
 
     REFERENCE_TIME default_latency_ms;
 
@@ -934,13 +1104,12 @@ namespace platf::audio {
         return nullptr;
       }
 
-      // If this is a virtual sink, set a callback that will change the sink back if it's changed
+      // If this is a virtual sink, protect the Windows default output while
+      // leaving an explicitly approved change on the existing capture session.
       auto virtual_sink_info = extract_virtual_sink_info(assigned_sink);
       if (virtual_sink_info) {
-        mic->default_endpt_changed_cb = [this] {
-          BOOST_LOG(info) << "Resetting sink to ["sv << assigned_sink << "] after default changed";
-          notify_virtual_sink_managed();
-          set_sink(assigned_sink);
+        mic->default_endpt_changed_cb = [this](const std::wstring &endpoint_id) {
+          return handle_default_output_change(endpoint_id);
         };
       }
 
@@ -1019,6 +1188,7 @@ namespace platf::audio {
 
     int
     set_sink(const std::string &sink) override {
+      const bool is_virtual_sink = extract_virtual_sink_info(sink).has_value();
       auto device_id = set_format(sink);
       if (!device_id) {
         return -1;
@@ -1044,32 +1214,175 @@ namespace platf::audio {
       // back after another application changes it
       if (!failure) {
         assigned_sink = sink;
+        if (is_virtual_sink) {
+          enable_output_protection(*device_id);
+        }
+        else {
+          disable_output_protection(*device_id);
+        }
       }
 
       return failure;
     }
 
-    void
-    notify_virtual_sink_managed() {
-      const auto now = std::chrono::steady_clock::now();
-      std::lock_guard<std::mutex> lock(last_virtual_sink_notification_mutex);
-      if (now - last_virtual_sink_notification < std::chrono::seconds(30)) {
-        return;
+    bool
+    should_restore_sink() const override {
+      std::lock_guard lock { output_change_state->mutex };
+      return !output_change_state->approved_output_selected;
+    }
+
+    std::string
+    endpoint_friendly_name(const std::wstring &endpoint_id) {
+      device_t device;
+      if (FAILED(device_enum->GetDevice(endpoint_id.c_str(), &device)) || !device) {
+        return {};
       }
 
-      last_virtual_sink_notification = now;
-      BOOST_LOG(info) << "Virtual audio sink is being kept selected for host audio streaming";
-      const auto notification_id = tray_state::set_notification(
-        "Audio device kept for streaming",
-        "Sunshine is keeping the virtual audio device selected for host audio streaming. Stop the stream before switching playback devices.");
-      task_pool.pushDelayed([notification_id]() {
+      prop_t properties;
+      if (FAILED(device->OpenPropertyStore(STGM_READ, &properties)) || !properties) {
+        return {};
+      }
+
+      prop_var_t friendly_name;
+      if (SUCCEEDED(properties->GetValue(PKEY_Device_FriendlyName, &friendly_name.prop)) &&
+          friendly_name.prop.pwszVal) {
+        return to_utf8(friendly_name.prop.pwszVal);
+      }
+
+      prop_var_t description;
+      if (SUCCEEDED(properties->GetValue(PKEY_Device_DeviceDesc, &description.prop)) &&
+          description.prop.pwszVal) {
+        return to_utf8(description.prop.pwszVal);
+      }
+
+      return {};
+    }
+
+    std::uint64_t
+    reset_output_change_state_locked(const std::wstring &endpoint_id) {
+      const auto stale_notification_id = output_change_state->notification_id;
+      ++output_change_state->generation;
+      output_change_state->notification_id = 0;
+      output_change_state->pending_target_id.clear();
+      output_change_state->transition_output_id.clear();
+      output_change_state->keep_capture_session = false;
+      output_change_state->approved_output_selected = false;
+      output_change_state->protected_output_id = endpoint_id;
+      return stale_notification_id;
+    }
+
+    void
+    enable_output_protection(const std::wstring &endpoint_id) {
+      std::uint64_t stale_notification_id;
+      {
+        std::lock_guard lock { output_change_state->mutex };
+        stale_notification_id = reset_output_change_state_locked(endpoint_id);
+        output_change_state->active = true;
+      }
+
+      if (stale_notification_id != 0) {
+        tray_state::clear_notification_if(stale_notification_id);
+      }
+    }
+
+    void
+    disable_output_protection(const std::wstring &current_output_id) {
+      std::uint64_t stale_notification_id;
+      {
+        std::lock_guard lock { output_change_state->mutex };
+        // Keep the current endpoint as the rollback target for an approval task
+        // that may already be running while streaming shuts down.
+        stale_notification_id = reset_output_change_state_locked(current_output_id);
+        output_change_state->active = false;
+      }
+
+      if (stale_notification_id != 0) {
+        tray_state::clear_notification_if(stale_notification_id);
+      }
+    }
+
+    bool
+    handle_default_output_change(const std::wstring &target_id) {
+      std::wstring protected_id;
+      std::uint64_t generation = 0;
+      bool keep_capture_session = false;
+      bool create_notification = false;
+      {
+        std::lock_guard lock { output_change_state->mutex };
+        if (!output_change_state->active || output_change_state->protected_output_id.empty()) {
+          return true;
+        }
+
+        keep_capture_session = output_change_state->keep_capture_session;
+        protected_id = output_change_state->protected_output_id;
+
+        if (!output_change_state->transition_output_id.empty() &&
+            target_id == output_change_state->transition_output_id) {
+          return false;
+        }
+
+        if (target_id == protected_id) {
+          return false;
+        }
+
+        if (output_change_state->pending_target_id != target_id) {
+          generation = ++output_change_state->generation;
+          output_change_state->pending_target_id = target_id;
+          output_change_state->notification_id = 0;
+          create_notification = true;
+        }
+      }
+
+      BOOST_LOG(info) << "Restoring protected audio output ["sv << to_utf8(protected_id)
+                      << "] after Windows requested ["sv << to_utf8(target_id) << ']';
+      set_default_endpoint_roles(policy.get(), protected_id);
+
+      if (!create_notification) {
+        return false;
+      }
+
+      auto target_name = endpoint_friendly_name(target_id);
+      const std::weak_ptr<output_change_state_t> weak_state = output_change_state;
+      const auto notification_id = tray_state::set_actionable_notification(
+        "Audio output change requested",
+        target_name,
+        "default",
+        "confirm_audio_output",
+        [weak_state, generation](const bool accepted) {
+          record_output_change_decision(weak_state, generation, accepted);
+        });
+
+      bool request_is_current = false;
+      {
+        std::lock_guard lock { output_change_state->mutex };
+        request_is_current = output_change_state->active &&
+                             output_change_state->generation == generation &&
+                             output_change_state->pending_target_id == target_id;
+        if (request_is_current) {
+          output_change_state->notification_id = notification_id;
+        }
+      }
+
+      if (!request_is_current) {
         tray_state::clear_notification_if(notification_id);
-      }, std::chrono::seconds(10));
+        return !keep_capture_session;
+      }
+
+      task_pool.pushDelayed([notification_id, weak_state, generation]() {
+        if (!tray_state::decide_notification(notification_id, false)) {
+          record_output_change_decision(weak_state, generation, false);
+        }
+      }, std::chrono::seconds(30));
+
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::show_notification(
-        "Audio device kept for streaming",
-        "Sunshine is keeping the virtual audio device selected for host audio streaming. Stop the stream before switching playback devices.");
+        "Audio output change blocked",
+        target_name.empty() ?
+          "Sunshine kept the current audio output selected while streaming." :
+          "Sunshine kept the current audio output selected instead of switching to " + target_name + ".");
 #endif
+
+      return !keep_capture_session;
     }
 
     enum class match_field_e {
@@ -1341,13 +1654,25 @@ namespace platf::audio {
     }
 
     ~audio_control_t() override {
+      std::uint64_t notification_id = 0;
+      {
+        std::lock_guard lock { output_change_state->mutex };
+        output_change_state->active = false;
+        ++output_change_state->generation;
+        notification_id = output_change_state->notification_id;
+        output_change_state->notification_id = 0;
+        output_change_state->pending_target_id.clear();
+        output_change_state->transition_output_id.clear();
+      }
+      if (notification_id != 0) {
+        tray_state::clear_notification_if(notification_id);
+      }
     }
 
     policy_t policy;
     audio::device_enum_t device_enum;
     std::string assigned_sink;
-    std::chrono::steady_clock::time_point last_virtual_sink_notification {};
-    std::mutex last_virtual_sink_notification_mutex;
+    std::shared_ptr<output_change_state_t> output_change_state = std::make_shared<output_change_state_t>();
 
     int
     init_mic_redirect_device() override {

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -501,6 +501,19 @@ namespace tray_http {
         return action_success("Notification acknowledged");
       }
 
+      if (action == "notification_decide") {
+        if (!notification_id || *notification_id == 0) {
+          return action_error("notification_id is required");
+        }
+        if (!enabled) {
+          return action_error("enabled is required");
+        }
+        if (!tray_state::decide_notification(*notification_id, *enabled)) {
+          return action_error("Notification decision is stale or not actionable");
+        }
+        return action_success(*enabled ? "Notification accepted" : "Notification rejected");
+      }
+
       return action_error("Unknown tray action");
     }
 

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -15,6 +15,8 @@ namespace tray_state {
     state_t current_state;
     std::uint64_t next_notification_id = 0;
     std::uint64_t next_operation_id = 0;
+    std::uint64_t notification_decision_id = 0;
+    notification_decision_sink_t notification_decision_sink;
     std::mutex change_sink_mutex;
     change_sink_t change_sink;
     std::int64_t
@@ -175,6 +177,8 @@ namespace tray_state {
       current_state.notification.message.clear();
       current_state.notification.icon = "locked";
       current_state.notification.action = "open_pin";
+      notification_decision_id = 0;
+      notification_decision_sink = {};
       touch_locked();
     }
     notify_changed();
@@ -188,6 +192,8 @@ namespace tray_state {
       current_state.pairing_client_name.clear();
       if (current_state.notification.action == "open_pin") {
         current_state.notification = {};
+        notification_decision_id = 0;
+        notification_decision_sink = {};
       }
       touch_locked();
     }
@@ -205,6 +211,37 @@ namespace tray_state {
       current_state.notification.message = message;
       current_state.notification.icon = icon;
       current_state.notification.action = action;
+      notification_decision_id = 0;
+      notification_decision_sink = {};
+      touch_locked();
+      notification_id = current_state.notification.id;
+    }
+    notify_changed();
+    return notification_id;
+  }
+
+  std::uint64_t
+  set_actionable_notification(
+    const std::string &title,
+    const std::string &message,
+    const std::string &icon,
+    const std::string &action,
+    notification_decision_sink_t decision_sink) {
+    if (action.empty() || !decision_sink) {
+      return set_notification(title, message, icon, action);
+    }
+
+    std::uint64_t notification_id;
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.notification.id = ++next_notification_id;
+      current_state.notification.active = true;
+      current_state.notification.title = title;
+      current_state.notification.message = message;
+      current_state.notification.icon = icon;
+      current_state.notification.action = action;
+      notification_decision_id = current_state.notification.id;
+      notification_decision_sink = std::move(decision_sink);
       touch_locked();
       notification_id = current_state.notification.id;
     }
@@ -217,6 +254,8 @@ namespace tray_state {
     {
       std::lock_guard lock { state_mutex };
       current_state.notification = {};
+      notification_decision_id = 0;
+      notification_decision_sink = {};
       touch_locked();
     }
     notify_changed();
@@ -230,6 +269,8 @@ namespace tray_state {
         return;
       }
       current_state.notification = {};
+      notification_decision_id = 0;
+      notification_decision_sink = {};
       touch_locked();
     }
     notify_changed();
@@ -243,6 +284,10 @@ namespace tray_state {
         return false;
       }
 
+      if (notification_decision_id == notification_id && notification_decision_sink) {
+        return false;
+      }
+
       // Pairing remains actionable until the pairing flow succeeds, expires, or
       // is cancelled. Clicking the menu must not make the PIN entry point vanish.
       if (current_state.pairing_pending || current_state.notification.action == "open_pin") {
@@ -252,6 +297,29 @@ namespace tray_state {
       current_state.notification = {};
       touch_locked();
     }
+    notify_changed();
+    return true;
+  }
+
+  bool
+  decide_notification(const std::uint64_t notification_id, const bool accepted) {
+    notification_decision_sink_t decision_sink;
+    {
+      std::lock_guard lock { state_mutex };
+      if (!current_state.notification.active ||
+          current_state.notification.id != notification_id ||
+          notification_decision_id != notification_id ||
+          !notification_decision_sink) {
+        return false;
+      }
+
+      decision_sink = std::move(notification_decision_sink);
+      notification_decision_id = 0;
+      current_state.notification = {};
+      touch_locked();
+    }
+
+    decision_sink(accepted);
     notify_changed();
     return true;
   }
@@ -405,7 +473,7 @@ namespace tray_state {
       { "protocol_version", protocol_version },
       { "instance_id", instance_id() },
       { "owner", tray_owner() },
-      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "sessions-v1", "actions-v1", "operations-v1", "notification-ack", "pairing", "vdd", "shutdown" }) },
+      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "sessions-v1", "actions-v1", "operations-v1", "notification-ack", "notification-decision-v1", "pairing", "vdd", "shutdown" }) },
       { "status", current_presentation.status },
       { "icon", current_presentation.icon },
       { "tooltip", current_presentation.tooltip },

--- a/src/tray/tray_state.h
+++ b/src/tray/tray_state.h
@@ -10,6 +10,7 @@
 namespace tray_state {
 
   using change_sink_t = std::function<void()>;
+  using notification_decision_sink_t = std::function<void(bool)>;
 
   inline constexpr std::uint32_t protocol_version = 1;
 
@@ -90,6 +91,15 @@ namespace tray_state {
   std::uint64_t
   set_notification(const std::string &title, const std::string &message, const std::string &icon = "default", const std::string &action = {});
 
+  std::uint64_t
+  set_actionable_notification(
+    const std::string &title,
+    const std::string &message,
+    const std::string &icon,
+    const std::string &action,
+    notification_decision_sink_t decision_sink
+  );
+
   void
   clear_notification();
 
@@ -98,6 +108,9 @@ namespace tray_state {
 
   bool
   acknowledge_notification(std::uint64_t notification_id);
+
+  bool
+  decide_notification(std::uint64_t notification_id, bool accepted);
 
   void
   set_vdd_state(bool active, bool keep_enabled, bool headless_create_enabled, bool cooldown);

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <optional>
 
 #include <src/tray/tray_state.h>
 
@@ -169,6 +170,61 @@ TEST_F(TrayStateTest, OldNotificationTimerCannotClearNewNotification) {
   EXPECT_NE(json.at("status"), "notification");
 }
 
+TEST_F(TrayStateTest, ActionableNotificationAcceptsOneMatchingDecision) {
+  std::optional<bool> decision;
+  const auto notification_id = tray_state::set_actionable_notification(
+    "Audio output change requested",
+    "Speakers",
+    "default",
+    "confirm_audio_output",
+    [&decision](const bool accepted) {
+      decision = accepted;
+    });
+
+  EXPECT_FALSE(tray_state::acknowledge_notification(notification_id));
+  EXPECT_FALSE(tray_state::decide_notification(notification_id + 1, true));
+  EXPECT_FALSE(decision.has_value());
+
+  EXPECT_TRUE(tray_state::decide_notification(notification_id, true));
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_TRUE(*decision);
+  EXPECT_FALSE(tray_state::decide_notification(notification_id, false));
+  EXPECT_FALSE(tray_state::to_json().at("notification").at("active").get<bool>());
+}
+
+TEST_F(TrayStateTest, ReplacingActionableNotificationInvalidatesItsDecision) {
+  bool called = false;
+  const auto old_id = tray_state::set_actionable_notification(
+    "Old",
+    "Speakers",
+    "default",
+    "confirm_audio_output",
+    [&called](const bool) {
+      called = true;
+    });
+  const auto new_id = tray_state::set_notification("New", "New notification");
+
+  EXPECT_FALSE(tray_state::decide_notification(old_id, true));
+  EXPECT_FALSE(called);
+  EXPECT_EQ(tray_state::to_json().at("notification").at("id").get<std::uint64_t>(), new_id);
+}
+
+TEST_F(TrayStateTest, ActionableNotificationCanBeRejected) {
+  std::optional<bool> decision;
+  const auto notification_id = tray_state::set_actionable_notification(
+    "Audio output change requested",
+    "Headphones",
+    "default",
+    "confirm_audio_output",
+    [&decision](const bool accepted) {
+      decision = accepted;
+    });
+
+  EXPECT_TRUE(tray_state::decide_notification(notification_id, false));
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_FALSE(*decision);
+}
+
 TEST_F(TrayStateTest, PublishesStableProtocolIdentity) {
   const auto first = tray_state::to_json();
   const auto second = tray_state::to_json();
@@ -183,6 +239,9 @@ TEST_F(TrayStateTest, PublishesStableProtocolIdentity) {
     first.at("capabilities").end());
   EXPECT_NE(
     std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "sessions-v1"),
+    first.at("capabilities").end());
+  EXPECT_NE(
+    std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "notification-decision-v1"),
     first.at("capabilities").end());
   EXPECT_NE(
     std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "shutdown"),


### PR DESCRIPTION
## 背景

关联：https://github.com/LizardByte/Sunshine/issues/976

在 Windows 上使用虚拟音频设备进行串流时，Sunshine 会保持该设备为默认音频输出。如果用户或其他应用尝试切换 Windows 默认音频输出，Sunshine 当前会立即切回串流使用的设备，并显示一条只用于告知的通知。

单纯停止保护会带来回归：Steam Big Picture 等应用也可能在串流期间更改默认音频输出，而 Sunshine 无法可靠判断一次切换是用户手动操作，还是其他应用触发的。

因此，本 PR 保留现有的安全默认行为，同时把通知改为一次性的用户确认：

- 默认拒绝切换，继续保持当前串流音频输出。
- 只有用户明确允许时，才执行本次切换。

## 行为变化

当 Windows 默认音频输出在串流期间发生变化时：

1. Sunshine 立即恢复当前受保护的串流音频输出。
2. Sunshine 发布一个包含目标设备名称的确认通知。
3. 用户可以选择：
   - **Allow This Change**：允许本次输出切换。
   - **Keep Current Output**：继续保持当前串流音频输出。
4. 如果通知被关闭、超时或没有收到有效选择，则默认拒绝切换。
5. 用户允许后，Sunshine 切换到请求的输出设备，并将该设备作为本次串流新的受保护输出。
6. 后续再次切换输出时，会再次要求确认。
7. 串流结束时保留用户最后明确批准的输出设备。

允许切换后，现有音频采集会话不会因为 Windows 默认输出变化而重新初始化。因此，如果声音不再输出到串流使用的虚拟音频设备，客户端会按预期停止收到主机音频。

本 PR 不改变用户配置的音频采集来源，也没有增加新的音频设备配置项。

## 安全默认行为

以下情况都会继续保持当前输出：

- 用户点击 `Keep Current Output`
- 用户关闭通知
- 30 秒内没有作出选择
- 收到过期或不匹配的通知 ID
- 请求切换到的目标设备已经失效
- 应用切换输出但用户没有明确批准

这可以继续阻止 Steam Big Picture 等应用未经确认改变串流期间的音频输出。

## 实现细节

### Windows 音频输出保护

- 记录当前受保护的 Windows 音频端点 ID。
- 默认设备变化回调现在会携带新的端点 ID，而不只是一个布尔变化标记。
- 检测到外部切换后，先恢复受保护端点，再发布确认通知。
- 用户批准后，通过 `IPolicyConfig::SetDefaultEndpoint()` 将请求的端点应用到所有 Windows audio roles。
- 使用 generation 和 notification ID 防止过期、重复或并发 decision 被错误应用。
- 检查目标端点是否仍然处于 active 状态。
- 在关闭串流或销毁音频控制对象时使未完成的通知失效。
- 只有虚拟串流输出启用这套保护逻辑；其他输出仍使用原有行为。

### Tray notification protocol

- 增加 actionable notification decision callback。
- 增加 `notification_decide` tray action。
- 增加 `notification-decision-v1` capability。
- decision 必须携带匹配的 notification ID。
- 每个通知最多接受一次有效 decision。
- 新通知替换旧通知时，旧通知的 decision 自动失效。

### 串流结束行为

如果用户在本次串流中明确批准了输出切换，Sunshine 不会在串流结束时恢复串流开始前记录的输出设备，从而保留用户最后明确选择的设备。

其他平台使用 `should_restore_sink()` 的默认实现，行为保持不变。

## GUI 依赖

配套 GUI PR：

https://github.com/qiin2333/sunshine-control-panel/pull/103

该 GUI PR 为 Windows 通知提供：

- `Allow This Change`
- `Keep Current Output`

两个按钮，并将用户选择通过 `notification_decide` 返回给 core。

## 测试

### Core

- CMake Release 配置通过
- `cmake --build build --config Release --parallel 8` 通过
- Tray state 单元测试通过
- Actionable notification 测试通过：
  - 接受一次匹配的 decision
  - 拒绝错误 notification ID
  - 替换通知后使旧 decision 失效
  - 显式拒绝通知
  - 发布 `notification-decision-v1` capability

### GUI

- Renderer production build 通过
- Rust 测试 156/156 通过
- Tauri Release 构建通过

### Windows Release

- CPack ZIP 打包通过
- 成功打包本地修改后的 `sunshine-gui.exe`
- 确认 ZIP 包含 `sunshine.exe`、GUI、Web UI、shaders 和驱动依赖
- 从完整打包目录启动测试通过
- DirectX shaders 加载成功
- H.264 NVENC 初始化成功
- HEVC NVENC 初始化成功
- HTTP/HTTPS 服务启动成功
- 打包目录中的 GUI agent 启动成功