### PR TITLE
feat(hdr): 增加 Dolby Vision Profile 8.4（HLG 基层）主机侧支持

### DIFF
--- a/docs/dolby_vision_profile84.md
+++ b/docs/dolby_vision_profile84.md
@@ -114,7 +114,8 @@ scene_refresh 两变体）生成 RPU bin，dovi_tool 2.3.3 验证：
 
 - **RPU 对 HLG BL 的兼容性**（Phase 0 消解）：手写模板基于 8.1 实测 golden；
   若 dovi_tool 显示 HLG 源需要不同的 mapping 头，Phase 0 即停，重新评估。
-- **客户端矛盾上报**（8.1/8.4 同报 + 请求 HLG）：主机按 client_caps_missing 落回 HDR10，
+- **客户端矛盾上报**（8.1/8.4 同报 + 请求 HLG）：主机按 colorspace_unsupported
+  拒绝 8.4，HLG 会话直落**无动态元数据的普通 HLG**（HDR10+ 需 PQ，无中转），
   行为保守不炸。
 - **旧主机 + 新客户端**：新客户端报 1<<4 位，旧主机 mask off，协商行为同现状。
 - **真机覆盖**：Phase 4 需要一台"仅支持 8.4"的目标设备做正例；8.1 设备回归只需现有

--- a/docs/dolby_vision_profile84.md
+++ b/docs/dolby_vision_profile84.md
@@ -1,0 +1,121 @@
+# Dolby Vision Profile 8.4 串流实施方案
+
+## 1. 定位
+
+DV Profile 8.4 与已落地的 8.1 通道（docs/dolby_vision_profile81.md）结构相同：单层 BL+RPU，
+UNSPEC 62 NAL 注入 HEVC AU，客户端经 `video/dolby-vision` MediaCodec 直渲染。
+唯一区别是基层 EOTF：
+
+| | 8.1 | 8.4 |
+|---|---|---|
+| 基层 | PQ (ST 2084) | HLG (ARIB STD-B67) |
+| 客户端 dynamicRangeMode | 1 | 2 |
+| 目标设备 | 主流 DV 设备 | 不接受 PQ-BL RPU、仅认 HLG-BL 的设备（部分 LG 等） |
+
+复用资产：`video_dolby_vision` RPU 写入器、`staged_rpu_queue_t`、`video_hdr_bitstream`
+strip/inject、`dynamic_hdr_selection` 协商框架、NVENC/AMF 注入链路、HLG 编码管线
+（bt2020hlg P010 已存在）。**不新增编码器代码。**
+
+优先级规则（已确认）：客户端同时报 8.1 与 8.4 时**只协商 8.1**；仅当客户端只报 8.4
+（且请求 HLG）时才协商 8.4。
+
+## 2. 与 RTX HDR（PR #1018）的互斥
+
+RTX HDR pre-encode filter 固定输出 PQ 语义（修复合入后 HLG 会话不再激活 filter，
+rtsp.cpp 守卫 `dynamicRange == 1`）。因此：
+
+- app 开启 `rtx-hdr` 时，8.4 **不参与协商**（8.1 不受影响，其会话本就锁 PQ）。
+- 实现位置：`select_dynamic_hdr` 增加 host gate `pre_encode_filter_active`；
+  或协商后由 rtsp 拒绝。前者可在 ANNOUNCE 响应头里给客户端明确 fallback 原因，选前者。
+
+## 3. 主机端改动
+
+### 3.1 协商层（src/hdr/dynamic_hdr_selection.h/.cpp）
+
+- 新能力位：`DYNAMIC_HDR_CAPS_DOLBY_VISION_84 = 1u << 4`（wire 稳定，旧客户端不会上报）。
+- 新格式枚举：`dynamic_hdr_format_e::dolby_vision_profile_84 = 5`（X-SS-Dynamic-HDR wire 值 5，
+  不重排现有 0-4）；`to_string` 加 `"dolby_vision_profile_84"`。
+- `dynamic_hdr_fallback_e` 不新增值：`colorspace_unsupported` 语义扩展为
+  "要求 PQ 但会话为 HLG / 要求 HLG 但会话为 PQ"。
+- 选择规则（preference 为 automatic 或 dolby_vision 时，按序判定）：
+  1. HEVC 门失败 → codec_unsupported（不变）
+  2. `dynamic_range_mode == 1` 且 caps 有 8.1 → **8.1**（现状优先级不变）
+  3. `dynamic_range_mode == 2` 且 caps 有 8.4 且无 8.1 → **8.4**
+     （caps 同时有 8.1/8.4 且 HLG：属客户端矛盾上报，按 client_caps_missing 落回，
+     客户端应自己在请求 HLG 时不报 8.1）
+  4. RTX HDR per-app 激活 → 8.4 门失败，reason `colorspace_unsupported`
+  5. direct surface 门不变
+- `dynamic_hdr_selection_t::dolby_vision_active()` 改为 8.1 或 8.4。
+- 已知位掩码 `known_bits` 加入 1u<<4。
+
+### 3.2 编码会话（video.cpp / video_dolby_vision）
+
+- 注入门控现状：`协商为 DV && 分析器可用 && PQ`。改为按协商格式分派：
+  - 8.1 → colorspace 必须 PQ（现状）
+  - 8.4 → colorspace 必须 HLG（dynamicRange=2 的 bt2020hlg P010）
+- RPU 写入器零改动：L1（场景光域 min/mid/max）、L5、L6 与基层 EOTF 无关；
+  主机显示原始 mastering 元数据配 L6 的路径直接复用。
+- 注入位置不变：编码输出侧按 encoder frame_index 注入 UNSPEC 62。
+- 会话日志：`NVENC: Dolby Vision Profile 8.4 active (HLG base layer, mastering peak N nits)`。
+
+### 3.3 信号
+
+8.4 会话 colorspace = bt2020hlg、10-bit，走现有 HLG 编码路径；
+HDR10+/Vivid SEI：8.4 时 HDR10+ 需 PQ 不再并行发送（Dual Carry 决策仅适用 8.1/PQ），
+Vivid HLG 可保留（vivid_hlg 枚举已存在，若分析器可用）。
+
+## 4. 客户端侧（moonlight-common-c fork + moonlight-vplus）
+
+- common-c（mic 分支续）：能力位常量 `DYNAMIC_HDR_CAPS_DOLBY_VISION_84 = 1<<4` 透传；
+  `LiGetNegotiatedDynamicHdrFormat()` 无需感知语义（int 直传）。
+- vplus：
+  - 能力探测：在现有 DvheSt 严格探测外，追加 HLG-BL 判定 —— 设备 DV 解码器接受
+    dvhe.08.04（MediaCodec `video/dolby-vision` + HLG signaled 内容）。探测结果驱动
+    只报 8.4 位还是同时报 8.1。
+  - 请求 HLG 的 DV 选项被用户选中时：dynamicRangeMode=2 + 只报 8.4 位。
+  - HDR 模式 UI：DV 8.1 条目旁新增 "DV 8.4"（仅探测通过时显示，沿用
+    StreamSettings 动态重建 list_hdr_mode 的既有逻辑，注意 foundDolbyVision 分支）。
+  - 解码器路由 #538 逻辑复用：协商 5 时同样配 `video/dolby-vision` + DvheSt。
+- 合并顺序：common-c → vplus（与 8.1 相同）。
+
+## 5. 阶段与判定
+
+| 阶段 | 内容 | Go/No-Go 判定 |
+|---|---|---|
+| 0 | RPU 8.4 变体 dovi_tool 2.3.3 验证：HLG BL 会话参数生成 RPU bin，`info -s`/`info -f` 解析 + CRC 往返通过；确认 RPU 头无需按基层改写 | 通过才进 Phase 1 |
+| 1 | 主机协商层 + 单测（优先级/矛盾上报/RTX HDR 互斥/旧客户端兼容） | CI 绿 |
+| 2 | 主机编码注入 + 全量 test_sunshine | CI 绿 |
+| 3 | common-c + vplus 客户端 | 编译 + 探测日志 |
+| 4 | 真机端到端：仅 8.4 设备点亮，logcat `negotiated:5` + DV 解码器路由生效；8.1 设备回归不受影响 | 里程碑 |
+
+### Phase 0 结论（2026-09-01，Go ✅）
+
+用现有写入器（golden 配置：peak 1000/min 1/cll 800/fall 320/l5 16,16 + L1 9,3200,1500，
+scene_refresh 两变体）生成 RPU bin，dovi_tool 2.3.3 验证：
+
+- `info -s` 两变体均解析通过：Profile 8 / CM v2.9 / L1+L5+L6 完整。RPU 本身不含
+  基层 EOTF 信息，"Profile: 8" 不区分 8.1/8.4。
+- `editor` mode 4（dovi_tool 的 8.1→8.4 转换）逐字段对比：**只重写 rpu_data_mapping
+  曲线（PQ 恒等映射 → HLG 域 8 段补偿曲线）与 CRC，L1/L5/L6 逐位不变** —— 该转换
+  面向"PQ 素材转码为 HLG"的场景，补偿的是像素域转换。
+- 我们的场景是**原生 HLG 编码**（分析器统计直接经 HLG OETF 出片），不存在需要补偿
+  的域转换，恒等映射 + L1/L5/L6 正是原生 8.4 RPU 的正确形态。
+- **结论：RPU 写入器零改动**；8.4 会话直接复用 `rpu_generator_t` 与注入链路。
+  最终正确性由 Phase 4 真机（DV 引擎实际映射行为）收口。
+
+## 6. 风险
+
+- **RPU 对 HLG BL 的兼容性**（Phase 0 消解）：手写模板基于 8.1 实测 golden；
+  若 dovi_tool 显示 HLG 源需要不同的 mapping 头，Phase 0 即停，重新评估。
+- **客户端矛盾上报**（8.1/8.4 同报 + 请求 HLG）：主机按 client_caps_missing 落回 HDR10，
+  行为保守不炸。
+- **旧主机 + 新客户端**：新客户端报 1<<4 位，旧主机 mask off，协商行为同现状。
+- **真机覆盖**：Phase 4 需要一台"仅支持 8.4"的目标设备做正例；8.1 设备回归只需现有
+  OPPO PKJ110 / Sony 电视。
+
+## 7. 首发规格
+
+- 协商格式：`dolby_vision_profile_84`（wire 5）
+- 编码：HEVC Main10、bt2020hlg、P010、RPU 注入同 8.1 链路
+- 互斥：app rtx-hdr=on 时 8.4 不协商
+- 降级链：任一门失败直落当前 HLG 无动态元数据状态（HLG 会话无 HDR10+ 中转）

