### PR TITLE
fix(webui): GUI 模式隐藏旧系统托盘设置

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/General.vue
+++ b/src_assets/common/assets/web/configs/tabs/General.vue
@@ -11,6 +11,7 @@ const props = defineProps({
 
 const config = ref(props.config)
 const globalPrepCmd = ref(props.globalPrepCmd)
+const isEmbeddedGui = window.isTauri === true && window.parent !== window
 
 function addCmd() {
   let template = {
@@ -128,6 +129,7 @@ function handleCommandOrderChanged(newOrder) {
 
       <!-- Enable system tray -->
       <Checkbox
+        v-if="!isEmbeddedGui"
         container-class="settings-field settings-toggle-field"
         id="system_tray"
         locale-prefix="config"


### PR DESCRIPTION
## 说明

Windows GUI 构建由控制面板统一提供系统托盘，Sunshine Core 的旧托盘已停用。在 GUI 内嵌的高级设置中继续显示“启用系统托盘”会让用户误以为该选项仍能控制当前托盘。

## 修改

- GUI 内嵌 WebUI 时隐藏旧的系统托盘配置项。
- 浏览器直接访问 WebUI 时保持现有配置项和行为不变。
- 不修改或覆盖已有 `system_tray` 配置值。