### PR TITLE
fix(windows): 修复非英文安装路径无法正常打开

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -385,7 +385,12 @@ namespace confighttp {
   getStaticResource(resp_https_t response, req_https_t request, const std::string& path, const std::string& contentType) {
     // print_req(request);
 
-    std::ifstream in(path, std::ios::binary);
+    std::ifstream in(file_handler::path_from_utf8(path), std::ios::binary);
+    if (!in.is_open()) {
+      BOOST_LOG(error) << "Failed to open Web UI resource: " << path;
+      response->write(SimpleWeb::StatusCode::server_error_internal_server_error);
+      return;
+    }
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", contentType);
     response->write(SimpleWeb::StatusCode::success_ok, in, headers);
@@ -434,7 +439,7 @@ namespace confighttp {
 
     BOOST_LOG(debug) << "getBoxArt: Requested file: " << path;
 
-    static const fs::path assetsRoot = fs::weakly_canonical(fs::path(SUNSHINE_ASSETS_DIR));
+    static const fs::path assetsRoot = fs::weakly_canonical(file_handler::path_from_utf8(SUNSHINE_ASSETS_DIR));
     static const fs::path coversRoot = fs::weakly_canonical(platf::appdata() / "covers");
 
     // First try to find in SUNSHINE_ASSETS_DIR
@@ -446,7 +451,7 @@ namespace confighttp {
     if (targetPath.parent_path() == assetsRoot && fs::exists(targetPath) && fs::is_regular_file(targetPath)) {
       finalPath = targetPath;
       found = true;
-      BOOST_LOG(debug) << "Found in boxart: " << finalPath.string();
+      BOOST_LOG(debug) << "Found in boxart: " << file_handler::path_to_utf8(finalPath);
     }
     
     // If not found in boxart, try covers directory
@@ -456,7 +461,7 @@ namespace confighttp {
       if (isChildPath(targetPath, coversRoot) && fs::exists(targetPath) && fs::is_regular_file(targetPath)) {
         finalPath = targetPath;
         found = true;
-        BOOST_LOG(debug) << "Found in covers: " << finalPath.string();
+        BOOST_LOG(debug) << "Found in covers: " << file_handler::path_to_utf8(finalPath);
       }
     }
 
@@ -466,17 +471,17 @@ namespace confighttp {
       finalPath = assetsRoot / "box.png";
       // Ensure default file exists, otherwise we might fail later
       if (!fs::exists(finalPath)) {
-        BOOST_LOG(warning) << "Default box.png not found at: " << finalPath.string();
+        BOOST_LOG(warning) << "Default box.png not found at: " << file_handler::path_to_utf8(finalPath);
         response->write(SimpleWeb::StatusCode::client_error_not_found, "Image not found");
         return;
       }
     }
 
-    std::string imagePath = finalPath.string();
+    const auto imagePath = file_handler::path_to_utf8(finalPath);
 
     // Get file size
     std::error_code ec;
-    auto fileSize = fs::file_size(imagePath, ec);
+    auto fileSize = fs::file_size(finalPath, ec);
     if (ec) {
       BOOST_LOG(warning) << "Failed to get file size for: " << imagePath;
       response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read image file");
@@ -484,7 +489,7 @@ namespace confighttp {
     }
 
     // Determine Content-Type from file extension
-    std::string ext = fs::path(imagePath).extension().string();
+    std::string ext = finalPath.extension().string();
     if (!ext.empty() && ext[0] == '.') {
       ext = ext.substr(1);
     }
@@ -499,7 +504,7 @@ namespace confighttp {
     BOOST_LOG(debug) << "Serving boxart: " << imagePath << " (Content-Type: " << contentType << ", Size: " << fileSize << " bytes)";
 
     // Return image resource
-    std::ifstream in(imagePath, std::ios::binary);
+    std::ifstream in(finalPath, std::ios::binary);
     if (!in.is_open()) {
       BOOST_LOG(warning) << "Failed to open image file: " << imagePath;
       response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to open image file");
@@ -517,7 +522,7 @@ namespace confighttp {
   void
   getNodeModules(resp_https_t response, req_https_t request) {
     // print_req(request);
-    fs::path webDirPath(WEB_DIR);
+    fs::path webDirPath = file_handler::path_from_utf8(WEB_DIR);
     fs::path nodeModulesPath(webDirPath / "assets");
 
     // .relative_path is needed to shed any leading slash that might exist in the request path
@@ -528,7 +533,7 @@ namespace confighttp {
       BOOST_LOG(warning) << "Someone requested a path " << filePath << " that is outside the assets folder";
       response->write(SimpleWeb::StatusCode::client_error_bad_request, "Bad Request");
     }
-    else if (!fs::exists(filePath)) {
+    else if (!fs::exists(filePath) || !fs::is_regular_file(filePath)) {
       response->write(SimpleWeb::StatusCode::client_error_not_found);
     }
     else {
@@ -541,7 +546,12 @@ namespace confighttp {
         // if it is, set the content type to the mime type
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", mimeType->second);
-        std::ifstream in(filePath.string(), std::ios::binary);
+        std::ifstream in(filePath, std::ios::binary);
+        if (!in.is_open()) {
+          BOOST_LOG(error) << "Failed to open Web UI asset: " << file_handler::path_to_utf8(filePath);
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error);
+          return;
+        }
         response->write(SimpleWeb::StatusCode::success_ok, in, headers);
       }
       // do not return any file if the type is not in the map
@@ -582,7 +592,7 @@ namespace confighttp {
     if (current_size <= prev_size || prev_size == 0 || !old_content) {
       return nullptr;
     }
-    std::ifstream in(log_path.string(), std::ios::binary);
+    std::ifstream in(log_path, std::ios::binary);
     if (!in || !in.seekg(static_cast<std::streamoff>(prev_size))) {
       return nullptr;
     }
@@ -600,7 +610,7 @@ namespace confighttp {
    */
   static std::shared_ptr<const std::string>
   read_file_range(const std::filesystem::path &path, std::uintmax_t offset, std::uintmax_t length) {
-    std::ifstream in(path.string(), std::ios::binary);
+    std::ifstream in(path, std::ios::binary);
     if (!in || !in.seekg(static_cast<std::streamoff>(offset))) {
       return nullptr;
     }
@@ -639,7 +649,7 @@ namespace confighttp {
     // --- Mode 1: No X-Log-Offset header → stream full file from disk (download) ---
     auto offset_it = request->header.find("X-Log-Offset");
     if (offset_it == request->header.end()) {
-      std::ifstream in(log_path.string(), std::ios::binary);
+      std::ifstream in(log_path, std::ios::binary);
       if (!in.is_open()) {
         response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to open log file");
         return;
@@ -822,7 +832,7 @@ namespace confighttp {
 
     try {
       pt::read_json(ss, inputTree);
-      pt::read_json(config::stream.file_apps, fileTree);
+      file_handler::read_json(config::stream.file_apps, fileTree);
 
       auto &apps_node = fileTree.get_child("apps"s);
       auto &input_apps_node = inputTree.get_child("apps"s);
@@ -896,7 +906,7 @@ namespace confighttp {
         }
       }
 
-      pt::write_json(config::stream.file_apps, fileTree);
+      file_handler::write_json(config::stream.file_apps, fileTree);
     }
     catch (std::exception &e) {
       BOOST_LOG(warning) << "SaveApp: "sv << e.what();
@@ -939,7 +949,7 @@ namespace confighttp {
     });
     pt::ptree fileTree;
     try {
-      pt::read_json(config::stream.file_apps, fileTree);
+      file_handler::read_json(config::stream.file_apps, fileTree);
       auto &apps_node = fileTree.get_child("apps"s);
       int index = stoi(request->path_match[1]);
 
@@ -961,7 +971,7 @@ namespace confighttp {
         fileTree.erase("apps");
         fileTree.push_back(std::make_pair("apps", newApps));
       }
-      pt::write_json(config::stream.file_apps, fileTree);
+      file_handler::write_json(config::stream.file_apps, fileTree);
     }
     catch (std::exception &e) {
       BOOST_LOG(warning) << "DeleteApp: "sv << e.what();
@@ -1069,7 +1079,7 @@ namespace confighttp {
 
     pt::ptree fileTree;
     try {
-      pt::read_json(config::stream.file_apps, fileTree);
+      file_handler::read_json(config::stream.file_apps, fileTree);
     }
     catch (std::exception &e) {
       BOOST_LOG(warning) << "BatchDeleteApps: "sv << e.what();
@@ -1117,7 +1127,7 @@ namespace confighttp {
       fileTree.erase("apps");
       fileTree.push_back(std::make_pair("apps", newApps));
 
-      pt::write_json(config::stream.file_apps, fileTree);
+      file_handler::write_json(config::stream.file_apps, fileTree);
     }
     catch (std::exception &e) {
       BOOST_LOG(warning) << "BatchDeleteApps: "sv << e.what();
@@ -1172,10 +1182,11 @@ namespace confighttp {
     }
     auto url = inputTree.get("url", "");
 
-    const std::string coverdir = platf::appdata().string() + "/covers/";
+    const std::string coverdir = file_handler::path_to_utf8(platf::appdata() / "covers");
     file_handler::make_directory(coverdir);
 
-    std::basic_string path = coverdir + http::url_escape(key) + ".png";
+    const auto cover_path = file_handler::path_from_utf8(coverdir) / (http::url_escape(key) + ".png");
+    const std::string path = file_handler::path_to_utf8(cover_path);
     if (!url.empty()) {
       if (!http::download_public_cover_image(url, path)) {
         outputTree.put("error", "Failed to download public HTTPS cover");
@@ -1193,7 +1204,7 @@ namespace confighttp {
       }
       auto data = SimpleWeb::Crypto::Base64::decode(base64_str);
 
-      std::ofstream imgfile(path, std::ios::binary);
+      std::ofstream imgfile(file_handler::path_from_utf8(path), std::ios::binary);
       if (!imgfile.is_open()) {
         outputTree.put("error", "Failed to create file");
         return;
@@ -1316,7 +1327,7 @@ namespace confighttp {
     // 类似于 config.cpp 中的 path_f 函数逻辑，使用相对路径
     std::filesystem::path idd_option_path = platf::appdata() / "vdd_settings.xml";
 
-    BOOST_LOG(info) << "VDD配置文件路径: " << idd_option_path.string();
+    BOOST_LOG(info) << "VDD配置文件路径: " << file_handler::path_to_utf8(idd_option_path);
 
     if (!fs::exists(idd_option_path)) {
         return false;
@@ -1327,7 +1338,13 @@ namespace confighttp {
     pt::ptree root;
 
     try {
-      pt::read_xml(idd_option_path.string(), existing_root);
+      {
+        std::ifstream input(idd_option_path, std::ios::binary);
+        if (!input.is_open()) {
+          throw std::runtime_error("Unable to open VDD configuration file");
+        }
+        pt::read_xml(input, existing_root);
+      }
       // 如果现有配置文件中已有vdd_settings节点
       if (existing_root.get_child_optional("vdd_settings")) {
         // 复制现有配置
@@ -1386,9 +1403,15 @@ namespace confighttp {
       boost::regex empty_lines_regex("\\n\\s*\\n");
       xml_content = boost::regex_replace(xml_content, empty_lines_regex, "\n");
 
-      std::ofstream file(idd_option_path.string());
+      std::ofstream file(idd_option_path);
+      if (!file.is_open()) {
+        throw std::runtime_error("Unable to open VDD configuration file");
+      }
       file << xml_content;
-      file.close();
+      file.flush();
+      if (!file) {
+        throw std::runtime_error("Unable to write VDD configuration file");
+      }
 
       return true;
     }
@@ -2728,15 +2751,15 @@ namespace confighttp {
   /**
    * @brief 获取 AI 配置文件路径（与 sunshine.conf 同目录）
    */
-  static std::string
+  static fs::path
   getAiConfigPath() {
-    auto config_dir = fs::path(config::sunshine.config_file).parent_path();
-    return (config_dir / "ai_config.json").string();
+    auto config_dir = file_handler::path_from_utf8(config::sunshine.config_file).parent_path();
+    return config_dir / "ai_config.json";
   }
 
   static fs::path
   getAiCredentialPath() {
-    auto config_dir = fs::path(config::sunshine.config_file).parent_path();
+    auto config_dir = file_handler::path_from_utf8(config::sunshine.config_file).parent_path();
     return config_dir / "ai_llm_credential.bin";
   }
 
@@ -2801,7 +2824,8 @@ namespace confighttp {
 
     auto path = getAiConfigPath();
     try {
-      std::string content = file_handler::read_file(path.c_str());
+      const auto utf8_path = file_handler::path_to_utf8(path);
+      std::string content = file_handler::read_file(utf8_path.c_str());
       if (!content.empty()) {
         auto persisted = nlohmann::json::parse(content);
         ai_config_cache = persisted;
@@ -3571,11 +3595,12 @@ namespace confighttp {
    */
   std::string
   calculate_file_hash(const std::string &filepath) {
-    if (filepath.empty() || !boost::filesystem::exists(filepath)) {
+    const auto native_path = file_handler::path_from_utf8(filepath);
+    if (filepath.empty() || !fs::exists(native_path)) {
       return "";
     }
 
-    std::ifstream file(filepath, std::ios::binary);
+    std::ifstream file(native_path, std::ios::binary);
     if (!file.is_open()) {
       return "";
     }
@@ -3715,18 +3740,18 @@ namespace confighttp {
       
       if (!executable_path.empty()) {
         // 如果是相对路径，尝试解析为绝对路径
-        boost::filesystem::path exec_path(executable_path);
+        auto exec_path = file_handler::path_from_utf8(executable_path);
         if (!exec_path.is_absolute()) {
           // 在PATH中查找或使用工作目录
           if (!working_dir.empty()) {
-            exec_path = boost::filesystem::path(working_dir) / exec_path;
+            exec_path = file_handler::path_from_utf8(working_dir) / exec_path;
           }
         }
         
-        file_hash = calculate_file_hash(exec_path.string());
+        file_hash = calculate_file_hash(file_handler::path_to_utf8(exec_path));
         
-        if (file_hash.empty() && boost::filesystem::exists(exec_path)) {
-          BOOST_LOG(warning) << "TestMenuCmd: Failed to calculate hash for executable: " << exec_path;
+        if (file_hash.empty() && fs::exists(exec_path)) {
+          BOOST_LOG(warning) << "TestMenuCmd: Failed to calculate hash for executable: " << file_handler::path_to_utf8(exec_path);
         }
       }
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -39,6 +39,7 @@
 #include <nlohmann/json.hpp>
 #include <Simple-Web-Server/crypto.hpp>
 #include <Simple-Web-Server/server_https.hpp>
+#include <Simple-Web-Server/utility.hpp>
 #include <boost/asio/ssl/context_base.hpp>
 
 #include "config.h"
@@ -436,6 +437,7 @@ namespace confighttp {
     if (path.find("/boxart/") == 0) {
       path = path.substr(8); // Remove "/boxart/" prefix
     }
+    path = SimpleWeb::Percent::decode(path);
 
     BOOST_LOG(debug) << "getBoxArt: Requested file: " << path;
 
@@ -443,7 +445,8 @@ namespace confighttp {
     static const fs::path coversRoot = fs::weakly_canonical(platf::appdata() / "covers");
 
     // First try to find in SUNSHINE_ASSETS_DIR
-    fs::path targetPath = fs::weakly_canonical(assetsRoot / path);
+    const auto requestedPath = file_handler::path_from_utf8(path);
+    fs::path targetPath = fs::weakly_canonical(assetsRoot / requestedPath);
     fs::path finalPath;
     bool found = false;
 
@@ -456,7 +459,7 @@ namespace confighttp {
     
     // If not found in boxart, try covers directory
     if (!found) {
-      targetPath = fs::weakly_canonical(coversRoot / path);
+      targetPath = fs::weakly_canonical(coversRoot / requestedPath);
       // For covers, we use isChildPath which allows subdirectories but prevents traversal out of root
       if (isChildPath(targetPath, coversRoot) && fs::exists(targetPath) && fs::is_regular_file(targetPath)) {
         finalPath = targetPath;
@@ -526,7 +529,8 @@ namespace confighttp {
     fs::path nodeModulesPath(webDirPath / "assets");
 
     // .relative_path is needed to shed any leading slash that might exist in the request path
-    auto filePath = fs::weakly_canonical(webDirPath / fs::path(request->path).relative_path());
+    const auto decodedRequestPath = SimpleWeb::Percent::decode(request->path);
+    auto filePath = fs::weakly_canonical(webDirPath / file_handler::path_from_utf8(decodedRequestPath).relative_path());
 
     // Don't do anything if file does not exist or is outside the assets directory
     if (!isChildPath(filePath, nodeModulesPath)) {
@@ -644,7 +648,7 @@ namespace confighttp {
 
     //print_req(request);
 
-    const std::filesystem::path log_path(config::sunshine.log_file);
+    const auto log_path = file_handler::path_from_utf8(config::sunshine.log_file);
 
     // --- Mode 1: No X-Log-Offset header → stream full file from disk (download) ---
     auto offset_it = request->header.find("X-Log-Offset");
@@ -3768,14 +3772,19 @@ namespace confighttp {
       boost::filesystem::path work_dir;
       
       if (!working_dir.empty()) {
+        const auto native_working_dir = file_handler::path_from_utf8(working_dir);
         // 验证工作目录是否存在
-        if (!boost::filesystem::exists(working_dir) || !boost::filesystem::is_directory(working_dir)) {
+        if (!fs::exists(native_working_dir) || !fs::is_directory(native_working_dir)) {
           BOOST_LOG(warning) << "TestMenuCmd: Invalid working directory: " << working_dir;
           outputTree.put("status", false);
           outputTree.put("error", "Invalid working directory");
           return;
         }
-        work_dir = boost::filesystem::path(working_dir);
+#ifdef _WIN32
+        work_dir = boost::filesystem::path(native_working_dir.wstring());
+#else
+        work_dir = boost::filesystem::path(native_working_dir.string());
+#endif
       } else {
         work_dir = boost::filesystem::current_path();
       }

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -17,15 +17,18 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <cmath>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <limits>
 #include <locale>
 #include <sstream>
+#include <stdexcept>
 #include <thread>
 #include <unordered_set>
 #include <vector>
 
 #include "src/globals.h"
+#include "src/file_handler.h"
 #include "src/platform/common.h"
 #include "src/platform/run_command.h"
 #include "src/platform/windows/display_device/windows_utils.h"
@@ -145,7 +148,8 @@ namespace display_device {
 
     bool
     execute_vdd_disable_enable_command() {
-      static const std::string kDevManPath = (std::filesystem::path(SUNSHINE_ASSETS_DIR).parent_path() / "tools" / "DevManView.exe").string();
+      static const std::string kDevManPath = file_handler::path_to_utf8(
+        file_handler::path_from_utf8(SUNSHINE_ASSETS_DIR).parent_path() / "tools" / "DevManView.exe");
       static const std::string kDriverName = "Zako Display Adapter";
       static constexpr auto kAction = "disable_enable";
 
@@ -200,13 +204,25 @@ namespace display_device {
       try {
         pt::ptree root;
         if (std::filesystem::exists(settings_path)) {
-          pt::read_xml(settings_path.string(), root);
+          std::ifstream input(settings_path, std::ios::binary);
+          if (!input.is_open()) {
+            throw std::runtime_error("unable to open VDD settings for reading");
+          }
+          pt::read_xml(input, root);
         }
 
         root.put("vdd_settings.cursor.HardwareCursor", enabled ? "true" : "false");
 
         auto setting = boost::property_tree::xml_writer_make_settings<std::string>(' ', 2);
-        pt::write_xml(settings_path.string(), root, std::locale(), setting);
+        std::ofstream output(settings_path, std::ios::binary | std::ios::trunc);
+        if (!output.is_open()) {
+          throw std::runtime_error("unable to open VDD settings for writing");
+        }
+        pt::write_xml(output, root, setting);
+        output.flush();
+        if (!output) {
+          throw std::runtime_error("unable to write VDD settings");
+        }
         return true;
       }
       catch (const std::exception &e) {
@@ -233,7 +249,11 @@ namespace display_device {
       try {
         if (std::filesystem::exists(settings_path)) {
           pt::ptree tree;
-          pt::read_xml(settings_path.string(), tree);
+          std::ifstream input(settings_path, std::ios::binary);
+          if (!input.is_open()) {
+            throw std::runtime_error("unable to open VDD settings for reading");
+          }
+          pt::read_xml(input, tree);
 
           if (const auto value = tree.get_optional<std::string>("vdd_settings.cursor.HardwareCursor")) {
             persisted_enabled = hardware_cursor_export_enabled(*value);

--- a/src/file_handler.cpp
+++ b/src/file_handler.cpp
@@ -7,6 +7,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <boost/property_tree/json_parser.hpp>
+
 // local includes
 #include "file_handler.h"
 #include "logging.h"
@@ -80,5 +82,29 @@ namespace file_handler {
     out.flush();
     out.close();
     return out ? 0 : -1;
+  }
+
+  void
+  read_json(std::string_view path, boost::property_tree::ptree &tree) {
+    std::ifstream input(path_from_utf8(path), std::ios::binary);
+    if (!input.is_open()) {
+      throw boost::property_tree::json_parser_error("cannot open file", std::string { path }, 0);
+    }
+
+    boost::property_tree::read_json(input, tree);
+  }
+
+  void
+  write_json(std::string_view path, const boost::property_tree::ptree &tree, bool pretty) {
+    std::ofstream output(path_from_utf8(path), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+      throw boost::property_tree::json_parser_error("cannot open file", std::string { path }, 0);
+    }
+
+    boost::property_tree::write_json(output, tree, pretty);
+    output.flush();
+    if (!output) {
+      throw boost::property_tree::json_parser_error("write failed", std::string { path }, 0);
+    }
   }
 }  // namespace file_handler

--- a/src/file_handler.h
+++ b/src/file_handler.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <string_view>
 
+#include <boost/property_tree/ptree_fwd.hpp>
+
 /**
  * @brief Responsible for file handling functions.
  */
@@ -68,4 +70,18 @@ namespace file_handler {
    */
   int
   write_file(const char *path, const std::string_view &contents);
+
+  /**
+   * @brief Read a JSON file whose path is encoded as UTF-8.
+   * @throws boost::property_tree::json_parser_error on open or parse failure.
+   */
+  void
+  read_json(std::string_view path, boost::property_tree::ptree &tree);
+
+  /**
+   * @brief Write a property tree to a JSON file whose path is encoded as UTF-8.
+   * @throws boost::property_tree::json_parser_error on open or write failure.
+   */
+  void
+  write_json(std::string_view path, const boost::property_tree::ptree &tree, bool pretty = true);
 }  // namespace file_handler

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -44,6 +44,16 @@
 #include "utility.h"
 #include "uuid.h"
 
+#ifdef _WIN32
+  #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+  #endif
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
+#endif
+
 namespace http {
   using namespace std::literals;
   namespace fs = std::filesystem;
@@ -436,6 +446,25 @@ namespace {
   constexpr auto COVER_DOWNLOAD_MAX_BYTES = static_cast<std::size_t>(10 * 1024 * 1024);
   constexpr auto COVER_DNS_TIMEOUT = std::chrono::seconds(10);
 
+  void remove_file_noexcept(const std::filesystem::path &path) noexcept {
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+  }
+
+  bool replace_file(const std::filesystem::path &temporary_path, const std::filesystem::path &destination_path) noexcept {
+#ifdef _WIN32
+    return MoveFileExW(
+             temporary_path.c_str(),
+             destination_path.c_str(),
+             MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH
+           ) != FALSE;
+#else
+    std::error_code ec;
+    std::filesystem::rename(temporary_path, destination_path, ec);
+    return !ec;
+#endif
+  }
+
   struct ParsedDownloadUrl {
     std::string scheme;
     std::string host;
@@ -814,8 +843,14 @@ namespace {
       return false;
     }
 
+    const auto destination_path = file_handler::path_from_utf8(file);
+    auto temporary_path = destination_path;
+    const auto temporary_suffix = file_handler::path_from_utf8(std::string { ".download-" } + uuid_util::uuid_t::generate().string());
+    temporary_path += temporary_suffix.native();
+    remove_file_noexcept(temporary_path);
+
     ImageCheckContext ctx;
-    ctx.filename = file;
+    ctx.filename = file_handler::path_to_utf8(temporary_path);
     ctx.url = url;
 
     curl_easy_setopt(curl, CURLOPT_SSLVERSION, ssl_version);
@@ -836,9 +871,8 @@ namespace {
     CURLcode result = curl_easy_perform(curl);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
-    if (ctx.fp) {
-      fclose(ctx.fp);
-    }
+    const bool close_ok = !ctx.fp || fclose(ctx.fp) == 0;
+    ctx.fp = nullptr;
 
     curl_slist_free_all(resolve_list);
     curl_easy_cleanup(curl);
@@ -852,12 +886,7 @@ namespace {
         BOOST_LOG(error) << "Download failed: HTTP " << response_code << " [" << url << "]";
       }
 
-      // Cleanup partial file if it exists (though usually it shouldn't be much)
-      const auto native_file = file_handler::path_from_utf8(file);
-      if (std::filesystem::exists(native_file)) {
-        std::error_code remove_ec;
-        std::filesystem::remove(native_file, remove_ec);
-      }
+      remove_file_noexcept(temporary_path);
       return false;
     }
 
@@ -865,12 +894,19 @@ namespace {
     // Treat as failure (empty or too small file)
     if (!ctx.checked) {
       BOOST_LOG(warning) << "Download too small to validate magic bytes ["sv << url << ']';
-      // Cleanup if file was created
-      const auto native_file = file_handler::path_from_utf8(file);
-      if (std::filesystem::exists(native_file)) {
-        std::error_code remove_ec;
-        std::filesystem::remove(native_file, remove_ec);
-      }
+      remove_file_noexcept(temporary_path);
+      return false;
+    }
+
+    if (!ctx.valid || !close_ok) {
+      BOOST_LOG(error) << "Downloaded image could not be finalized ["sv << url << ']';
+      remove_file_noexcept(temporary_path);
+      return false;
+    }
+
+    if (!replace_file(temporary_path, destination_path)) {
+      BOOST_LOG(error) << "Couldn't replace downloaded image ["sv << file << ']';
+      remove_file_noexcept(temporary_path);
       return false;
     }
 

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <cstdio>
 #include <cstdint>
 #include <filesystem>
 #include <initializer_list>
@@ -64,11 +65,12 @@ namespace http {
     if (clean_slate) {
       unique_id = uuid_util::uuid_t::generate().string();
       auto dir = std::filesystem::temp_directory_path() / "Sunshine"sv;
-      config::nvhttp.cert = (dir / ("cert-"s + unique_id)).string();
-      config::nvhttp.pkey = (dir / ("pkey-"s + unique_id)).string();
+      config::nvhttp.cert = file_handler::path_to_utf8(dir / ("cert-"s + unique_id));
+      config::nvhttp.pkey = file_handler::path_to_utf8(dir / ("pkey-"s + unique_id));
     }
 
-    if ((!fs::exists(config::nvhttp.pkey) || !fs::exists(config::nvhttp.cert)) &&
+    if ((!fs::exists(file_handler::path_from_utf8(config::nvhttp.pkey)) ||
+         !fs::exists(file_handler::path_from_utf8(config::nvhttp.cert))) &&
         create_creds(config::nvhttp.pkey, config::nvhttp.cert)) {
       return -1;
     }
@@ -84,9 +86,9 @@ namespace http {
   save_user_creds(const std::string &file, const std::string &username, const std::string &password, bool run_our_mouth) {
     pt::ptree outputTree;
 
-    if (fs::exists(file)) {
+    if (fs::exists(file_handler::path_from_utf8(file))) {
       try {
-        pt::read_json(file, outputTree);
+        file_handler::read_json(file, outputTree);
       }
       catch (std::exception &e) {
         BOOST_LOG(error) << "Couldn't read user credentials: "sv << e.what();
@@ -99,7 +101,7 @@ namespace http {
     outputTree.put("salt", salt);
     outputTree.put("password", util::hex(crypto::hash(password + salt)).to_string());
     try {
-      pt::write_json(file, outputTree);
+      file_handler::write_json(file, outputTree);
     }
     catch (std::exception &e) {
       BOOST_LOG(error) << "error writing to the credentials file, perhaps try this again as an administrator? Details: "sv << e.what();
@@ -112,13 +114,13 @@ namespace http {
 
   bool
   user_creds_exist(const std::string &file) {
-    if (!fs::exists(file)) {
+    if (!fs::exists(file_handler::path_from_utf8(file))) {
       return false;
     }
 
     pt::ptree inputTree;
     try {
-      pt::read_json(file, inputTree);
+      file_handler::read_json(file, inputTree);
       return inputTree.find("username") != inputTree.not_found() &&
              inputTree.find("password") != inputTree.not_found() &&
              inputTree.find("salt") != inputTree.not_found();
@@ -134,7 +136,7 @@ namespace http {
   reload_user_creds(const std::string &file) {
     pt::ptree inputTree;
     try {
-      pt::read_json(file, inputTree);
+      file_handler::read_json(file, inputTree);
       config::sunshine.username = inputTree.get<std::string>("username");
       config::sunshine.password = inputTree.get<std::string>("password");
       config::sunshine.salt = inputTree.get<std::string>("salt");
@@ -148,8 +150,8 @@ namespace http {
 
   int
   create_creds(const std::string &pkey, const std::string &cert) {
-    fs::path pkey_path = pkey;
-    fs::path cert_path = cert;
+    fs::path pkey_path = file_handler::path_from_utf8(pkey);
+    fs::path cert_path = file_handler::path_from_utf8(cert);
 
     auto creds = crypto::gen_creds("Sunshine Gamestream Host"sv, 2048);
 
@@ -217,7 +219,12 @@ namespace http {
       return false;
     }
 
-    FILE *fp = fopen(file.c_str(), "wb");
+    FILE *fp = nullptr;
+#ifdef _WIN32
+    fp = _wfopen(file_handler::path_from_utf8(file).c_str(), L"wb");
+#else
+    fp = fopen(file.c_str(), "wb");
+#endif
     if (!fp) {
       BOOST_LOG(error) << "Couldn't open ["sv << file << "] for ["sv << url << ']';
       curl_easy_cleanup(curl);
@@ -253,9 +260,10 @@ namespace http {
     fclose(fp);
     if (result != CURLE_OK) {
         // Cleanup partial file
-        if (fs::exists(file)) {
-            boost::system::error_code ec;
-            fs::remove(file, ec); // Don't crash if delete fails
+        const auto native_file = file_handler::path_from_utf8(file);
+        if (fs::exists(native_file)) {
+            std::error_code ec;
+            fs::remove(native_file, ec); // Don't crash if delete fails
         }
     }
     return result == CURLE_OK;
@@ -720,7 +728,11 @@ namespace {
           }
 
           // Check passed, open file
+#ifdef _WIN32
+          ctx->fp = _wfopen(file_handler::path_from_utf8(ctx->filename).c_str(), L"wb");
+#else
           ctx->fp = fopen(ctx->filename.c_str(), "wb");
+#endif
           if (!ctx->fp) {
             BOOST_LOG(error) << "Couldn't open ["sv << ctx->filename << "] for ["sv << ctx->url << ']';
             return 0;
@@ -841,9 +853,10 @@ namespace {
       }
 
       // Cleanup partial file if it exists (though usually it shouldn't be much)
-      if (boost::filesystem::exists(file)) {
-        boost::system::error_code remove_ec;
-        boost::filesystem::remove(file, remove_ec);
+      const auto native_file = file_handler::path_from_utf8(file);
+      if (std::filesystem::exists(native_file)) {
+        std::error_code remove_ec;
+        std::filesystem::remove(native_file, remove_ec);
       }
       return false;
     }
@@ -853,9 +866,10 @@ namespace {
     if (!ctx.checked) {
       BOOST_LOG(warning) << "Download too small to validate magic bytes ["sv << url << ']';
       // Cleanup if file was created
-      if (boost::filesystem::exists(file)) {
-        boost::system::error_code remove_ec;
-        boost::filesystem::remove(file, remove_ec);
+      const auto native_file = file_handler::path_from_utf8(file);
+      if (std::filesystem::exists(native_file)) {
+        std::error_code remove_ec;
+        std::filesystem::remove(native_file, remove_ec);
       }
       return false;
     }

--- a/src/nvhttp/apps.cpp
+++ b/src/nvhttp/apps.cpp
@@ -10,6 +10,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <nlohmann/json.hpp>
 
+#include "src/file_handler.h"
 #include "src/logging.h"
 #include "src/process.h"
 #include "src/utility.h"
@@ -97,7 +98,7 @@ namespace nvhttp::apps {
       auto args = request->parse_query_string();
       auto app_image = proc::proc.get_app_image(util::from_view(get_arg(args, "appid")));
 
-      std::ifstream in(app_image, std::ios::binary);
+      std::ifstream in(file_handler::path_from_utf8(app_image), std::ios::binary);
       if (!in.is_open()) {
         response->write(SimpleWeb::StatusCode::client_error_not_found, "App asset not found");
         return;

--- a/src/platform/windows/ds5/ds5_sidecar_client.cpp
+++ b/src/platform/windows/ds5/ds5_sidecar_client.cpp
@@ -20,6 +20,7 @@
 #include <random>
 #include <sstream>
 #include <span>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -233,7 +234,11 @@ namespace platf::ds5 {
 
       boost::property_tree::ptree manifest;
       try {
-        boost::property_tree::read_json((expected_active_root / "component.json").string(), manifest);
+        std::ifstream manifest_file_stream(expected_active_root / "component.json", std::ios::binary);
+        if (!manifest_file_stream.is_open()) {
+          throw std::runtime_error("unable to open component manifest");
+        }
+        boost::property_tree::read_json(manifest_file_stream, manifest);
       }
       catch (const std::exception &exception) {
         BOOST_LOG(error) << "Unable to read the active DualSense component manifest: "sv

--- a/src/platform/windows/vulkan_hdr_bridge_session.cpp
+++ b/src/platform/windows/vulkan_hdr_bridge_session.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "src/file_handler.h"
 #include "src/logging.h"
 #include "src/platform/run_command.h"
 #include "src/platform/windows/misc.h"
@@ -255,9 +256,9 @@ namespace platf::vulkan_hdr_bridge {
     bool
     run_helper(const std::filesystem::path &probe, const std::string &arguments,
                const char *operation, bool log_errors = true) {
-      const std::string command = '"' + probe.string() + "\" " + arguments;
+      const std::string command = '"' + file_handler::path_to_utf8(probe) + "\" " + arguments;
       boost::process::v1::environment environment = boost::this_process::environment();
-      boost::filesystem::path working_directory = probe.parent_path().string();
+      boost::filesystem::path working_directory { probe.parent_path().wstring() };
       std::error_code error;
       auto child = platf::run_command(true, false, command, working_directory, environment, nullptr, error, nullptr);
       if (error || !child.valid()) {
@@ -334,7 +335,7 @@ namespace platf::vulkan_hdr_bridge {
 
     bool
     register_user_manifest(const std::filesystem::path &probe, const std::filesystem::path &manifest) {
-      return run_helper(probe, "--register-implicit-layer \"" + manifest.string() + "\"", "per-user layer registration");
+      return run_helper(probe, "--register-implicit-layer \"" + file_handler::path_to_utf8(manifest) + "\"", "per-user layer registration");
     }
 
     bool
@@ -351,7 +352,7 @@ namespace platf::vulkan_hdr_bridge {
       const auto layer_dll = directory / kLayerDllName;
       const auto probe = directory / kProbeName;
       if (!artifacts_installed()) {
-        BOOST_LOG(warning) << "Vulkan HDR bridge artifacts are not installed under " << directory.string();
+        BOOST_LOG(warning) << "Vulkan HDR bridge artifacts are not installed under " << file_handler::path_to_utf8(directory);
         set_status("unavailable", "Vulkan HDR bridge files are not installed.");
         return false;
       }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "crypto.h"
 #include "display_device/session.h"
+#include "file_handler.h"
 #include "httpcommon.h"
 #include "logging.h"
 #include "platform/common.h"
@@ -647,18 +648,18 @@ namespace proc {
         std::string filename = "url_" + std::to_string(hash) + (ext.empty() ? ".png" : ext);
         
         // 保存到本地 covers 目录 (User requested to save to covers instead of assets)
-        auto local_path = std::filesystem::path(platf::appdata().string()) / "covers" / filename;
+        auto local_path = platf::appdata() / "covers" / filename;
         
         // 如果文件不存在则下载
         if (!std::filesystem::exists(local_path)) {
           BOOST_LOG(info) << "Downloading image from URL: " << original_url;
-          if (!http::download_public_cover_image(original_url, local_path.string())) {
+          if (!http::download_public_cover_image(original_url, file_handler::path_to_utf8(local_path))) {
             BOOST_LOG(warning) << "Failed to download image (or rejected by magic check) from URL: " << original_url;
             return DEFAULT_APP_IMAGE_PATH;
           }
         }
         
-        app_image_path = local_path.string();
+        app_image_path = file_handler::path_to_utf8(local_path);
       } catch (const std::exception& e) {
         BOOST_LOG(warning) << "Error processing image URL: " << e.what();
         return DEFAULT_APP_IMAGE_PATH;
@@ -680,7 +681,7 @@ namespace proc {
     }
 
     // 检查图像扩展名是否支持
-    auto image_extension = std::filesystem::path(app_image_path).extension().string();
+    auto image_extension = file_handler::path_from_utf8(app_image_path).extension().string();
     boost::to_lower(image_extension);
     if (image_extension != ".png" && image_extension != ".jpg" && image_extension != ".jpeg") {
       BOOST_LOG(warning) << "Unsupported image extension: " << image_extension;
@@ -690,9 +691,9 @@ namespace proc {
     // 检查各种可能的图像路径
     std::vector<std::string> paths_to_check = {
       // 1. 检查assets目录中的相对路径
-      (std::filesystem::path(SUNSHINE_ASSETS_DIR) / app_image_path).string(),
+      file_handler::path_to_utf8(file_handler::path_from_utf8(SUNSHINE_ASSETS_DIR) / file_handler::path_from_utf8(app_image_path)),
       // 2. 检查covers目录中的相对路径
-      (std::filesystem::path(platf::appdata().string()) / "covers" / app_image_path).string(),
+      file_handler::path_to_utf8(platf::appdata() / "covers" / file_handler::path_from_utf8(app_image_path)),
       // 2. 处理旧的steam默认图像定义
       app_image_path == "./assets/steam.png" ? SUNSHINE_ASSETS_DIR "/steam.png" : "",
       // 3. 检查绝对路径
@@ -700,7 +701,7 @@ namespace proc {
     };
     
     for (const auto& path : paths_to_check) {
-      if (!path.empty() && std::filesystem::exists(path)) {
+      if (!path.empty() && std::filesystem::exists(file_handler::path_from_utf8(path))) {
         return path;
       }
     }
@@ -723,7 +724,7 @@ namespace proc {
 
     // Read file and update calculated SHA
     char buf[1024 * 16];
-    std::ifstream file(filename, std::ifstream::binary);
+    std::ifstream file(file_handler::path_from_utf8(filename), std::ifstream::binary);
     while (file.good()) {
       file.read(buf, sizeof(buf));
       if (!EVP_DigestUpdate(ctx.get(), buf, file.gcount())) {
@@ -799,7 +800,7 @@ namespace proc {
     pt::ptree tree;
 
     try {
-      pt::read_json(file_name, tree);
+      file_handler::read_json(file_name, tree);
 
       auto &apps_node = tree.get_child("apps"s);
       auto &env_vars = tree.get_child("env"s);

--- a/src/tray/system_tray.cpp
+++ b/src/tray/system_tray.cpp
@@ -746,7 +746,9 @@ namespace system_tray {
 
         // 原子性替换：重命名临时文件为实际配置文件
         try {
-          std::filesystem::rename(temp_path, config::sunshine.config_file);
+          std::filesystem::rename(
+            file_handler::path_from_utf8(temp_path),
+            file_handler::path_from_utf8(config::sunshine.config_file));
           BOOST_LOG(info) << "[tray_import_config] Configuration imported successfully from: " << file_path;
           
           // 询问用户是否重启Sunshine以应用新配置
@@ -766,7 +768,7 @@ namespace system_tray {
         catch (const std::exception &e) {
           BOOST_LOG(error) << "[tray_import_config] Failed to rename temp file: " << e.what();
           // 清理临时文件
-          std::filesystem::remove(temp_path);
+          std::filesystem::remove(file_handler::path_from_utf8(temp_path));
           std::wstring title = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_IMPORT_ERROR_TITLE));
           std::wstring message = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_IMPORT_ERROR_WRITE));
           MessageBoxW(NULL, message.c_str(), title.c_str(), MB_OK | MB_ICONERROR);
@@ -1058,7 +1060,7 @@ namespace system_tray {
         }
 
         // 创建空的配置文件（重置为默认值）
-        std::ofstream config_file(config::sunshine.config_file);
+        std::ofstream config_file(file_handler::path_from_utf8(config::sunshine.config_file));
         if (config_file.is_open()) {
           config_file.close();
           BOOST_LOG(info) << "Configuration reset successfully";

--- a/src/tray/system_tray.cpp
+++ b/src/tray/system_tray.cpp
@@ -492,7 +492,7 @@ namespace system_tray {
   // 安全验证：检查文件路径是否安全
   auto is_safe_config_path = [](const std::string &path) -> bool {
     try {
-      std::filesystem::path p(path);
+      const auto p = file_handler::path_from_utf8(path);
 
       // 检查文件是否存在
       if (!std::filesystem::exists(p)) {
@@ -932,7 +932,7 @@ namespace system_tray {
 
       // 安全验证：检查输出文件路径（基本检查）
       try {
-        std::filesystem::path p(file_path);
+        const auto p = file_handler::path_from_utf8(file_path);
         
         // 检查文件扩展名
         if (p.extension() != ".conf") {
@@ -985,7 +985,9 @@ namespace system_tray {
 
         // 原子性替换
         try {
-          std::filesystem::rename(temp_path, file_path);
+          std::filesystem::rename(
+            file_handler::path_from_utf8(temp_path),
+            file_handler::path_from_utf8(file_path));
           BOOST_LOG(info) << "[tray_export_config] Configuration exported successfully to: " << file_path;
           std::wstring title = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_EXPORT_SUCCESS_TITLE));
           std::wstring message = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_EXPORT_SUCCESS_MSG));
@@ -994,7 +996,7 @@ namespace system_tray {
         catch (const std::exception &e) {
           BOOST_LOG(error) << "[tray_export_config] Failed to rename temp export file: " << e.what();
           // 清理临时文件
-          std::filesystem::remove(temp_path);
+          std::filesystem::remove(file_handler::path_from_utf8(temp_path));
           std::wstring title = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_EXPORT_ERROR_TITLE));
           std::wstring message = system_tray_i18n::utf8_to_wstring(system_tray_i18n::get_localized_string(system_tray_i18n::KEY_EXPORT_ERROR_WRITE));
           MessageBoxW(NULL, message.c_str(), title.c_str(), MB_OK | MB_ICONERROR);

--- a/tests/unit/test_file_handler.cpp
+++ b/tests/unit/test_file_handler.cpp
@@ -4,6 +4,8 @@
  */
 #include <chrono>
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <src/file_handler.h>
 
 #include "../tests_common.h"
@@ -103,6 +105,30 @@ TEST(FileHandlerTests, ReadsAndWritesUnicodePath) {
   ASSERT_TRUE(file_handler::make_directory(utf8_root));
   ASSERT_EQ(file_handler::write_file(utf8_file.c_str(), "unicode-path"), 0);
   EXPECT_EQ(file_handler::read_file(utf8_file.c_str()), "unicode-path");
+
+  std::error_code ignored;
+  std::filesystem::remove_all(root, ignored);
+}
+
+TEST(FileHandlerTests, ReadsAndWritesJsonInUnicodePath) {
+  const auto root = std::filesystem::temp_directory_path() /
+                    (std::filesystem::path { L"sunshine_JSON路径_" } /
+                     std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const auto file = root / L"应用配置.json";
+  const auto utf8_root = file_handler::path_to_utf8(root);
+  const auto utf8_file = file_handler::path_to_utf8(file);
+
+  ASSERT_TRUE(file_handler::make_directory(utf8_root));
+
+  boost::property_tree::ptree expected;
+  expected.put("name", "Sunshine");
+  expected.put("enabled", true);
+  ASSERT_NO_THROW(file_handler::write_json(utf8_file, expected));
+
+  boost::property_tree::ptree actual;
+  ASSERT_NO_THROW(file_handler::read_json(utf8_file, actual));
+  EXPECT_EQ(actual.get<std::string>("name"), "Sunshine");
+  EXPECT_TRUE(actual.get<bool>("enabled"));
 
   std::error_code ignored;
   std::filesystem::remove_all(root, ignored);

--- a/tests/unit/test_file_handler.cpp
+++ b/tests/unit/test_file_handler.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 
 #include <boost/property_tree/ptree.hpp>
+#include <Simple-Web-Server/utility.hpp>
 
 #include <src/file_handler.h>
 
@@ -132,5 +133,13 @@ TEST(FileHandlerTests, ReadsAndWritesJsonInUnicodePath) {
 
   std::error_code ignored;
   std::filesystem::remove_all(root, ignored);
+}
+
+TEST(FileHandlerTests, ConvertsPercentEncodedUnicodeFilename) {
+  const std::filesystem::path expected { L"中文封面.png" };
+  const auto encoded = SimpleWeb::Percent::encode(file_handler::path_to_utf8(expected));
+  const auto actual = file_handler::path_from_utf8(SimpleWeb::Percent::decode(encoded));
+
+  EXPECT_EQ(actual, expected);
 }
 #endif

--- a/tests/unit/test_httpcommon.cpp
+++ b/tests/unit/test_httpcommon.cpp
@@ -5,10 +5,14 @@
 // test imports
 #include "../tests_common.h"
 
+#include <chrono>
+#include <filesystem>
+
 // lib imports
 #include <curl/curl.h>
 
 // local imports
+#include <src/file_handler.h>
 #include <src/httpcommon.h>
 
 #include "../tests_common.h"
@@ -58,3 +62,19 @@ INSTANTIATE_TEST_SUITE_P(
   testing::Values(
     std::make_tuple("https://httpbin.org/base64/aGVsbG8h", "hello.txt"),
     std::make_tuple("https://httpbin.org/redirect-to?url=/base64/aGVsbG8h", "hello-redirect.txt")));
+
+TEST(ImageDownloadTest, FailedDownloadPreservesExistingFile) {
+  const auto root = std::filesystem::temp_directory_path() /
+                    ("sunshine-cover-test-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const auto destination = root / "cover.png";
+  const auto utf8_root = file_handler::path_to_utf8(root);
+  const auto utf8_destination = file_handler::path_to_utf8(destination);
+
+  ASSERT_TRUE(file_handler::make_directory(utf8_root));
+  ASSERT_EQ(file_handler::write_file(utf8_destination.c_str(), "existing-cover"), 0);
+  EXPECT_FALSE(http::download_image_with_magic_check("://invalid", utf8_destination));
+  EXPECT_EQ(file_handler::read_file(utf8_destination.c_str()), "existing-cover");
+
+  std::error_code ignored;
+  std::filesystem::remove_all(root, ignored);
+}


### PR DESCRIPTION
## 说明

Windows 安装目录包含中文或其他 Unicode 字符时，部分文件访问仍会把原生路径转换为窄字符串。WebUI 的 JavaScript/CSS 因此可能返回空内容，应用配置和首次设置凭据也可能无法读取或保存。

## 修改

- 统一通过 UTF-8 路径转换后使用原生文件系统路径读写 Property Tree JSON。
- 修复 WebUI 静态资源、应用配置、用户凭据、封面和下载文件的 Unicode 路径访问。
- 修复 VDD 设置、DualSense 组件清单、托盘配置和 Vulkan HDR 辅助程序中的同类路径入口。
- 增加中文目录下 JSON 读写的回归测试。