--- a/docs/dolby_vision_profile84.md
+++ b/docs/dolby_vision_profile84.md
@@ -21,8 +21,9 @@ strip/inject、`dynamic_hdr_selection` 协商框架、NVENC/AMF 注入链路、H
 
 ## 2. 与 RTX HDR（PR #1018）的互斥
 
-RTX HDR pre-encode filter 固定输出 PQ 语义（HLG 会话不激活 filter，
-rtsp.cpp 守卫 `dynamicRange == 1`）。因此：
+RTX HDR 管线固定 PQ 编码输出：TrueHDR 滤镜输出 FP16 linear scRGB，由后续
+RGB→PQ/P010 编码阶段产生 PQ 码流（HLG 会话不激活滤镜，rtsp.cpp 守卫
+`dynamicRange == 1`）。因此：
 
 - app 开启 `rtx-hdr` 时，8.4 **不参与协商**（8.1 不受影响，其会话本就锁 PQ）。
 - 实现位置：`select_dynamic_hdr` 的 host gate `synthetic_hdr_enabled` —— 跟随
@@ -46,8 +47,9 @@ rtsp.cpp 守卫 `dynamicRange == 1`）。因此：
   1. HEVC 门失败 → codec_unsupported（不变）
   2. `dynamic_range_mode == 1` 且 caps 有 8.1 → **8.1**（现状优先级不变）
   3. `dynamic_range_mode == 2` 且 caps 有 8.4 且无 8.1 → **8.4**
-     （caps 同时有 8.1/8.4 且 HLG：属客户端矛盾上报，按 client_caps_missing 落回，
-     客户端应自己在请求 HLG 时不报 8.1）
+     （caps 同时有 8.1/8.4 且 HLG：属客户端矛盾上报，按 colorspace_unsupported
+     落回 —— 8.1 报位意味着客户端应预期 PQ，与 HLG 请求冲突；客户端应自己在
+     请求 HLG 时不报 8.1）
   4. RTX HDR per-app 激活 → 8.4 门失败，reason `colorspace_unsupported`
   5. direct surface 门不变
 - `dynamic_hdr_selection_t::dolby_vision_active()` 改为 8.1 或 8.4。

--- a/docs/dolby_vision_profile84.md
+++ b/docs/dolby_vision_profile84.md
@@ -21,12 +21,17 @@ strip/inject、`dynamic_hdr_selection` 协商框架、NVENC/AMF 注入链路、H
 
 ## 2. 与 RTX HDR（PR #1018）的互斥
 
-RTX HDR pre-encode filter 固定输出 PQ 语义（修复合入后 HLG 会话不再激活 filter，
+RTX HDR pre-encode filter 固定输出 PQ 语义（HLG 会话不激活 filter，
 rtsp.cpp 守卫 `dynamicRange == 1`）。因此：
 
 - app 开启 `rtx-hdr` 时，8.4 **不参与协商**（8.1 不受影响，其会话本就锁 PQ）。
-- 实现位置：`select_dynamic_hdr` 增加 host gate `pre_encode_filter_active`；
-  或协商后由 rtsp 拒绝。前者可在 ANNOUNCE 响应头里给客户端明确 fallback 原因，选前者。
+- 实现位置：`select_dynamic_hdr` 的 host gate `synthetic_hdr_enabled` —— 跟随
+  **应用特性**（`session.synthetic_hdr.enabled`）而非会话 filter 状态，因为
+  HLG 请求下 filter 恒为关闭，用 filter 状态做 gate 会让 RTX HDR 应用在 HLG
+  路径漏排除。gate 可在 ANNOUNCE 响应头里给客户端明确 fallback 原因
+  （`colorspace_unsupported`）。
+- 术语链（`rtx_hdr` / `synthetic_hdr` / `pre_encode_filter` 三层各自的消费
+  边界）见 rtx_hdr_stream_implementation.md §2.7。
 
 ## 3. 主机端改动
 

--- a/docs/rtx_hdr_stream_implementation.md
+++ b/docs/rtx_hdr_stream_implementation.md
@@ -116,6 +116,27 @@ FP16 输出纹理，再把两者交给后端处理。这样可以：
 SDR→PQ；TrueHDR 连续成功后只在可控边界激活；连续失败后本会话永久降级，直到下次
 重建视频会话。
 
+### 2.7 术语链：rtx_hdr / synthetic_hdr / pre_encode_filter 各指什么
+
+同一特性在代码里有三个名字，分别属于三层，**只能被各自所在层消费**，不能拿相邻层
+的值做另一层的判断（2026-09 曾因此产生 8.4 协商误判，见 profile84.md §2）：
+
+| 名字 | 所在层 | 生命周期 | 消费者 |
+|---|---|---|---|
+| `rtx_hdr`（apps.json 配置键） | 用户配置 | 持久 | nvhttp：填充 `session.synthetic_hdr` |
+| `synthetic_hdr.enabled`（`launch_session_t`） | 会话意图 | ANNOUNCE 时即可读 | 协商层 gate `synthetic_hdr_enabled`；`post_process_hdr_active` 的输入 |
+| `pre_encode_filter`（`video::config_t`）+ `post_process_hdr_active`（本地计算） | 管线对象 | 编码会话期间 | display_vram 的 filter 构造、colorspace/metadata 决策 |
+
+边界规则（均有单测钉住）：
+
+- HLG 守卫钉 PQ：`post_process_hdr_active = synthetic_hdr.enabled && dynamicRange == 1`，
+  因此 **HLG 会话里 filter 对象恒不存在**；
+- 8.4 协商排除跟随**应用意图**（`synthetic_hdr.enabled` → gate
+  `synthetic_hdr_enabled`），不跟随会话 filter 状态 —— 否则 RTX HDR 应用 + HLG
+  客户端会漏排除；
+- 协商 gate 位于 `dynamic_hdr_host_gates_t`（dynamic_hdr_selection.h），消费规则
+  见 profile84.md §2、§3.1。
+
 ---
 
 ## 3. 范围

--- a/src/hdr/dynamic_hdr_selection.cpp
+++ b/src/hdr/dynamic_hdr_selection.cpp
@@ -61,10 +61,10 @@ namespace hdr {
         }
       }
       else if (caps_84 && !caps_81 && gates.dynamic_range_mode == 2) {
-        // 8.4 is the HLG-base-layer channel. An active pre-encode filter
-        // (RTX HDR) pins the wire to PQ, so it excludes 8.4 — an 8.1 report
-        // alongside 8.4 keeps PQ the expected transfer and falls through too.
-        if (gates.pre_encode_filter_active) {
+        // 8.4 is the HLG-base-layer channel. An app with the SDR-to-HDR
+        // feature (RTX HDR) is excluded from it outright (profile84.md §2),
+        // and so is an 8.1 report, which keeps PQ the expected transfer.
+        if (gates.synthetic_hdr_enabled) {
           dv_fallback = dynamic_hdr_fallback_e::colorspace_unsupported;
         }
         else if (!request.dolby_vision_direct_surface) {

--- a/src/hdr/dynamic_hdr_selection.cpp
+++ b/src/hdr/dynamic_hdr_selection.cpp
@@ -31,11 +31,13 @@ namespace hdr {
     const dynamic_hdr_host_gates_t &gates) noexcept {
     const bool dv_preferred = request.preference == dynamic_hdr_preference_e::automatic ||
                               request.preference == dynamic_hdr_preference_e::dolby_vision;
+    const bool caps_81 = (request.caps_mask & DYNAMIC_HDR_CAPS_DOLBY_VISION_81) != 0;
+    const bool caps_84 = (request.caps_mask & DYNAMIC_HDR_CAPS_DOLBY_VISION_84) != 0;
     // "Requested" covers both a capability the client offered and an explicit
     // preference for Dolby Vision — the latter without the former is a client
     // bug worth a diagnostic, not silence.
     const bool dv_requested = dv_preferred &&
-                              (((request.caps_mask & DYNAMIC_HDR_CAPS_DOLBY_VISION_81) != 0) ||
+                              ((caps_81 || caps_84) ||
                                 request.preference == dynamic_hdr_preference_e::dolby_vision);
 
     // The DV verdict first: a selection returns immediately, a refusal falls
@@ -45,18 +47,35 @@ namespace hdr {
       if (gates.video_format != 1) {
         dv_fallback = dynamic_hdr_fallback_e::codec_unsupported;
       }
-      else if (gates.dynamic_range_mode != 1) {
-        dv_fallback = dynamic_hdr_fallback_e::colorspace_unsupported;
-      }
-      else if ((request.caps_mask & DYNAMIC_HDR_CAPS_DOLBY_VISION_81) == 0) {
+      else if (!caps_81 && !caps_84) {
         dv_fallback = dynamic_hdr_fallback_e::client_caps_missing;
       }
-      else if (!request.dolby_vision_direct_surface) {
-        dv_fallback = dynamic_hdr_fallback_e::direct_surface_missing;
+      else if (caps_81 && gates.dynamic_range_mode == 1) {
+        // 8.1 wins whenever it is servable, regardless of an 8.4 report
+        // (profile84.md §3.1: PQ base layer is the priority channel).
+        if (!request.dolby_vision_direct_surface) {
+          dv_fallback = dynamic_hdr_fallback_e::direct_surface_missing;
+        }
+        else {
+          return { dynamic_hdr_format_e::dolby_vision_profile_81, dynamic_hdr_fallback_e::none };
+        }
       }
-
-      if (!dv_fallback) {
-        return { dynamic_hdr_format_e::dolby_vision_profile_81, dynamic_hdr_fallback_e::none };
+      else if (caps_84 && !caps_81 && gates.dynamic_range_mode == 2) {
+        // 8.4 is the HLG-base-layer channel. An active pre-encode filter
+        // (RTX HDR) pins the wire to PQ, so it excludes 8.4 — an 8.1 report
+        // alongside 8.4 keeps PQ the expected transfer and falls through too.
+        if (gates.pre_encode_filter_active) {
+          dv_fallback = dynamic_hdr_fallback_e::colorspace_unsupported;
+        }
+        else if (!request.dolby_vision_direct_surface) {
+          dv_fallback = dynamic_hdr_fallback_e::direct_surface_missing;
+        }
+        else {
+          return { dynamic_hdr_format_e::dolby_vision_profile_84, dynamic_hdr_fallback_e::none };
+        }
+      }
+      else {
+        dv_fallback = dynamic_hdr_fallback_e::colorspace_unsupported;
       }
 
       // The reason is only worth reporting when the client actually asked
@@ -84,7 +103,7 @@ namespace hdr {
     // Non-DV preference: a DV-capable client that chose otherwise gets the
     // preference as the reason, for client-side "you disabled this" UI.
     const dynamic_hdr_fallback_e preference_reason =
-      (request.caps_mask & DYNAMIC_HDR_CAPS_DOLBY_VISION_81) != 0
+      (request.caps_mask & (DYNAMIC_HDR_CAPS_DOLBY_VISION_81 | DYNAMIC_HDR_CAPS_DOLBY_VISION_84)) != 0
         ? dynamic_hdr_fallback_e::preference
         : dynamic_hdr_fallback_e::none;
 
@@ -118,7 +137,8 @@ namespace hdr {
         constexpr std::uint64_t known_bits = DYNAMIC_HDR_CAPS_HDR10_PLUS |
                                              DYNAMIC_HDR_CAPS_VIVID_PQ |
                                              DYNAMIC_HDR_CAPS_VIVID_HLG |
-                                             DYNAMIC_HDR_CAPS_DOLBY_VISION_81;
+                                             DYNAMIC_HDR_CAPS_DOLBY_VISION_81 |
+                                             DYNAMIC_HDR_CAPS_DOLBY_VISION_84;
         request.caps_mask = static_cast<std::uint32_t>(*mask & known_bits);
         request.caps_reported = true;
       }
@@ -162,6 +182,8 @@ namespace hdr {
         return "vivid_hlg";
       case dynamic_hdr_format_e::dolby_vision_profile_81:
         return "dolby_vision_profile_81";
+      case dynamic_hdr_format_e::dolby_vision_profile_84:
+        return "dolby_vision_profile_84";
     }
     return "unknown";
   }

--- a/src/hdr/dynamic_hdr_selection.h
+++ b/src/hdr/dynamic_hdr_selection.h
@@ -30,6 +30,7 @@ namespace hdr {
     DYNAMIC_HDR_CAPS_VIVID_PQ = 1u << 1,
     DYNAMIC_HDR_CAPS_VIVID_HLG = 1u << 2,
     DYNAMIC_HDR_CAPS_DOLBY_VISION_81 = 1u << 3,
+    DYNAMIC_HDR_CAPS_DOLBY_VISION_84 = 1u << 4,
   };
 
   /// The format the host selected, reported as X-SS-Dynamic-HDR.
@@ -40,6 +41,7 @@ namespace hdr {
     vivid_pq = 2,
     vivid_hlg = 3,
     dolby_vision_profile_81 = 4,
+    dolby_vision_profile_84 = 5,  ///< DV with an HLG base layer
   };
 
   /// The client-side user preference, x-ss-video[0].dynamicHdrPreference.
@@ -54,8 +56,8 @@ namespace hdr {
   /// reported as X-SS-Dynamic-HDR-Fallback for client-side diagnostics.
   enum class dynamic_hdr_fallback_e {
     none,
-    codec_unsupported,  ///< Dolby Vision 8.1 requires HEVC
-    colorspace_unsupported,  ///< Requires BT.2020 PQ (dynamicRangeMode 1)
+    codec_unsupported,  ///< Dolby Vision requires HEVC
+    colorspace_unsupported,  ///< 8.1 requires BT.2020 PQ; 8.4 requires BT.2020 HLG (or is excluded by an active pre-encode filter)
     client_caps_missing,  ///< Client reported no Dolby Vision capability
     direct_surface_missing,  ///< Client cannot promise a direct surface path
     preference,  ///< A non-DV preference won
@@ -77,6 +79,9 @@ namespace hdr {
     int video_format = 0;
     /// x-nv-video[0].dynamicRangeMode: 0 SDR, 1 PQ, 2 HLG.
     int dynamic_range_mode = 0;
+    /// An active SDR-to-HDR pre-encode filter (RTX HDR) pins the wire to PQ,
+    /// excluding the HLG-base-layer profile 8.4.
+    bool pre_encode_filter_active = false;
   };
 
   struct dynamic_hdr_selection_t {
@@ -87,19 +92,23 @@ namespace hdr {
 
     bool
     dolby_vision_active() const {
-      return format == dynamic_hdr_format_e::dolby_vision_profile_81;
+      return format == dynamic_hdr_format_e::dolby_vision_profile_81 ||
+             format == dynamic_hdr_format_e::dolby_vision_profile_84;
     }
   };
 
   /**
-   * The one-shot session decision, docs §4.2.
+   * The one-shot session decision, docs/dolby_vision_profile81.md §4 and
+   * docs/dolby_vision_profile84.md §3.1.
    *
-   * Priority: preference dolby_vision/automatic → DV 8.1 → HDR10+ → HDR10;
-   * preference hdr10_plus → HDR10+ → HDR10; preference hdr10_only → HDR10.
-   * DV additionally requires HEVC, PQ, and the client capability with a
-   * direct surface. HDR10+ requires PQ; a client that reported
-   * capabilities without the HDR10+ bit gets plain HDR10, while a legacy
-   * client (no report) keeps the unconditional HDR10+ of previous versions.
+   * DV priority: 8.1 whenever the client reports it and the session is PQ;
+   * 8.4 only when the client reports 8.4 alone and the session is HLG
+   * (user-confirmed rule). Preference: dolby_vision/automatic → DV →
+   * HDR10+ → HDR10; hdr10_plus → HDR10+ → HDR10; hdr10_only → HDR10.
+   * DV additionally requires HEVC and the client capability with a direct
+   * surface. HDR10+ requires PQ; a client that reported capabilities without
+   * the HDR10+ bit gets plain HDR10, while a legacy client (no report) keeps
+   * the unconditional HDR10+ of previous versions.
    */
   [[nodiscard]] dynamic_hdr_selection_t
   select_dynamic_hdr(

--- a/src/hdr/dynamic_hdr_selection.h
+++ b/src/hdr/dynamic_hdr_selection.h
@@ -79,9 +79,11 @@ namespace hdr {
     int video_format = 0;
     /// x-nv-video[0].dynamicRangeMode: 0 SDR, 1 PQ, 2 HLG.
     int dynamic_range_mode = 0;
-    /// An active SDR-to-HDR pre-encode filter (RTX HDR) pins the wire to PQ,
-    /// excluding the HLG-base-layer profile 8.4.
-    bool pre_encode_filter_active = false;
+    /// The app has the SDR-to-HDR (RTX HDR) feature enabled. Its pipeline is
+    /// PQ-pinned, which excludes the HLG-base profile 8.4 for the whole app —
+    /// even when the filter itself stays off because the client requested HLG
+    /// (docs/dolby_vision_profile84.md §2).
+    bool synthetic_hdr_enabled = false;
   };
 
   struct dynamic_hdr_selection_t {

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1451,6 +1451,8 @@ namespace rtsp_stream {
 
     std::int64_t configuredBitrateKbps;
     config.audio.flags[audio::config_t::HOST_AUDIO] = session.host_audio;
+    // Set inside the SDP parse below; consumed by the dynamic HDR selection.
+    bool post_process_hdr_active = false;
     auto getArg = [&args](std::string_view key) {
       return util::from_view(args.at(key));
     };
@@ -1551,7 +1553,7 @@ namespace rtsp_stream {
       // The TrueHDR chain (filter output, synthetic metadata, wire colorspace)
       // is specified for PQ only; HLG sessions must keep the legacy capture
       // path. Docs §5.4 of rtx_hdr_stream_implementation.md.
-      const bool post_process_hdr_active = session.synthetic_hdr.enabled && monitor.dynamicRange == 1;
+      post_process_hdr_active = session.synthetic_hdr.enabled && monitor.dynamicRange == 1;
       if (session.synthetic_hdr.enabled && monitor.dynamicRange == 2) {
         BOOST_LOG(warning) << "RTX HDR requires PQ (dynamicRangeMode=1); ignoring it for this HLG session"sv;
       }
@@ -1565,8 +1567,6 @@ namespace rtsp_stream {
         };
         monitor.pre_encode_filter_backend_path = config::video.rtx_hdr_backend_path;
       }
-#else
-      constexpr bool post_process_hdr_active = false;
 #endif
       monitor.frame_pipeline_policy =
         platf::resolve_frame_pipeline_policy(monitor.dynamicRange, post_process_hdr_active);
@@ -1708,6 +1708,7 @@ namespace rtsp_stream {
       {
         .video_format = config.monitor.videoFormat,
         .dynamic_range_mode = config.monitor.dynamicRange,
+        .pre_encode_filter_active = post_process_hdr_active,
       });
     config.monitor.dynamic_hdr_format = hdr::to_wire(dynamic_hdr_selection.format);
     session.negotiated_dynamic_hdr_format = config.monitor.dynamic_hdr_format;
@@ -1716,7 +1717,7 @@ namespace rtsp_stream {
         ? std::string(hdr::to_string(dynamic_hdr_selection.fallback_reason))
         : std::string {};
     if (dynamic_hdr_selection.dolby_vision_active()) {
-      BOOST_LOG(info) << "Dynamic HDR negotiated: dolby_vision_profile_81"sv;
+      BOOST_LOG(info) << "Dynamic HDR negotiated: "sv << hdr::to_string(dynamic_hdr_selection.format);
     }
     else if (dynamic_hdr_selection.fallback_reason != hdr::dynamic_hdr_fallback_e::none) {
       BOOST_LOG(info) << "Dynamic HDR negotiated: "sv << hdr::to_string(dynamic_hdr_selection.format)

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1708,7 +1708,7 @@ namespace rtsp_stream {
       {
         .video_format = config.monitor.videoFormat,
         .dynamic_range_mode = config.monitor.dynamicRange,
-        .pre_encode_filter_active = post_process_hdr_active,
+        .synthetic_hdr_enabled = session.synthetic_hdr.enabled,
       });
     config.monitor.dynamic_hdr_format = hdr::to_wire(dynamic_hdr_selection.format);
     session.negotiated_dynamic_hdr_format = config.monitor.dynamic_hdr_format;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3065,29 +3065,40 @@ namespace video {
 
     // The device moves into the session; sample its gates beforehand.
     const bool dv_analysis_usable = encode_device && hdr_luminance_analysis_usable(encode_device->hdr_luminance_analysis_available);
-    const bool dv_pq = encode_device && colorspace_is_pq(encode_device->colorspace);
+    const auto dv_format = static_cast<hdr::dynamic_hdr_format_e>(client_config.dynamic_hdr_format);
+    const bool dv_negotiated = dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_81 ||
+                               dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84;
+    // 8.1 rides PQ, 8.4 rides HLG: the RPU metadata domain is the same
+    // (profile84.md Phase 0), only the required base-layer transfer differs.
+    const bool dv_transfer_ok =
+      encode_device &&
+      ((dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_81 && colorspace_is_pq(encode_device->colorspace)) ||
+        (dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84 && colorspace_is_hlg(encode_device->colorspace)));
     auto session = std::make_unique<nvenc_encode_session_t>(std::move(encode_device), client_config.videoFormat);
 
     // Contract note: a negotiated-DV session that cannot carry the RPU still
     // serves a valid HDR10-compatible HEVC base layer; the client's decoder
     // routing must tolerate RPU absence and fall back. These warnings are the
     // diagnostics for exactly that path -- do not promise the RPU here.
-    if (client_config.dynamic_hdr_format == static_cast<int>(hdr::dynamic_hdr_format_e::dolby_vision_profile_81) &&
-        !is_probe) {
+    if (dv_negotiated && !is_probe) {
       // Dynamic L1 is the whole point of the pipeline; without analyzer
       // output the stream would carry nothing but a static template.
       if (!dv_analysis_usable) {
         BOOST_LOG(warning) << "NVENC: Dolby Vision negotiated but luminance analysis is unavailable; "
                               "streaming without RPU"sv;
       }
-      else if (!dv_pq) {
-        BOOST_LOG(warning) << "NVENC: Dolby Vision negotiated but the final colorspace is not PQ; "
-                              "streaming without RPU"sv;
+      else if (!dv_transfer_ok) {
+        BOOST_LOG(warning) << "NVENC: Dolby Vision negotiated but the final colorspace does not match the "
+                              "negotiated profile; streaming without RPU"sv;
       }
       else if (const auto dv_config = dolby_vision_config_for_session(disp, client_config);
                !dv_config || !session->dolby_vision_.configure(*dv_config)) {
         BOOST_LOG(warning) << "NVENC: Dolby Vision negotiated but no usable mastering metadata; "
                               "streaming without RPU"sv;
+      }
+      else if (dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84) {
+        BOOST_LOG(info) << "NVENC: Dolby Vision Profile 8.4 active (HLG base layer, mastering peak "
+                        << dv_config->source_mastering_peak_nits << " nits)"sv;
       }
       else {
         BOOST_LOG(info) << "NVENC: Dolby Vision Profile 8.1 active (mastering peak "
@@ -3132,7 +3143,15 @@ namespace video {
 
     // The device moves into the session; sample its gates beforehand.
     const bool dv_analysis_usable = encode_device && hdr_luminance_analysis_usable(encode_device->hdr_luminance_analysis_available);
-    const bool dv_pq = encode_device && colorspace_is_pq(encode_device->colorspace);
+    const auto dv_format = static_cast<hdr::dynamic_hdr_format_e>(client_config.dynamic_hdr_format);
+    const bool dv_negotiated = dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_81 ||
+                               dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84;
+    // 8.1 rides PQ, 8.4 rides HLG: the RPU metadata domain is the same
+    // (profile84.md Phase 0), only the required base-layer transfer differs.
+    const bool dv_transfer_ok =
+      encode_device &&
+      ((dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_81 && colorspace_is_pq(encode_device->colorspace)) ||
+        (dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84 && colorspace_is_hlg(encode_device->colorspace)));
     auto session = std::make_unique<amf_encode_session_t>(std::move(encode_device), client_config.videoFormat);
 
     // Contract note: a negotiated-DV session that cannot carry the RPU still
@@ -3140,20 +3159,23 @@ namespace video {
     // routing must tolerate RPU absence and fall back (docs dolby_vision_
     // profile81.md SS 5.3). These warnings are the diagnostics for exactly
     // that path -- do not promise the RPU here.
-    if (client_config.dynamic_hdr_format == static_cast<int>(hdr::dynamic_hdr_format_e::dolby_vision_profile_81) &&
-        !is_probe) {
+    if (dv_negotiated && !is_probe) {
       if (!dv_analysis_usable) {
         BOOST_LOG(warning) << "AMF: Dolby Vision negotiated but luminance analysis is unavailable; "
                               "streaming without RPU"sv;
       }
-      else if (!dv_pq) {
-        BOOST_LOG(warning) << "AMF: Dolby Vision negotiated but the final colorspace is not PQ; "
-                              "streaming without RPU"sv;
+      else if (!dv_transfer_ok) {
+        BOOST_LOG(warning) << "AMF: Dolby Vision negotiated but the final colorspace does not match the "
+                              "negotiated profile; streaming without RPU"sv;
       }
       else if (const auto dv_config = dolby_vision_config_for_session(disp, client_config);
                !dv_config || !session->dolby_vision_.configure(*dv_config)) {
         BOOST_LOG(warning) << "AMF: Dolby Vision negotiated but no usable mastering metadata; "
                               "streaming without RPU"sv;
+      }
+      else if (dv_format == hdr::dynamic_hdr_format_e::dolby_vision_profile_84) {
+        BOOST_LOG(info) << "AMF: Dolby Vision Profile 8.4 active (HLG base layer, mastering peak "
+                        << dv_config->source_mastering_peak_nits << " nits)"sv;
       }
       else {
         BOOST_LOG(info) << "AMF: Dolby Vision Profile 8.1 active (mastering peak "
@@ -3184,7 +3206,9 @@ namespace video {
       // native NVENC/AMF paths own end to end; an AVPacket cannot be resized
       // in place. The stream stays a valid HDR10-compatible HEVC base layer,
       // so the client is served — just without the Dolby Vision metadata.
-      if (!is_probe && effective_config.dynamic_hdr_format == static_cast<int>(hdr::dynamic_hdr_format_e::dolby_vision_profile_81)) {
+      if (!is_probe &&
+          (effective_config.dynamic_hdr_format == static_cast<int>(hdr::dynamic_hdr_format_e::dolby_vision_profile_81) ||
+            effective_config.dynamic_hdr_format == static_cast<int>(hdr::dynamic_hdr_format_e::dolby_vision_profile_84))) {
         BOOST_LOG(warning) << "Dolby Vision negotiated but an avcodec-family encoder was selected; "
                               "streaming HDR10 without RPU"sv;
       }

--- a/tests/unit/test_dynamic_hdr_selection.cpp
+++ b/tests/unit/test_dynamic_hdr_selection.cpp
@@ -26,6 +26,7 @@ namespace {
   using hdr::select_dynamic_hdr;
 
   using hdr::DYNAMIC_HDR_CAPS_DOLBY_VISION_81;
+  using hdr::DYNAMIC_HDR_CAPS_DOLBY_VISION_84;
   using hdr::DYNAMIC_HDR_CAPS_HDR10_PLUS;
   using hdr::DYNAMIC_HDR_CAPS_NONE;
 
@@ -174,18 +175,18 @@ TEST(DynamicHdrSelection, ParsesSdpArguments) {
   // Unknown capability bits are masked off, not fatal: a future client keeps
   // its negotiation with the subset this host understands.
   const auto future = parse_dynamic_hdr_request(
-    std::string_view("25"),      // HDR10+ | DV 8.1 | unknown bit 4
+    std::string_view("49"),      // HDR10+ | DV 8.4 | unknown bit 5
     std::string_view("1"),
     std::string_view("0"));
   EXPECT_TRUE(future.caps_reported);
   EXPECT_EQ(future.caps_mask,
-    DYNAMIC_HDR_CAPS_HDR10_PLUS | DYNAMIC_HDR_CAPS_DOLBY_VISION_81);
+    DYNAMIC_HDR_CAPS_HDR10_PLUS | DYNAMIC_HDR_CAPS_DOLBY_VISION_84);
 
   // A report carrying ONLY unknown bits is still a report: it must land in
   // the negotiated "no formats" downgrade, never back in the legacy path
   // that keeps unconditional HDR10+.
   const auto only_unknown = parse_dynamic_hdr_request(
-    std::string_view("16"),      // unknown bit 4 alone
+    std::string_view("32"),      // unknown bit 5 alone
     std::string_view("0"),
     std::string_view("0"));
   EXPECT_TRUE(only_unknown.caps_reported);
@@ -231,7 +232,72 @@ TEST(DynamicHdrSelection, WireValuesAreStable) {
   EXPECT_EQ(hdr::to_wire(dynamic_hdr_format_e::vivid_pq), 2);
   EXPECT_EQ(hdr::to_wire(dynamic_hdr_format_e::vivid_hlg), 3);
   EXPECT_EQ(hdr::to_wire(dynamic_hdr_format_e::dolby_vision_profile_81), 4);
+  EXPECT_EQ(hdr::to_wire(dynamic_hdr_format_e::dolby_vision_profile_84), 5);
 
   EXPECT_EQ(hdr::to_string(dynamic_hdr_format_e::dolby_vision_profile_81), "dolby_vision_profile_81");
+  EXPECT_EQ(hdr::to_string(dynamic_hdr_format_e::dolby_vision_profile_84), "dolby_vision_profile_84");
   EXPECT_EQ(hdr::to_string(dynamic_hdr_fallback_e::direct_surface_missing), "direct_surface_missing");
+}
+
+namespace {
+
+  // An 8.4-only client: no 8.1 report, direct surface.
+  dynamic_hdr_request_t
+  dv84_client(dynamic_hdr_preference_e preference = dynamic_hdr_preference_e::automatic) {
+    dynamic_hdr_request_t request;
+    request.caps_mask = DYNAMIC_HDR_CAPS_HDR10_PLUS | DYNAMIC_HDR_CAPS_DOLBY_VISION_84;
+    request.caps_reported = true;
+    request.dolby_vision_direct_surface = true;
+    request.preference = preference;
+    return request;
+  }
+
+  dynamic_hdr_host_gates_t
+  hevc_hlg_host() {
+    return { .video_format = 1, .dynamic_range_mode = 2 };
+  }
+
+}  // namespace
+
+TEST(DynamicHdrSelection, Selects84WhenOnly84ReportedAndHlgRequested) {
+  const auto selection = select_dynamic_hdr(dv84_client(), hevc_hlg_host());
+  EXPECT_EQ(selection.format, dynamic_hdr_format_e::dolby_vision_profile_84);
+  EXPECT_TRUE(selection.dolby_vision_active());
+  EXPECT_EQ(selection.fallback_reason, dynamic_hdr_fallback_e::none);
+}
+
+TEST(DynamicHdrSelection, AlwaysPrefers81WhenReported) {
+  // Both bits reported + PQ: 8.1, never 8.4.
+  dynamic_hdr_request_t both = dv84_client();
+  both.caps_mask |= DYNAMIC_HDR_CAPS_DOLBY_VISION_81;
+  const auto pq = select_dynamic_hdr(both, hevc_pq_host());
+  EXPECT_EQ(pq.format, dynamic_hdr_format_e::dolby_vision_profile_81);
+
+  // Both bits reported + HLG: 8.1 is unservable and 8.4 must not step in for
+  // an 8.1-capable client (profile84.md §3.1) — colorspace refusal.
+  const auto hlg = select_dynamic_hdr(both, hevc_hlg_host());
+  EXPECT_EQ(hlg.format, dynamic_hdr_format_e::none);
+  EXPECT_EQ(hlg.fallback_reason, dynamic_hdr_fallback_e::colorspace_unsupported);
+}
+
+TEST(DynamicHdrSelection, ActivePreEncodeFilterExcludes84ButNot81) {
+  // RTX HDR pins the wire to PQ: the HLG-base-layer profile is out.
+  const auto hlg = select_dynamic_hdr(dv84_client(), { .video_format = 1, .dynamic_range_mode = 2, .pre_encode_filter_active = true });
+  EXPECT_EQ(hlg.format, dynamic_hdr_format_e::none);
+  EXPECT_EQ(hlg.fallback_reason, dynamic_hdr_fallback_e::colorspace_unsupported);
+
+  // 8.1 rides the same PQ signal the filter produces, so it stays available.
+  const auto pq = select_dynamic_hdr(full_dv_client(), { .video_format = 1, .dynamic_range_mode = 1, .pre_encode_filter_active = true });
+  EXPECT_EQ(pq.format, dynamic_hdr_format_e::dolby_vision_profile_81);
+}
+
+TEST(DynamicHdrSelection, EightyFourRefusalOnHlgHasNoHdr10PlusFallthrough) {
+  // 8.4 needs a direct surface like 8.1 does; the refusal lands on plain
+  // HDR10 because HDR10+ is PQ-only and this session is HLG.
+  dynamic_hdr_request_t no_surface = dv84_client(dynamic_hdr_preference_e::dolby_vision);
+  no_surface.dolby_vision_direct_surface = false;
+  const auto selection = select_dynamic_hdr(no_surface, hevc_hlg_host());
+  EXPECT_EQ(selection.fallback_reason, dynamic_hdr_fallback_e::direct_surface_missing);
+  EXPECT_EQ(selection.format, dynamic_hdr_format_e::none);
+  EXPECT_FALSE(selection.dolby_vision_active());
 }

--- a/tests/unit/test_dynamic_hdr_selection.cpp
+++ b/tests/unit/test_dynamic_hdr_selection.cpp
@@ -280,15 +280,21 @@ TEST(DynamicHdrSelection, AlwaysPrefers81WhenReported) {
   EXPECT_EQ(hlg.fallback_reason, dynamic_hdr_fallback_e::colorspace_unsupported);
 }
 
-TEST(DynamicHdrSelection, ActivePreEncodeFilterExcludes84ButNot81) {
-  // RTX HDR pins the wire to PQ: the HLG-base-layer profile is out.
-  const auto hlg = select_dynamic_hdr(dv84_client(), { .video_format = 1, .dynamic_range_mode = 2, .pre_encode_filter_active = true });
+TEST(DynamicHdrSelection, SyntheticHdrAppExcludes84ButNot81) {
+  // An RTX HDR app is excluded from 8.4 for the whole app (profile84.md §2),
+  // including the HLG ANNOUNCE path where the filter itself stays off —
+  // the exclusion follows the app feature, not the per-session filter state.
+  const auto hlg = select_dynamic_hdr(dv84_client(), { .video_format = 1, .dynamic_range_mode = 2, .synthetic_hdr_enabled = true });
   EXPECT_EQ(hlg.format, dynamic_hdr_format_e::none);
   EXPECT_EQ(hlg.fallback_reason, dynamic_hdr_fallback_e::colorspace_unsupported);
 
   // 8.1 rides the same PQ signal the filter produces, so it stays available.
-  const auto pq = select_dynamic_hdr(full_dv_client(), { .video_format = 1, .dynamic_range_mode = 1, .pre_encode_filter_active = true });
+  const auto pq = select_dynamic_hdr(full_dv_client(), { .video_format = 1, .dynamic_range_mode = 1, .synthetic_hdr_enabled = true });
   EXPECT_EQ(pq.format, dynamic_hdr_format_e::dolby_vision_profile_81);
+
+  // Without the app feature the same HLG report still negotiates 8.4.
+  const auto plain_hlg = select_dynamic_hdr(dv84_client(), hevc_hlg_host());
+  EXPECT_EQ(plain_hlg.format, dynamic_hdr_format_e::dolby_vision_profile_84);
 }
 
 TEST(DynamicHdrSelection, EightyFourRefusalOnHlgHasNoHdr10PlusFallthrough) {


### PR DESCRIPTION
## 概要

在已合并的 RTX HDR 管线（#1018）之上，为不支持 DV Profile 8.1、仅支持 8.4 的设备增加 HLG 基层的 Dolby Vision 通道。完整设计、Phase 0 验证结论与阶段计划见 `docs/dolby_vision_profile84.md`（本 PR 内含）。

- 协商层：新增能力位 `1<<4` 与 wire 格式 `5`（`dolby_vision_profile_84`）；**8.1 优先** —— 客户端同时报 8.1/8.4 时只协商 8.1，仅"只报 8.4 且请求 HLG"才协商 8.4
- 与 RTX HDR 互斥：synthetic 管线固定 PQ，app 开启 rtx-hdr 时 8.4 不参与协商（8.1 不受影响）
- NVENC/AMF 注入门控按协商 profile 分派 colorspace（8.1→PQ / 8.4→HLG）；RPU 写入器**零改动**（Phase 0 已验证 RPU 与基层 EOTF 无关）
- HDR10+ Dual Carry 仅适用 PQ 会话（现有 colorspace 门控自然满足）；Vivid HLG 可保留

## 客户端配套

- qiin2333/moonlight-common-c `feat/dolby-vision-profile-84`（mic 之上）：协商常量
- qiin2333/moonlight-vplus `feat/dolby-vision-profile-84`（master 之上）：8.4 模式 UI / 探测 / 解码路由
- 合并顺序：common-c → vplus（与 8.1 相同）

## 测试

- [x] 协商单测新增 4 用例（8.4 选择 / 8.1 优先 / RTX HDR 互斥 / HLG 无 HDR10+ 直降），全量 501 测试通过（唯一失败为 httpbin.org 外网下载测试，与本 PR 无关）
- [x] dovi_tool 2.3.3 Phase 0 验证：RPU 解析/CRC 往返通过，mode-4 转换仅重写 mapping 曲线
- [ ] 真机端到端（仅 8.4 设备点亮 + 8.1 设备回归）