### PR TITLE
feat(remote-usb): 虚拟 USB HID 触摸

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -124,6 +124,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/file_mapping/service.cpp"
         "${CMAKE_SOURCE_DIR}/src/file_mapping/service.h"
         "${CMAKE_SOURCE_DIR}/src/remote_usb/loopback_usbip_bridge.cpp"
+        "${CMAKE_SOURCE_DIR}/src/remote_usb/virtual_touchscreen_device.cpp"
+        "${CMAKE_SOURCE_DIR}/src/remote_usb/virtual_touchscreen_device.h"
         "${CMAKE_SOURCE_DIR}/src/remote_usb/loopback_usbip_bridge.h"
         "${CMAKE_SOURCE_DIR}/src/remote_usb/remote_usb_capability.cpp"
         "${CMAKE_SOURCE_DIR}/src/remote_usb/remote_usb_capability.h"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -168,6 +168,10 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/input.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/ds5/ds5_sidecar_client.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/ds5/ds5_sidecar_client.cpp"
+        "${CMAKE_SOURCE_DIR}/src/touch_keyboard_session.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/touch_keyboard_session.cpp"
+        "${CMAKE_SOURCE_DIR}/src/virtual_touchscreen_session.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_touchscreen_session.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_device_host/microphone_client.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_mouse.h"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_mouse.cpp"
@@ -248,6 +252,7 @@ list(PREPEND PLATFORM_LIBRARIES
         userenv
         ws2_32
         wsock32
+        wtsapi32
 )
 
 if(SUNSHINE_ENABLE_TRAY AND SUNSHINE_ENABLE_LEGACY_TRAY)

--- a/docs/per-client-touch-profile-design.md
+++ b/docs/per-client-touch-profile-design.md
@@ -1,0 +1,139 @@
+# 按客户端的触摸体验档案——第一层设计稿
+
+## 1. 文档状态
+
+- 状态：实施设计稿
+- 日期：2026-09-02
+- 前置：PR #1025（虚拟 USB HID 触摸屏设备 + POC，真机验证"点文本框自动弹触摸键盘"通过）
+- 范围：第一层（纯 Sunshine 侧配置与注册表事务，不涉及驱动改动）
+- 修订：2026-09-02 全变量隔离对照实验确认**注册表写入必需**（§5.2），事务设计恢复并扩展为全键写
+
+## 2. 背景与目标
+
+触摸键盘的体验由两个独立机制决定：
+
+1. **弹不弹**：触摸 digitizer 在场 + 触摸输入 + `EnableDesktopModeAutoInvoke`
+2. **长什么样**：显示器 EDID 物理尺寸档位（≥18" 强制 undocked，<18" 允许 docked）——软件手段无法覆盖，EDID 是唯一判定源（Apollo #818 实验结论）
+
+现状：`clients` JSON 已有 per-client 的 `deviceSize`（物理尺寸 cm），经 `CREATEMONITOR {GUID}:[nits][wCm,hCm]` 传入 VDD——**EDID 档位绑定已落地**。本设计稿把"弹"的一侧（虚拟触摸屏设备）也纳入 per-client 档案，与 `deviceSize` 同级管理。对照实验（见非目标）确认：**设备挂载即满足弹出条件，无需注册表预处理**。
+
+### 目标
+
+1. `clients[]` schema 增加 `touch` 对象（启用开关、AutoInvoke 预处理）
+2. 会话开始时按档案：attach 虚拟触摸屏 + 写 AutoInvoke 注册表键组（记录 undo）；会话结束时反向还原
+3. 虚拟触摸屏设备的正式化：从 POC 工具形态接入服务内会话生命周期
+4. 任何失败不阻断流会话（触摸是增强能力，降级仅日志）
+
+### 非目标
+
+- 不做 EDID/物理尺寸的运行时切换（`deviceSize` 已覆盖；会话中切档会闪屏，明确不做）
+- 不做第二层的 VDD EDID 参数化重构
+- **不做 TabletTip 布局偏好（dockedState 等）的 per-client 覆写**——Apollo #818 实验证明此类值被 EDID 档位判定覆盖；AutoInvoke 键组与布局偏好是两类事务，前者必需（本设计稿），后者排除
+- 不解决 USB 外接 digitizer 的多屏触摸路由（映射虚拟桌面，单 VDD 场景无影响）
+- 不实现 `--auto` 之外的 POC UI
+
+## 3. 现状基线（复用点）
+
+| 组件 | 位置 | 复用方式 |
+|---|---|---|
+| 客户端档案容器 | `sunshine.conf` 的 `clients` 键（`config.cpp:2011-2050`），schema 校验在 `confighttp.cpp:1503-1592` | `touch` 对象直接加入现有 schema |
+| 客户端识别 | `client_cert_uuid`（`pairing.cpp:493`，`launch_session_t` 携带，`rtsp.h:43`） | 会话内按 uuid 查档案 |
+| 会话挂载点 | 开始：`configure_display`（`nvhttp_stream_start.cpp:222/488/688`）；结束：`restore_state`（`stream.cpp:4160-4180`） | 触摸事务挂载于 VDD 阶段之后 |
+| USB/IP 设备端 | PR #1025 `virtual_touchscreen_device` + `loopback_usbip_bridge` | 原样接入，attach 用 `usbip.exe`（usbip-win2 组件） |
+| 面板入口 | 控制面板 clients 管理（`/api/clients/list`） | `touch` 字段 UI 在现有客户端编辑界面扩展 |
+
+## 4. Schema 设计
+
+`clients[]` 每项新增可选 `touch` 对象；**缺省 = 完全维持现状**（不创建设备、不写注册表），向后兼容：
+
+```json
+{
+  "uuid": "…",
+  "name": "…",
+  "deviceSize": "…",
+  "touch": {
+    "enabled": true,
+    "autoInvoke": true
+  }
+}
+```
+
+- `enabled`：会话期间为此客户端创建并 attach 虚拟触摸屏
+- `autoInvoke`：会话期间写 AutoInvoke 注册表键组（见 §5.2，undo 到原值）。**全变量隔离对照实验（2026-09-02）证实必需**：全部 AutoInvoke 键置 0 后，设备挂载 + 触摸 tap 键盘不再弹出；键组恢复后弹出。触摸键盘自动弹出依赖这批注册表键，无法省略
+
+校验：`touch.enabled` 为 false 时忽略其余字段。
+
+## 5. 会话事务设计
+
+### 5.1 时序
+
+```
+会话开始（configure_display，VDD prepare 之后）
+  ├─ 按 client_cert_uuid 解析 touch 档案；无 touch/enabled=false → 跳过
+  ├─ [T1] 写注册表预处理 + 记录 undo → appdata/touch_session_undo.json
+  ├─ [T2] 创建 virtual_touchscreen_device + loopback_usbip_bridge
+  └─ [T3] usbip.exe attach（复用 remote_usb 的 usbip_host_controller 命令封装）
+        任一步失败 → 执行已成功步骤的逆操作，降级日志，会话继续
+
+会话结束（restore_state，最后一个视频会话注销）
+  ├─ detach（usbip detach --port）+ 销毁设备与 bridge
+  └─ 应用 touch_session_undo.json 还原注册表，删除 undo 文件
+```
+
+### 5.2 注册表项与目标 hive
+
+| 项 | 值 | undo |
+|---|---|---|
+| `TabletTip\1.7\EnableDesktopModeAutoInvoke` | 1 | 记录原值（含"不存在"），结束时还原 |
+| `TabletTip\1.7\EnableDesktopModeDockedAutoInvoke` | 1 | 同上 |
+| `TabletTip\1.7\EnableInDesktopMode` | 1 | 同上 |
+| `TabletTip\1.7\EnableInDesktopModeTabletKeyboard` | 1 | 同上 |
+| `TabletTip\1.7\EnableInDesktopModeAutoInvoke` | 1 | 同上 |
+| `TabletTip\1.7\EnableDockedModeAutoInvoke` | 1 | 同上 |
+| `TabletTip\1.7\EnableTouchKeyboardAutoInvokeInDesktopMode` | 1 | 同上 |
+| `TabletTip\1.7\EnableTouchKeyboardAutoInvoke` | 1 | 同上 |
+| `TabletTip\1.7\TouchKeyboardTapInvoke` | 2 | 同上 |
+| `TabletTip\1.7\PreventTouchKeyboardAutoInvoke` | 0 | 同上（仅当原值非 0 时写入） |
+
+> **实验依据（2026-09-02，全变量隔离对照）**：上述全部键置 0 + TabTip 重启后，虚拟触摸屏 attach + tap **键盘不弹出**（IFrameworkInputPane 判定 visible=0 ×3）；键组恢复 1 后弹出。Windows 未提供任何 API/设置 UI 之外的策略接口，键组整体写入是"自动弹"的必要条件。不确定哪个键是充分键，整体写 + undo 是最稳健策略（等效于用户在设置中开启）。
+
+目标 hive：**Sunshine 服务态（SYSTEM）写 `HKEY_USERS\<交互用户 SID>\…`**（枚举活动 console 会话令牌解析 SID）；便携态直接 HKCU。两者在事务模块内统一封装为 `write_user_registry()`。
+
+### 5.3 已知限制（记录进文档与日志）
+
+- TabletTip 值由 TextInputHost 进程读取并缓存，会话中写入**可能到下一次键盘进程启动才生效**；AutoInvoke 主键经验上即时生效。设计上接受"尽力而为"，不强制重启 TextInputHost（杀进程影响正在输入的用户）。
+- 同机多客户端并发会话：注册表是 per-user 全局的，后写覆盖前写。第一层明确**仅支持单活动会话场景**，多会话并发时触摸事务跳过并告警（VDD 会话本身也是单活动假设）。
+
+## 6. 虚拟触摸屏设备接入形态
+
+- 生命周期：**per-session**（与会话同生共死），非常驻——避免非流期间虚拟设备污染桌面
+- attach 命令封装复用 `remote_usb/remote_usb_host_controller` 的 usbip 命令构造（`--terse`，无 `--receive-mode`/`--once`）
+- 依赖声明：usbip-win2 组件（与 DS5 完整模式组件同源，`FetchDriverDeps.cmake` 已有下载通道）；组件缺失时 T2/T3 跳过并给出一次性日志
+- keepalive、lift 帧、0 长度 idle 应答等协议行为已在 PR #1025 设备类中实现，直接沿用
+- 坐标映射：单 VDD 场景 digitizer logical range 对齐虚拟桌面；多屏路由问题记入非目标
+
+## 7. 代码落点
+
+| 内容 | 文件 |
+|---|---|
+| schema 校验扩展 | `confighttp.cpp`（clients 路由校验处） |
+| 档案读取 helper | `config.cpp`（clients 存取器旁新增 `get_touch_profile(uuid)`） |
+| 注册表事务模块 | 新 `src/platform/windows/touch_session.cpp/.h`（hive 解析、undo json） |
+| 设备 attach/detach 封装 | 新 `src/remote_usb/virtual_touchscreen_session.cpp/.h`（组合 device + bridge + host_controller） |
+| 挂载 | `nvhttp_stream_start.cpp`（开始）、`stream.cpp`（restore_state 旁结束） |
+| 面板 UI | 控制面板客户端编辑界面加 touch 开关与布局选择（后端字段透传即可） |
+
+## 8. 测试计划
+
+- 单测：`touch` schema 校验、undo 写入/还原、无 touch 字段的向后兼容
+- 对照实验：`autoInvoke=false` 时仅 attach 验证键盘是否弹出（确认注册表依赖）
+- 对照实验：`autoInvoke=false` 时仅 attach 验证键盘是否弹出（确认注册表依赖）
+- 真机（console 会话）：attach → tap 记事本 → 键盘弹出（PR #1025 已有判据）；会话结束后注册表还原、设备消失、reattach 正常
+- 降级：usbip-win2 组件缺失 / attach 失败时流会话不受影响
+- 断电类异常：undo 文件残留时下次会话开始先尝试还原
+
+## 9. 发布闸门
+
+1. `clients` schema 变更需控制面板同步发版（新字段 UI）
+2. usbip-win2 组件版本固定（当前 0.9.7.7），升级需重跑真机矩阵
+3. 注册表写入面收敛到单键（AutoInvoke），后续扩展需评审

--- a/docs/per-client-touch-profile-design.md
+++ b/docs/per-client-touch-profile-design.md
@@ -15,7 +15,7 @@
 1. **弹不弹**：触摸 digitizer 在场 + 触摸输入 + `EnableDesktopModeAutoInvoke`
 2. **长什么样**：显示器 EDID 物理尺寸档位（≥18" 强制 undocked，<18" 允许 docked）——软件手段无法覆盖，EDID 是唯一判定源（Apollo #818 实验结论）
 
-现状：`clients` JSON 已有 per-client 的 `deviceSize`（物理尺寸 cm），经 `CREATEMONITOR {GUID}:[nits][wCm,hCm]` 传入 VDD——**EDID 档位绑定已落地**。本设计稿把"弹"的一侧（虚拟触摸屏设备）也纳入 per-client 档案，与 `deviceSize` 同级管理。对照实验（见非目标）确认：**设备挂载即满足弹出条件，无需注册表预处理**。
+现状：`clients` JSON 已有 per-client 的 `deviceSize`（物理尺寸 cm），经 `CREATEMONITOR {GUID}:[nits][wCm,hCm]` 传入 VDD——**EDID 档位绑定已落地**。本设计稿把"弹"的一侧（虚拟触摸屏设备）也纳入 per-client 档案，与 `deviceSize` 同级管理。对照实验（2026-09-02 全变量隔离）确认：**设备挂载提供触摸输入源，弹出策略由 TabletTip AutoInvoke 键组决定——两者都需要**（键组全 0 时不弹，恢复后弹出，见 §5.2）。
 
 ### 目标
 
@@ -67,7 +67,7 @@
 
 ### 5.1 时序
 
-```
+```text
 会话开始（configure_display，VDD prepare 之后）
   ├─ 按 client_cert_uuid 解析 touch 档案；无 touch/enabled=false → 跳过
   ├─ [T1] 写注册表预处理 + 记录 undo → appdata/touch_session_undo.json
@@ -76,8 +76,8 @@
         任一步失败 → 执行已成功步骤的逆操作，降级日志，会话继续
 
 会话结束（restore_state，最后一个视频会话注销）
-  ├─ detach（usbip detach --port）+ 销毁设备与 bridge
-  └─ 应用 touch_session_undo.json 还原注册表，删除 undo 文件
+  ├─ [R1] 先应用 touch_session_undo.json 还原注册表；仅还原成功后删除 undo 文件
+  ├─ [R2] detach（usbip detach --port）+ 销毁设备与 bridge（失败仅告警，不影响 R1）
 ```
 
 ### 5.2 注册表项与目标 hive
@@ -117,17 +117,16 @@
 | 内容 | 文件 |
 |---|---|
 | schema 校验扩展 | `confighttp.cpp`（clients 路由校验处） |
-| 档案读取 helper | `config.cpp`（clients 存取器旁新增 `get_touch_profile(uuid)`） |
-| 注册表事务模块 | 新 `src/platform/windows/touch_session.cpp/.h`（hive 解析、undo json） |
-| 设备 attach/detach 封装 | 新 `src/remote_usb/virtual_touchscreen_session.cpp/.h`（组合 device + bridge + host_controller） |
+| 档案读取 helper | `config.cpp` `get_client_touch_keyboard_enabled(uuid)` |
+| 注册表事务模块 | `src/touch_keyboard_session.h` + `src/platform/windows/touch_keyboard_session.cpp`（hive 解析、undo json） |
+| 设备 attach/detach 封装 | `src/virtual_touchscreen_session.h` + `src/platform/windows/virtual_touchscreen_session.cpp`（组合 device + bridge + usbip attach） |
 | 挂载 | `nvhttp_stream_start.cpp`（开始）、`stream.cpp`（restore_state 旁结束） |
-| 面板 UI | 控制面板客户端编辑界面加 touch 开关与布局选择（后端字段透传即可） |
+| 面板 UI | 控制面板客户端编辑界面加 touch 开关（后端字段透传即可） |
 
 ## 8. 测试计划
 
 - 单测：`touch` schema 校验、undo 写入/还原、无 touch 字段的向后兼容
-- 对照实验：`autoInvoke=false` 时仅 attach 验证键盘是否弹出（确认注册表依赖）
-- 对照实验：`autoInvoke=false` 时仅 attach 验证键盘是否弹出（确认注册表依赖）
+- 对照实验（已完成 2026-09-02）：键组全 0 不弹、恢复后弹出——注册表依赖确认
 - 真机（console 会话）：attach → tap 记事本 → 键盘弹出（PR #1025 已有判据）；会话结束后注册表还原、设备消失、reattach 正常
 - 降级：usbip-win2 组件缺失 / attach 失败时流会话不受影响
 - 断电类异常：undo 文件残留时下次会话开始先尝试还原
@@ -136,4 +135,4 @@
 
 1. `clients` schema 变更需控制面板同步发版（新字段 UI）
 2. usbip-win2 组件版本固定（当前 0.9.7.7），升级需重跑真机矩阵
-3. 注册表写入面收敛到单键（AutoInvoke），后续扩展需评审
+3. 注册表写入面限定于 §5.2 键组（含 undo），键集合变更需评审

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2014,6 +2014,34 @@ namespace config {
   }
 
   bool
+  get_client_touch_keyboard_enabled(const std::string &uuid) {
+    if (uuid.empty()) {
+      return false;
+    }
+    try {
+      const auto clients = nlohmann::json::parse(get_clients_config());
+      if (!clients.is_array()) {
+        return false;
+      }
+      for (const auto &entry : clients) {
+        if (!entry.is_object() || !entry.contains("uuid")) {
+          continue;
+        }
+        if (entry["uuid"] != uuid) {
+          continue;
+        }
+        return entry.contains("touch") &&
+               entry["touch"].is_object() &&
+               entry["touch"].value("enabled", false) == true;
+      }
+    }
+    catch (const std::exception &e) {
+      BOOST_LOG(warning) << "Failed to read touch profile for client: " << e.what();
+    }
+    return false;
+  }
+
+  bool
   save_clients_config(const std::string &clients) {
     std::lock_guard lock { config_file_mutex };
     try {

--- a/src/config.h
+++ b/src/config.h
@@ -312,6 +312,14 @@ namespace config {
   get_clients_config();
 
   /**
+   * Return the per-client touch-keyboard preference: true when the client
+   * entry exists and its touch.enabled is true.  Unknown clients and
+   * entries without a touch object default to false.
+   */
+  bool
+  get_client_touch_keyboard_enabled(const std::string &uuid);
+
+  /**
    * Persist per-client settings and publish them to the running process.
    * Unlike update_config(), an unchanged value is still a successful save.
    */

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -482,6 +482,9 @@ namespace nvhttp {
     launch_session->enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
     launch_session->use_vdd = util::from_view(get_arg(args, "useVdd", "0"));
     launch_session->custom_screen_mode = util::from_view(get_arg(args, "customScreenMode", "-1"));
+    // Client-declared touch-keyboard intent (Sunshine protocol extension).
+    // -1 undeclared: fall back to the per-client server profile.
+    launch_session->touch_keyboard = util::from_view(get_arg(args, "touchKeyboard", "-1"));
     const auto hdr_capabilities = hdr::parse_client_display_capabilities(
       find_arg(args, "maxBrightness"),
       find_arg(args, "minBrightness"),

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -21,6 +21,8 @@
 #include "logging.h"
 #include "touch_keyboard_session.h"
 #include "video.h"
+
+#include <algorithm>
 #include "virtual_touchscreen_session.h"
 
 namespace nvhttp::stream_start {

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -19,7 +19,9 @@
 #include "display_device/vdd_capability.h"
 #include "hdr/session_target.h"
 #include "logging.h"
+#include "touch_keyboard_session.h"
 #include "video.h"
+#include "virtual_touchscreen_session.h"
 
 namespace nvhttp::stream_start {
 
@@ -690,6 +692,25 @@ namespace nvhttp::stream_start {
     if (display_result) {
       hdr::adopt_vdd_calibration_if_needed(launch_session);
     }
+
+#ifdef _WIN32
+    // Touch experience: attach the virtual touchscreen when the client (or
+    // its server profile) opted in, then enable the touch-keyboard AutoInvoke
+    // key group for the session.  Failures degrade to a log line only.
+    {
+      bool touch_effective = false;
+      if (launch_session.touch_keyboard < 0) {
+        touch_effective = config::get_client_touch_keyboard_enabled(launch_session.client_cert_uuid);
+      }
+      else {
+        touch_effective = launch_session.touch_keyboard == 1;
+      }
+      if (vts::start({"", (std::uint16_t) std::max(0, launch_session.width),
+                      (std::uint16_t) std::max(0, launch_session.height)})) {
+        touch_kb::start_session(touch_effective);
+      }
+    }
+#endif
     auto_recovery_result_t recovery_result;
     const auto probe_target = make_probe_target(intent);
     bool probe_matches_display_state = false;

--- a/src/platform/windows/touch_keyboard_session.cpp
+++ b/src/platform/windows/touch_keyboard_session.cpp
@@ -1,0 +1,344 @@
+/**
+ * @file src/platform/windows/touch_keyboard_session.cpp
+ * @brief Windows implementation of the session-scoped touch keyboard
+ *        AutoInvoke registry transaction.
+ *
+ * Sunshine may run elevated (SYSTEM service) or as a plain user process:
+ * - plain user: values are written through HKCU;
+ * - SYSTEM: the active console session user is resolved and values are
+ *   written into HKEY_USERS\<sid>, because the service's own HKCU belongs
+ *   to S-1-5-18 and is invisible to the user's shell.
+ *
+ * Undo journal: platf::appdata()/touch_keyboard_undo.json captures the
+ * pre-session state of every touched value (including "did not exist") so
+ * an abnormal termination can be repaired by the next end_session() call.
+ */
+
+#include "src/touch_keyboard_session.h"
+
+#include "src/logging.h"
+#include "src/platform/common.h"
+
+#include <nlohmann/json.hpp>
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+#include <Windows.h>
+#include <sddl.h>
+#include <WtsApi32.h>
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace touch_kb {
+
+  namespace {
+
+    constexpr auto REG_SUBKEY = L"SOFTWARE\\Microsoft\\TabletTip\\1.7";
+
+    struct key_def {
+      const wchar_t *name;
+      DWORD desired;
+      // Desired value for keys whose semantics are enums rather than flags.
+      // PreventTouchKeyboardAutoInvoke stays 0 (neutral) and is only written
+      // when it was non-zero before the session.
+      bool write_only_if_previously_present = false;
+    };
+
+    // Full-variable-isolation ablation (2026-09-02): with all of these keys
+    // zeroed and TabTip restarted, the attached virtual touchscreen no longer
+    // auto-invokes the touch keyboard; restoring them restores invocation.
+    constexpr key_def KEYS[] = {
+      { L"EnableDesktopModeAutoInvoke", 1 },
+      { L"EnableDesktopModeDockedAutoInvoke", 1 },
+      { L"EnableInDesktopMode", 1 },
+      { L"EnableInDesktopModeTabletKeyboard", 1 },
+      { L"EnableInDesktopModeAutoInvoke", 1 },
+      { L"EnableDockedModeAutoInvoke", 1 },
+      { L"EnableTouchKeyboardAutoInvokeInDesktopMode", 1 },
+      { L"EnableTouchKeyboardAutoInvoke", 1 },
+      { L"TouchKeyboardTapInvoke", 2 },
+      { L"PreventTouchKeyboardAutoInvoke", 0, true },
+    };
+
+    struct captured_value {
+      bool exists;
+      DWORD value;
+    };
+
+    std::wstring
+    to_wstring(const std::string &utf8) {
+      if (utf8.empty()) {
+        return {};
+      }
+      int size = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), (int) utf8.size(), nullptr, 0);
+      std::wstring out(size, L'\0');
+      MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), (int) utf8.size(), out.data(), size);
+      return out;
+    }
+
+    std::string
+    to_utf8(const std::wstring &wide) {
+      if (wide.empty()) {
+        return {};
+      }
+      int size = WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), (int) wide.size(), nullptr, 0, nullptr, nullptr);
+      std::string out(size, '\0');
+      WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), (int) wide.size(), out.data(), size, nullptr, nullptr);
+      return out;
+    }
+
+    bool
+    running_as_system() {
+      HANDLE token = nullptr;
+      if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+        return false;
+      }
+      BYTE sid[SECURITY_MAX_SID_SIZE];
+      DWORD size = sizeof(sid);
+      BOOL result = GetTokenInformation(token, TokenUser, sid, size, &size);
+      CloseHandle(token);
+      if (!result) {
+        return false;
+      }
+      return IsWellKnownSid(sid, WinLocalSystemSid);
+    }
+
+    struct hive_t {
+      HKEY root;
+      std::wstring prefix;  // "HKEY_USERS\<sid>" form for the undo journal
+    };
+
+    /**
+     * Registry root plus per-user prefix of the active console session user.
+     * The prefix is empty when running as the interactive user (HKCU).
+     */
+    std::optional<hive_t>
+    resolve_hive() {
+      const DWORD session_id = WTSGetActiveConsoleSessionId();
+      if (session_id == 0xFFFFFFFF) {
+        return std::nullopt;
+      }
+
+      LPWSTR user_buf = nullptr;
+      LPWSTR domain_buf = nullptr;
+      DWORD bytes = 0;
+      if (!WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, session_id, WTSUserName, &user_buf, &bytes)) {
+        BOOST_LOG(warning) << "touch_kb: WTSQuerySessionInformation(user) failed: " << GetLastError();
+        return std::nullopt;
+      }
+      WTSFreeMemory(user_buf);
+      // Re-query for the domain (each query returns its own buffer).
+      if (!WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, session_id, WTSDomainName, &domain_buf, &bytes)) {
+        BOOST_LOG(warning) << "touch_kb: WTSQuerySessionInformation(domain) failed: " << GetLastError();
+        return std::nullopt;
+      }
+      std::wstring domain = domain_buf;
+      WTSFreeMemory(domain_buf);
+
+      // Re-query the user name: the first buffer was freed.
+      if (!WTSQuerySessionInformationW(WTS_CURRENT_SERVER_HANDLE, session_id, WTSUserName, &user_buf, &bytes)) {
+        return std::nullopt;
+      }
+      std::wstring user = user_buf;
+      WTSFreeMemory(user_buf);
+
+      BYTE sid[SECURITY_MAX_SID_SIZE];
+      DWORD sid_size = sizeof(sid);
+      wchar_t referenced_domain[256];
+      DWORD ref_size = 256;
+      SID_NAME_USE use;
+      const std::wstring account = domain + L"\\" + user;
+      if (!LookupAccountNameW(nullptr, account.c_str(), sid, &sid_size,
+                              referenced_domain, &ref_size, &use)) {
+        BOOST_LOG(warning) << "touch_kb: LookupAccountName failed: " << GetLastError();
+        return std::nullopt;
+      }
+
+      LPWSTR sid_string = nullptr;
+      if (!ConvertSidToStringSidW(sid, &sid_string)) {
+        return std::nullopt;
+      }
+      hive_t hive { HKEY_USERS, std::wstring(L"HKEY_USERS\\") + sid_string };
+      LocalFree(sid_string);
+      return hive;
+    }
+
+    hive_t
+    get_hive() {
+      if (running_as_system()) {
+        auto resolved = resolve_hive();
+        if (resolved) {
+          return *resolved;
+        }
+        BOOST_LOG(warning) << "touch_kb: unable to resolve the console user hive";
+        return { HKEY_USERS, L"HKEY_USERS" };
+      }
+      return { HKEY_CURRENT_USER, L"HKEY_CURRENT_USER" };
+    }
+
+    std::filesystem::path
+    undo_path() {
+      return platf::appdata() / "touch_keyboard_undo.json";
+    }
+
+    std::optional<captured_value>
+    read_value(HKEY key, const wchar_t *name) {
+      DWORD type = 0;
+      DWORD data = 0;
+      DWORD size = sizeof(data);
+      const LONG rc = RegGetValueW(key, nullptr, name, RRF_RT_REG_DWORD, &type, &data, &size);
+      if (rc == ERROR_SUCCESS) {
+        return captured_value { true, data };
+      }
+      if (rc == ERROR_FILE_NOT_FOUND) {
+        return captured_value { false, 0 };
+      }
+      return std::nullopt;
+    }
+
+    bool
+    write_value(HKEY key, const wchar_t *name, DWORD value) {
+      return RegSetKeyValueW(key, nullptr, name, REG_DWORD, &value, sizeof(value)) == ERROR_SUCCESS;
+    }
+
+    bool
+    delete_value(HKEY key, const wchar_t *name) {
+      const LONG rc = RegDeleteKeyValueW(key, nullptr, name);
+      return rc == ERROR_SUCCESS || rc == ERROR_FILE_NOT_FOUND;
+    }
+
+  }  // namespace
+
+  bool
+  start_session(bool effective) {
+    if (!effective) {
+      return false;
+    }
+
+    const auto hive = get_hive();
+    std::wstring subkey = REG_SUBKEY;
+    const wchar_t sep = L'\\';
+    if (!hive.prefix.empty()) {
+      subkey = hive.prefix.substr(hive.prefix.find(sep) + 1) + sep + REG_SUBKEY;
+    }
+
+    HKEY key = nullptr;
+    if (RegCreateKeyExW(hive.root, subkey.c_str(), 0, nullptr, 0, KEY_SET_VALUE | KEY_QUERY_VALUE,
+                        nullptr, &key, nullptr) != ERROR_SUCCESS) {
+      BOOST_LOG(warning) << "touch_kb: cannot open [" << to_utf8(subkey) << "]: " << GetLastError();
+      return false;
+    }
+
+    nlohmann::json undo_keys = nlohmann::json::array();
+    bool all_written = true;
+    for (const auto &def : KEYS) {
+      const auto captured = read_value(key, def.name);
+      if (!captured) {
+        all_written = false;
+        continue;
+      }
+      undo_keys.push_back({
+        { "name", to_utf8(def.name) },
+        { "exists", captured->exists },
+        { "value", captured->value },
+      });
+      // Enum-style keys are only forced back to their desired value when the
+      // value was present before; a missing PreventTouchKeyboardAutoInvoke
+      // means the neutral default and creating it adds no information.
+      if (def.write_only_if_previously_present && !captured->exists) {
+        continue;
+      }
+      if (!write_value(key, def.name, def.desired)) {
+        all_written = false;
+      }
+    }
+    RegCloseKey(key);
+
+    try {
+      nlohmann::json undo = {
+        { "hive", to_utf8(hive.prefix) },
+        { "keys", undo_keys },
+      };
+      const auto path = undo_path();
+      std::filesystem::create_directories(path.parent_path());
+      std::ofstream undo_file(path.string());
+      undo_file << undo.dump(2);
+    }
+    catch (const std::exception &e) {
+      BOOST_LOG(warning) << "touch_kb: cannot persist the undo journal: " << e.what();
+      all_written = false;
+    }
+
+    BOOST_LOG(info) << "touch_kb: AutoInvoke key group applied (complete=" << all_written << ")";
+    return all_written;
+  }
+
+  void
+  end_session() {
+    const auto path = undo_path();
+    if (!std::filesystem::exists(path)) {
+      return;
+    }
+
+    nlohmann::json undo;
+    try {
+      std::ifstream undo_file(path.string());
+      undo = nlohmann::json::parse(undo_file);
+    }
+    catch (const std::exception &e) {
+      BOOST_LOG(warning) << "touch_kb: undo journal unreadable, leaving values as-is: " << e.what();
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      return;
+    }
+
+    const auto hive_id = to_wstring(undo.value("hive", ""));
+    // The journal stores "HKEY_USERS\<sid>" for elevated runs and
+    // "HKEY_CURRENT_USER" for interactive runs.
+    HKEY key = nullptr;
+    const wchar_t prefix[] = L"HKEY_USERS\\";
+    if (hive_id.rfind(prefix, 0) == 0) {
+      const std::wstring sid_prefix = hive_id.substr(wcslen(prefix));
+      RegOpenKeyExW(HKEY_USERS, (sid_prefix + L"\\" + REG_SUBKEY).c_str(), 0, KEY_SET_VALUE, &key);
+    }
+    else if (hive_id == L"HKEY_CURRENT_USER") {
+      RegOpenKeyExW(HKEY_CURRENT_USER, REG_SUBKEY, 0, KEY_SET_VALUE, &key);
+    }
+    if (!key) {
+      BOOST_LOG(warning) << "touch_kb: cannot reopen the registry key for restore";
+      return;
+    }
+
+    if (undo.contains("keys")) {
+      for (const auto &entry : undo["keys"]) {
+        const auto name = to_wstring(entry.value("name", ""));
+        if (name.empty() || !key) {
+          continue;
+        }
+        if (entry.value("exists", false)) {
+          const auto value = (DWORD) entry.value("value", 0);
+          write_value(key, name.c_str(), value);
+        }
+        else {
+          delete_value(key, name.c_str());
+        }
+      }
+    }
+    if (key) {
+      RegCloseKey(key);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    BOOST_LOG(info) << "touch_kb: AutoInvoke key group restored";
+  }
+
+}  // namespace touch_kb

--- a/src/platform/windows/virtual_touchscreen_session.cpp
+++ b/src/platform/windows/virtual_touchscreen_session.cpp
@@ -1,0 +1,222 @@
+/**
+ * @file src/platform/windows/virtual_touchscreen_session.cpp
+ * @brief Windows implementation: device + loopback bridge + usbip attach.
+ *
+ * Attach requires elevation to open the VHCI device interface; the Sunshine
+ * service already runs as SYSTEM so no extra prompt is needed in-stream.
+ * On detach the VHCI removes the emulated device automatically when the
+ * control connection drops.
+ */
+
+#include "src/virtual_touchscreen_session.h"
+
+#include "src/logging.h"
+#include "src/remote_usb/loopback_usbip_bridge.h"
+#include "src/remote_usb/virtual_touchscreen_device.h"
+
+#include <Windows.h>
+
+#include <boost/system/error_code.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+
+
+namespace vts {
+
+  namespace {
+
+    namespace rusb = remote_usb;
+
+    struct session_state_t {
+      std::mutex mutex;
+
+      // Construction order matters: the device outlives the bridge (the
+      // bridge's reply hook calls into the device), and both are addressed
+      // through this stable allocation for the whole session.
+      rusb::virtual_touchscreen_device device;
+      rusb::loopback_usbip_bridge bridge;
+      std::wstring usbip_executable;
+      std::wstring busid;
+      std::map<std::uint8_t, rusb::touchscreen_contact> active;
+      bool imported { false };
+
+      explicit session_state_t(rusb::virtual_touchscreen_device::config cfg) :
+          device(cfg) {}
+    };
+
+    std::mutex state_mutex;
+    std::unique_ptr<session_state_t> state;
+
+    std::wstring
+    to_wide(const std::string &utf8) {
+      if (utf8.empty()) {
+        return {};
+      }
+      int size = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), (int) utf8.size(), nullptr, 0);
+      std::wstring out(size, L'\0');
+      MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), (int) utf8.size(), out.data(), size);
+      return out;
+    }
+
+    /** Run usbip.exe with output captured; killed after 20 s on hang. */
+    std::string
+    run_usbip(const std::wstring &cmdline) {
+      SECURITY_ATTRIBUTES sa = { sizeof(sa), nullptr, TRUE };
+      HANDLE read_end = nullptr, write_end = nullptr;
+      if (!CreatePipe(&read_end, &write_end, &sa, 0)) {
+        return "pipe failed";
+      }
+      SetHandleInformation(read_end, HANDLE_FLAG_INHERIT, 0);
+      STARTUPINFOW si = {};
+      si.cb = sizeof(si);
+      si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+      si.wShowWindow = SW_HIDE;
+      si.hStdOutput = write_end;
+      si.hStdError = write_end;
+      PROCESS_INFORMATION pi = {};
+      std::vector<wchar_t> mutable_cmd(cmdline.begin(), cmdline.end());
+      mutable_cmd.push_back(L'\0');
+      if (!CreateProcessW(nullptr, mutable_cmd.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW,
+                          nullptr, nullptr, &si, &pi)) {
+        CloseHandle(read_end);
+        CloseHandle(write_end);
+        return "create process failed: " + std::to_string(GetLastError());
+      }
+      CloseHandle(write_end);
+      std::string out;
+      std::thread reader([&]() {
+        char buf[512];
+        DWORD read = 0;
+        while (ReadFile(read_end, buf, sizeof(buf), &read, nullptr) && read != 0) {
+          out.append(buf, read);
+        }
+      });
+      const bool timed_out = WaitForSingleObject(pi.hProcess, 20000) == WAIT_TIMEOUT;
+      if (timed_out) {
+        TerminateProcess(pi.hProcess, 1);
+        WaitForSingleObject(pi.hProcess, 3000);
+      }
+      reader.join();
+      DWORD code = 0;
+      GetExitCodeProcess(pi.hProcess, &code);
+      CloseHandle(read_end);
+      CloseHandle(pi.hProcess);
+      CloseHandle(pi.hThread);
+      return out + (timed_out ? " [timed out]" : " [exit " + std::to_string(code) + "]");
+    }
+
+  }  // namespace
+
+  bool
+  start(const session_config &config) {
+    std::lock_guard<std::mutex> state_lock(state_mutex);
+    stop();
+
+    rusb::virtual_touchscreen_device::config cfg;
+    cfg.width_px = config.width_px;
+    cfg.height_px = config.height_px;
+
+    state = std::make_unique<session_state_t>(cfg);
+    auto *raw = state.get();  // stable for the whole session
+    raw->usbip_executable = config.usbip_executable.empty()
+                              ? L"usbip.exe"
+                              : to_wide(config.usbip_executable);
+    raw->busid.clear();
+
+    auto callbacks = rusb::callbacks {};
+    // The device object address is stable; the bridge serialises requests.
+    callbacks.on_request = [raw](std::vector<std::uint8_t> pdu) {
+      return raw->device.handle_request(std::move(pdu));
+    };
+    callbacks.on_imported = []() {
+      BOOST_LOG(info) << "vts: VHCI imported the virtual touchscreen";
+    };
+    callbacks.on_closed = [](rusb::close_reason reason) {
+      BOOST_LOG(info) << "vts: bridge closed (" << (int) reason << ")";
+    };
+
+    boost::system::error_code ec;
+    auto endpoint = raw->bridge.start(raw->device.info(), std::move(callbacks), ec);
+    if (!endpoint) {
+      BOOST_LOG(warning) << "vts: bridge start failed: " << ec.message();
+      state.reset();
+      return false;
+    }
+    raw->device.set_send_reply([raw](std::vector<std::uint8_t> wire) {
+      raw->bridge.send_reply(std::move(wire));
+    });
+
+    std::wstring cmd = L"\"" + raw->usbip_executable + L"\" --tcp-port " +
+                       std::to_wstring(endpoint->port) + L" attach --remote " +
+                       to_wide(endpoint->address) + L" --bus-id " + to_wide(endpoint->busid) +
+                       L" --terse";
+    const std::string attach_out = run_usbip(cmd);
+    BOOST_LOG(info) << "vts: usbip attach: " << attach_out;
+
+    for (int i = 0; i < 60 && !raw->device.imported(); ++i) {
+      Sleep(100);
+    }
+    if (!raw->device.imported()) {
+      BOOST_LOG(warning) << "vts: device was not imported; tearing down";
+      raw->bridge.stop();
+      state.reset();
+      return false;
+    }
+
+    BOOST_LOG(info) << "vts: virtual touchscreen attached (" << config.width_px << "x"
+                    << config.height_px << ")";
+    return true;
+  }
+
+  void
+  update_contact(std::uint8_t contact_id, std::uint16_t x, std::uint16_t y, bool tip) {
+    std::lock_guard<std::mutex> lock(state_mutex);
+    if (!state) {
+      return;
+    }
+    std::lock_guard<std::mutex> device_lock(state->mutex);
+    if (tip) {
+      state->active[contact_id] = rusb::touchscreen_contact {
+        contact_id, x, y, 0, true, true
+      };
+    }
+    else {
+      state->active.erase(contact_id);
+    }
+    std::vector<rusb::touchscreen_contact> contacts;
+    contacts.reserve(state->active.size());
+    for (const auto &[id, c] : state->active) {
+      contacts.push_back(c);
+    }
+    state->device.update_contacts(contacts);
+  }
+
+  void
+  lift_contact(std::uint8_t contact_id) {
+    update_contact(contact_id, 0, 0, false);
+  }
+
+  void
+  stop() {
+    std::lock_guard<std::mutex> state_lock(state_mutex);
+    if (!state) {
+      return;
+    }
+    state->bridge.stop();
+    BOOST_LOG(info) << "vts: virtual touchscreen detached";
+    state.reset();
+  }
+
+}  // namespace vts

--- a/src/remote_usb/virtual_touchscreen_device.cpp
+++ b/src/remote_usb/virtual_touchscreen_device.cpp
@@ -1,6 +1,6 @@
 /**
  * @file src/remote_usb/virtual_touchscreen_device.cpp
- * @brief Implementation of the virtual USB multi-touch touchscreen.
+ * @brief Implementation of the virtual USB single-touch touchscreen.
  *
  * USB/IP PDU headers are big-endian (network order); USB descriptor/report
  * payloads are little-endian per the USB specification.
@@ -30,8 +30,15 @@ namespace {
   constexpr std::uint32_t kRetUnlink = 0x0004;
 
   constexpr std::size_t kPduHeaderSize = 48;
+  constexpr std::size_t kOpCommonSize = 8;
+  constexpr std::size_t kDeviceBlockSize = 312;
+  constexpr std::size_t kInterfaceBlockSize = 4;
 
   constexpr std::int32_t kStallEpipe = -32;  // -EPIPE, usbip status convention
+
+  // Frames buffered while the guest is not polling; oldest frames are dropped
+  // beyond this so an unattached device cannot grow without bound.
+  constexpr std::size_t kMaxQueuedReports = 64;
 
   void
   put_u16le(std::vector<std::uint8_t> &out, std::size_t offset, std::uint16_t value) {
@@ -215,17 +222,6 @@ namespace {
     return finger.tip || finger.in_range;
   }
 
-  std::size_t
-  live_finger_count(const std::vector<report_finger> &fingers) {
-    std::size_t count = 0;
-    for (const auto &finger : fingers) {
-      if (finger_is_live(finger)) {
-        ++count;
-      }
-    }
-    return count;
-  }
-
   std::vector<std::uint8_t>
   build_input_report(const std::vector<report_finger> &fingers, std::uint8_t slots) {
     (void) slots;
@@ -282,13 +278,12 @@ struct virtual_touchscreen_device::impl {
   std::vector<std::uint8_t> config_descriptor;
   std::size_t interrupt_packet_size { 64 };
 
-  // Pending interrupt-IN submits awaiting data, in arrival order.
+  /** Addressing of one interrupt-IN submit, echoed back in RET_SUBMIT. */
   struct pending_submit {
     std::uint32_t seqnum;
     std::uint32_t devid;
     std::uint32_t endpoint;
   };
-  std::vector<pending_submit> pending_in;
 
   // Frames queued for delivery (lift transitions, then the live snapshot).
   std::vector<std::vector<std::uint8_t>> queued_reports;
@@ -346,6 +341,26 @@ struct virtual_touchscreen_device::impl {
     config_descriptor.push_back(0x04);    // bInterval: 1 ms @ high speed
   }
 
+  /** Bounded FIFO push; drops the oldest frame once the cap is reached. */
+  void
+  push_report_locked(std::vector<std::uint8_t> report) {
+    if (queued_reports.size() >= kMaxQueuedReports) {
+      queued_reports.erase(queued_reports.begin());
+    }
+    queued_reports.push_back(std::move(report));
+  }
+
+  /** Clears all per-connection state so a new client starts clean. */
+  void
+  reset_locked() {
+    imported_flag = false;
+    in_submit_count = 0;
+    queued_reports.clear();
+    active_fingers.clear();
+    last_mouse_report.clear();
+  }
+
+  /** 312-byte `usbip_usb_device` block (shared by DEVLIST and IMPORT). */
   void
   append_device_block(std::vector<std::uint8_t> &out) const {
     auto path_str = padded_string(path, 256);
@@ -367,7 +382,11 @@ struct virtual_touchscreen_device::impl {
     out.push_back(0x01);                                   // bConfigurationValue
     out.push_back(0x01);                                   // bNumConfigurations
     out.push_back(0x01);                                   // bNumInterfaces
+  }
 
+  /** 4-byte `usbip_usb_interface` block (DEVLIST only). */
+  void
+  append_interface_block(std::vector<std::uint8_t> &out) const {
     out.push_back(0x03);                                   // bInterfaceClass: HID
     out.push_back(0x00);                                   // bInterfaceSubClass
     out.push_back(0x00);                                   // bInterfaceProtocol
@@ -443,18 +462,18 @@ struct virtual_touchscreen_device::impl {
 
     if (class_request) {
       if (dir_in) {
-        // GET_REPORT.  The feature report (Contact Count Maximum) has its own
-        // layout: report id + one byte.  Answering it with the input layout
-        // makes HIDCLASS reject the digitizer during initialisation.
+        // GET_REPORT.  Neither descriptor declares Feature/Output reports, so
+        // only INPUT is answerable; anything else stalls.
         const std::uint8_t report_type = static_cast<std::uint8_t>(wValue >> 8);
+        if (report_type != 0x01) {
+          reply_control_locked(seqnum, nullptr, 0, kStallEpipe);
+          return;
+        }
         std::vector<std::uint8_t> report;
-        if (report_type == 0x03) {  // FEATURE
-          report = { 0x02, 0x0A };  // Contact Count Maximum
+        if (cfg.mouse_mode) {  // last mouse report
+          report = last_mouse_report.empty() ? build_mouse_report(0, 0, 0) : last_mouse_report;
         }
-        else if (cfg.mouse_mode) {  // INPUT: last mouse report
-          report = last_mouse_report;
-        }
-        else {                      // INPUT: idle-touch snapshot
+        else {                 // idle-touch snapshot
           report = build_input_report(active_fingers, cfg.finger_slots);
         }
         const std::size_t size = std::min<std::size_t>(report.size(), wLength);
@@ -535,28 +554,6 @@ struct virtual_touchscreen_device::impl {
     const std::size_t size = std::min<std::size_t>(descriptor.size(), wLength);
     reply_control_locked(seqnum, descriptor.data(), size, 0);
   }
-
-  void
-  deliver_locked() {
-    while (!pending_in.empty()) {
-      if (!queued_reports.empty()) {
-        auto report = std::move(queued_reports.front());
-        queued_reports.erase(queued_reports.begin());
-        auto submit = pending_in.front();
-        pending_in.erase(pending_in.begin());
-        reply_submit_locked(submit, 0, report.data(), report.size());
-        continue;
-      }
-      if (!cfg.mouse_mode && !active_fingers.empty()) {
-        auto report = build_input_report(active_fingers, cfg.finger_slots);
-        auto submit = pending_in.front();
-        pending_in.erase(pending_in.begin());
-        reply_submit_locked(submit, 0, report.data(), report.size());
-        continue;
-      }
-      break;
-    }
-  }
 };
 
 virtual_touchscreen_device::virtual_touchscreen_device(config cfg) :
@@ -589,7 +586,14 @@ virtual_touchscreen_device::info() const {
 
 void
 virtual_touchscreen_device::set_send_reply(std::function<void(std::vector<std::uint8_t>)> send) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->send = std::move(send);
+}
+
+void
+virtual_touchscreen_device::reset() {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  impl_->reset_locked();
 }
 
 bool
@@ -614,15 +618,18 @@ virtual_touchscreen_device::handle_request(const std::vector<std::uint8_t> &pdu)
   std::lock_guard<std::mutex> lock(impl_->mutex);
 
   if (code == kOpReqDevlist) {
-    if (pdu.size() != 8) {
+    if (pdu.size() != kOpCommonSize) {
       return false;
     }
+    // op_common + ndev + usbip_usb_device + usbip_usb_interface[bNumInterfaces]
     std::vector<std::uint8_t> wire;
-    wire.reserve(12 + 304);
+    wire.reserve(kOpCommonSize + 4 + kDeviceBlockSize + kInterfaceBlockSize);
     append_u16be(wire, kUsbipVersion);
     append_u16be(wire, kRepDevlist);
     append_u32be(wire, 0);  // status: ok
+    append_u32be(wire, 1);  // ndev
     impl_->append_device_block(wire);
+    impl_->append_interface_block(wire);
     if (impl_->send) {
       impl_->send(std::move(wire));
     }
@@ -630,13 +637,14 @@ virtual_touchscreen_device::handle_request(const std::vector<std::uint8_t> &pdu)
   }
 
   if (code == kOpReqImport) {
-    if (pdu.size() < 40) {
+    if (pdu.size() < kOpCommonSize + 32) {
       return false;
     }
     const auto requested = padded_string(impl_->busid, 32);
-    const bool match = std::equal(requested.begin(), requested.end(), pdu.begin() + 8);
+    const bool match = std::equal(requested.begin(), requested.end(), pdu.begin() + kOpCommonSize);
+    // op_common + usbip_usb_device (no interface block on IMPORT)
     std::vector<std::uint8_t> wire;
-    wire.reserve(12 + 304);
+    wire.reserve(kOpCommonSize + kDeviceBlockSize);
     append_u16be(wire, kUsbipVersion);
     append_u16be(wire, kRepImport);
     append_u32be(wire, match ? 0 : static_cast<std::uint32_t>(-2));  // -ENODEV on mismatch
@@ -714,14 +722,9 @@ virtual_touchscreen_device::handle_request(const std::vector<std::uint8_t> &pdu)
     if (pdu.size() < kPduHeaderSize) {
       return false;
     }
+    // Every submit is answered synchronously, so nothing is ever parked and
+    // there is nothing to cancel; acknowledge the unlink as a no-op.
     const std::uint32_t seqnum = get_u32be(pdu.data() + 4);
-    const std::uint32_t unlink_seqnum = get_u32be(pdu.data() + 20);
-    auto &pending = impl_->pending_in;
-    const auto found = std::find_if(pending.begin(), pending.end(),
-      [unlink_seqnum](const impl::pending_submit &s) { return s.seqnum == unlink_seqnum; });
-    if (found != pending.end()) {
-      pending.erase(found);
-    }
     impl_->reply_unlink_locked(seqnum, 0);
     return true;
   }
@@ -733,8 +736,7 @@ void
 virtual_touchscreen_device::update_mouse(std::int8_t dx, std::int8_t dy, std::uint8_t buttons) {
   std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->last_mouse_report = build_mouse_report(dx, dy, buttons);
-  impl_->queued_reports.push_back(impl_->last_mouse_report);
-  impl_->deliver_locked();
+  impl_->push_report_locked(impl_->last_mouse_report);
 }
 
 void
@@ -755,7 +757,7 @@ virtual_touchscreen_device::update_contacts(const std::vector<touchscreen_contac
   }
 
   // Contacts that disappeared since the last update emit one explicit lift
-  // frame (tip=0, in_range=0) so the multi-touch stack releases them cleanly.
+  // frame (tip=0, in_range=0) so the touch stack releases them cleanly.
   std::vector<report_finger> lift_frame = impl_->active_fingers;
   bool lift_needed = false;
   for (auto &finger : lift_frame) {
@@ -767,7 +769,7 @@ virtual_touchscreen_device::update_contacts(const std::vector<touchscreen_contac
     }
   }
   if (lift_needed) {
-    impl_->queued_reports.push_back(build_input_report(lift_frame, impl_->cfg.finger_slots));
+    impl_->push_report_locked(build_input_report(lift_frame, impl_->cfg.finger_slots));
   }
 
   std::vector<report_finger> snapshot;
@@ -777,7 +779,6 @@ virtual_touchscreen_device::update_contacts(const std::vector<touchscreen_contac
     snapshot.push_back(finger);
   }
   impl_->active_fingers = std::move(snapshot);
-  impl_->deliver_locked();
 }
 
 }  // namespace remote_usb

--- a/src/remote_usb/virtual_touchscreen_device.cpp
+++ b/src/remote_usb/virtual_touchscreen_device.cpp
@@ -394,14 +394,14 @@ struct virtual_touchscreen_device::impl {
   }
 
   void
-  reply_submit_locked(const pending_submit &submit, std::int32_t status,
-                      const std::uint8_t *data, std::size_t size) {
+  reply_submit_locked(std::uint32_t seqnum, std::uint32_t devid, std::uint32_t endpoint,
+                      std::int32_t status, const std::uint8_t *data, std::size_t size) {
     std::vector<std::uint8_t> wire(kPduHeaderSize + size, 0);
     put_u32be(wire.data(), 0, kRetSubmit);
-    put_u32be(wire.data(), 4, submit.seqnum);
-    put_u32be(wire.data(), 8, submit.devid);
+    put_u32be(wire.data(), 4, seqnum);
+    put_u32be(wire.data(), 8, devid);
     put_u32be(wire.data(), 12, 1);  // direction: IN
-    put_u32be(wire.data(), 16, submit.endpoint);
+    put_u32be(wire.data(), 16, endpoint);
     put_i32be(wire.data(), 20, status);
     put_i32be(wire.data(), 24, static_cast<std::int32_t>(size));
     put_i32be(wire.data(), 32, -1);  // number_of_packets
@@ -686,17 +686,14 @@ virtual_touchscreen_device::handle_request(const std::vector<std::uint8_t> &pdu)
       if (!impl_->queued_reports.empty()) {
         auto report = std::move(impl_->queued_reports.front());
         impl_->queued_reports.erase(impl_->queued_reports.begin());
-        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
-                                   report.data(), report.size());
+        impl_->reply_submit_locked(seqnum, devid, endpoint, 0, report.data(), report.size());
       }
       else if (!impl_->cfg.mouse_mode && !impl_->active_fingers.empty()) {
         auto report = build_input_report(impl_->active_fingers, impl_->cfg.finger_slots);
-        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
-                                   report.data(), report.size());
+        impl_->reply_submit_locked(seqnum, devid, endpoint, 0, report.data(), report.size());
       }
       else {
-        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
-                                   nullptr, 0);
+        impl_->reply_submit_locked(seqnum, devid, endpoint, 0, nullptr, 0);
       }
       return true;
     }
@@ -757,19 +754,19 @@ virtual_touchscreen_device::update_contacts(const std::vector<touchscreen_contac
   }
 
   // Contacts that disappeared since the last update emit one explicit lift
-  // frame (tip=0, in_range=0) so the touch stack releases them cleanly.
-  std::vector<report_finger> lift_frame = impl_->active_fingers;
-  bool lift_needed = false;
-  for (auto &finger : lift_frame) {
+  // frame (tip=0, in_range=0) so the touch stack releases them cleanly.  The
+  // lift frame carries only the released contacts: build_input_report()
+  // prefers a live finger, so mixing would swallow the lift.
+  std::vector<report_finger> lifted_only;
+  for (const auto &finger : impl_->active_fingers) {
     if (finger_is_live(finger) && !next.contains(finger.contact_id)) {
-      finger.tip = false;
-      finger.in_range = false;
-      finger.pressure = 0;
-      lift_needed = true;
+      lifted_only.push_back(report_finger {
+        finger.contact_id, finger.x, finger.y, 0, false, false,
+      });
     }
   }
-  if (lift_needed) {
-    impl_->push_report_locked(build_input_report(lift_frame, impl_->cfg.finger_slots));
+  if (!lifted_only.empty()) {
+    impl_->push_report_locked(build_input_report(lifted_only, impl_->cfg.finger_slots));
   }
 
   std::vector<report_finger> snapshot;

--- a/src/remote_usb/virtual_touchscreen_device.cpp
+++ b/src/remote_usb/virtual_touchscreen_device.cpp
@@ -1,0 +1,783 @@
+/**
+ * @file src/remote_usb/virtual_touchscreen_device.cpp
+ * @brief Implementation of the virtual USB multi-touch touchscreen.
+ *
+ * USB/IP PDU headers are big-endian (network order); USB descriptor/report
+ * payloads are little-endian per the USB specification.
+ */
+
+#include "virtual_touchscreen_device.h"
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <stdexcept>
+
+namespace remote_usb {
+
+namespace {
+
+  constexpr std::uint16_t kUsbipVersion = 0x0111;
+
+  constexpr std::uint16_t kOpReqDevlist = 0x8005;
+  constexpr std::uint16_t kRepDevlist = 0x0005;
+  constexpr std::uint16_t kOpReqImport = 0x8003;
+  constexpr std::uint16_t kRepImport = 0x0003;
+
+  constexpr std::uint32_t kCmdSubmit = 0x0001;
+  constexpr std::uint32_t kCmdUnlink = 0x0002;
+  constexpr std::uint32_t kRetSubmit = 0x0003;
+  constexpr std::uint32_t kRetUnlink = 0x0004;
+
+  constexpr std::size_t kPduHeaderSize = 48;
+
+  constexpr std::int32_t kStallEpipe = -32;  // -EPIPE, usbip status convention
+
+  void
+  put_u16le(std::vector<std::uint8_t> &out, std::size_t offset, std::uint16_t value) {
+    out[offset] = static_cast<std::uint8_t>(value);
+    out[offset + 1] = static_cast<std::uint8_t>(value >> 8);
+  }
+
+  void
+  put_u32be(std::uint8_t *out, std::size_t offset, std::uint32_t value) {
+    out[offset] = static_cast<std::uint8_t>(value >> 24);
+    out[offset + 1] = static_cast<std::uint8_t>(value >> 16);
+    out[offset + 2] = static_cast<std::uint8_t>(value >> 8);
+    out[offset + 3] = static_cast<std::uint8_t>(value);
+  }
+
+  void
+  put_i32be(std::uint8_t *out, std::size_t offset, std::int32_t value) {
+    put_u32be(out, offset, static_cast<std::uint32_t>(value));
+  }
+
+  void
+  append_u16le(std::vector<std::uint8_t> &out, std::uint16_t value) {
+    out.push_back(static_cast<std::uint8_t>(value));
+    out.push_back(static_cast<std::uint8_t>(value >> 8));
+  }
+
+  void
+  append_u16be(std::vector<std::uint8_t> &out, std::uint16_t value) {
+    out.push_back(static_cast<std::uint8_t>(value >> 8));
+    out.push_back(static_cast<std::uint8_t>(value));
+  }
+
+  void
+  append_u32be(std::vector<std::uint8_t> &out, std::uint32_t value) {
+    out.push_back(static_cast<std::uint8_t>(value >> 24));
+    out.push_back(static_cast<std::uint8_t>(value >> 16));
+    out.push_back(static_cast<std::uint8_t>(value >> 8));
+    out.push_back(static_cast<std::uint8_t>(value));
+  }
+
+  std::uint16_t
+  get_u16be(const std::uint8_t *in) {
+    return static_cast<std::uint16_t>((static_cast<std::uint16_t>(in[0]) << 8) | in[1]);
+  }
+
+  std::uint16_t
+  get_u16le(const std::uint8_t *in) {
+    return static_cast<std::uint16_t>(in[0] | (in[1] << 8));
+  }
+
+  std::uint32_t
+  get_u32be(const std::uint8_t *in) {
+    return (static_cast<std::uint32_t>(in[0]) << 24) |
+           (static_cast<std::uint32_t>(in[1]) << 16) |
+           (static_cast<std::uint32_t>(in[2]) << 8) |
+           static_cast<std::uint32_t>(in[3]);
+  }
+
+  /** Fixed-size, NUL-padded USB/IP wire string. */
+  std::vector<std::uint8_t>
+  padded_string(const std::string &value, std::size_t size) {
+    std::vector<std::uint8_t> out(size, 0);
+    std::memcpy(out.data(), value.data(), std::min(value.size(), size));
+    return out;
+  }
+
+  std::vector<std::uint8_t>
+  hid_utf16_string(const std::string &value) {
+    std::vector<std::uint8_t> out;
+    out.push_back(static_cast<std::uint8_t>((value.size() * 2 + 2) & 0xFF));
+    out.push_back(0x03);  // bDescriptorType = STRING
+    for (char c : value) {
+      append_u16le(out, static_cast<std::uint16_t>(static_cast<unsigned char>(c)));
+    }
+    return out;
+  }
+
+  /**
+   * Minimal 3-byte boot-style mouse report descriptor: buttons(1B) + dx + dy.
+   */
+  std::vector<std::uint8_t>
+  build_mouse_report_descriptor() {
+    std::vector<std::uint8_t> d;
+    d.insert(d.end(), { 0x05, 0x01 });  // Usage Page (Generic Desktop)
+    d.insert(d.end(), { 0x09, 0x02 });  // Usage (Mouse)
+    d.insert(d.end(), { 0xA1, 0x01 });  // Collection (Application)
+    d.insert(d.end(), { 0x09, 0x01 });  //   Usage (Pointer)
+    d.insert(d.end(), { 0xA1, 0x00 });  //   Collection (Physical)
+    d.insert(d.end(), { 0x05, 0x09 });  //     Usage Page (Buttons)
+    d.insert(d.end(), { 0x19, 0x01 });  //     Usage Min (1)
+    d.insert(d.end(), { 0x29, 0x03 });  //     Usage Max (3)
+    d.insert(d.end(), { 0x15, 0x00 });  //     Logical Min (0)
+    d.insert(d.end(), { 0x25, 0x01 });  //     Logical Max (1)
+    d.insert(d.end(), { 0x75, 0x01 });  //     Report Size (1)
+    d.insert(d.end(), { 0x95, 0x03 });  //     Report Count (3)
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0x75, 0x01 });  //     Report Size (1)
+    d.insert(d.end(), { 0x95, 0x05 });  //     Report Count (5)
+    d.insert(d.end(), { 0x81, 0x03 });  //     Input (Const) padding
+    d.insert(d.end(), { 0x05, 0x01 });  //     Usage Page (Generic Desktop)
+    d.insert(d.end(), { 0x09, 0x30 });  //     Usage (X)
+    d.insert(d.end(), { 0x09, 0x31 });  //     Usage (Y)
+    d.insert(d.end(), { 0x15, 0x81 });  //     Logical Min (-127)
+    d.insert(d.end(), { 0x25, 0x7F });  //     Logical Max (127)
+    d.insert(d.end(), { 0x75, 0x08 });  //     Report Size (8)
+    d.insert(d.end(), { 0x95, 0x02 });  //     Report Count (2)
+    d.insert(d.end(), { 0x81, 0x06 });  //     Input (Data,Var,Rel)
+    d.insert(d.end(), { 0xC0 });        //   End Collection
+    d.insert(d.end(), { 0xC0 });        // End Collection
+    return d;
+  }
+
+  /** 3-byte mouse input report: buttons, dx, dy. */
+  std::vector<std::uint8_t>
+  build_mouse_report(std::int8_t dx, std::int8_t dy, std::uint8_t buttons) {
+    return { buttons, static_cast<std::uint8_t>(dx), static_cast<std::uint8_t>(dy) };
+  }
+
+  /**
+   * Minimal single-touch touchscreen descriptor in the style of decades-old
+   * USB resistive touch controllers (eGalax et al): Tip/In-Range + 16-bit
+   * absolute X/Y, no report id, no contact id.  5-byte input reports.
+   */
+  std::vector<std::uint8_t>
+  build_report_descriptor(std::uint16_t width_px, std::uint16_t height_px, std::uint8_t slots) {
+    (void) slots;
+    const std::uint16_t x_max = static_cast<std::uint16_t>(width_px - 1);
+    const std::uint16_t y_max = static_cast<std::uint16_t>(height_px - 1);
+
+    std::vector<std::uint8_t> d;
+    d.reserve(96);
+
+    d.insert(d.end(), { 0x05, 0x0D });  // Usage Page (Digitizers)
+    d.insert(d.end(), { 0x09, 0x04 });  // Usage (Touch Screen)
+    d.insert(d.end(), { 0xA1, 0x01 });  // Collection (Application)
+    d.insert(d.end(), { 0x09, 0x22 });  //   Usage (Finger)
+    d.insert(d.end(), { 0xA1, 0x02 });  //   Collection (Logical)
+    d.insert(d.end(), { 0x09, 0x42 });  //     Usage (Tip Switch)
+    d.insert(d.end(), { 0x15, 0x00 });  //     Logical Min (0)
+    d.insert(d.end(), { 0x25, 0x01 });  //     Logical Max (1)
+    d.insert(d.end(), { 0x75, 0x01 });  //     Report Size (1)
+    d.insert(d.end(), { 0x95, 0x01 });  //     Report Count (1)
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0x09, 0x32 });  //     Usage (In Range)
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0x09, 0x47 });  //     Usage (Confidence)
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0x95, 0x05 });  //     Report Count (5)
+    d.insert(d.end(), { 0x81, 0x03 });  //     Input (Const) padding
+    d.insert(d.end(), { 0x05, 0x01 });  //     Usage Page (Generic Desktop)
+    d.insert(d.end(), { 0x09, 0x30 });  //     Usage (X)
+    d.insert(d.end(), { 0x15, 0x00 });  //     Logical Min (0)
+    d.insert(d.end(), { 0x26, static_cast<std::uint8_t>(x_max & 0xFF),
+                        static_cast<std::uint8_t>(x_max >> 8) });  // Logical Max
+    d.insert(d.end(), { 0x75, 0x10 });  //     Report Size (16)
+    d.insert(d.end(), { 0x95, 0x01 });  //     Report Count (1)
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0x09, 0x31 });  //     Usage (Y)
+    d.insert(d.end(), { 0x15, 0x00 });  //     Logical Min (0)
+    d.insert(d.end(), { 0x26, static_cast<std::uint8_t>(y_max & 0xFF),
+                        static_cast<std::uint8_t>(y_max >> 8) });  // Logical Max
+    d.insert(d.end(), { 0x81, 0x02 });  //     Input (Data,Var,Abs)
+    d.insert(d.end(), { 0xC0 });        //   End Collection
+    d.insert(d.end(), { 0xC0 });        // End Collection
+
+    return d;
+  }
+
+  /** One live finger slot as it appears in the input report. */
+  struct report_finger {
+    std::uint8_t contact_id { 0 };
+    std::uint16_t x { 0 };
+    std::uint16_t y { 0 };
+    std::uint8_t pressure { 0 };
+    bool tip { false };
+    bool in_range { false };
+  };
+
+  bool
+  finger_is_live(const report_finger &finger) {
+    return finger.tip || finger.in_range;
+  }
+
+  std::size_t
+  live_finger_count(const std::vector<report_finger> &fingers) {
+    std::size_t count = 0;
+    for (const auto &finger : fingers) {
+      if (finger_is_live(finger)) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  std::vector<std::uint8_t>
+  build_input_report(const std::vector<report_finger> &fingers, std::uint8_t slots) {
+    (void) slots;
+    // 5-byte report: status byte, X (LE16), Y (LE16).  Report the first
+    // live finger, or the lifted finger during a release frame.
+    std::size_t picked = fingers.size();
+    for (std::size_t i = 0; i < fingers.size(); ++i) {
+      if (finger_is_live(fingers[i])) {
+        picked = i;
+        break;
+      }
+    }
+    if (picked == fingers.size() && !fingers.empty()) {
+      picked = 0;  // release frame: first finger carries the lift
+    }
+
+    std::uint8_t bits = 0;
+    std::uint16_t x = 0, y = 0;
+    if (picked < fingers.size()) {
+      const auto &finger = fingers[picked];
+      if (finger.tip) {
+        bits |= 0x01;
+      }
+      if (finger.in_range) {
+        bits |= 0x02;
+        bits |= 0x04;  // confidence: valid touch
+      }
+      x = finger.x;
+      y = finger.y;
+    }
+    std::vector<std::uint8_t> report;
+    report.reserve(5);
+    report.push_back(bits);
+    append_u16le(report, x);
+    append_u16le(report, y);
+    return report;
+  }
+
+
+}  // namespace
+
+struct virtual_touchscreen_device::impl {
+  config cfg;
+  std::function<void(std::vector<std::uint8_t>)> send;
+  std::string busid;
+  std::string path;
+
+  // State shared between the bridge I/O thread and the touch producer.
+  std::mutex mutex;
+  bool imported_flag { false };
+  unsigned in_submit_count { 0 };
+
+  std::vector<std::uint8_t> report_descriptor;
+  std::vector<std::uint8_t> config_descriptor;
+  std::size_t interrupt_packet_size { 64 };
+
+  // Pending interrupt-IN submits awaiting data, in arrival order.
+  struct pending_submit {
+    std::uint32_t seqnum;
+    std::uint32_t devid;
+    std::uint32_t endpoint;
+  };
+  std::vector<pending_submit> pending_in;
+
+  // Frames queued for delivery (lift transitions, then the live snapshot).
+  std::vector<std::vector<std::uint8_t>> queued_reports;
+  // Live contact snapshot; re-sent for every poll while contacts stay down.
+  std::vector<report_finger> active_fingers;
+  std::vector<std::uint8_t> last_mouse_report;
+
+  explicit impl(config config_in) :
+      cfg(std::move(config_in)) {
+    report_descriptor = cfg.mouse_mode
+                          ? build_mouse_report_descriptor()
+                          : build_report_descriptor(cfg.width_px, cfg.height_px, cfg.finger_slots);
+    build_config_descriptor();
+  }
+
+  void
+  build_config_descriptor() {
+    const std::size_t report_size = 5;  // minimal single-touch report
+    interrupt_packet_size = report_size;
+    const std::uint16_t packet_size = static_cast<std::uint16_t>(
+      std::max<std::size_t>(report_size, 64));
+
+    config_descriptor.clear();
+    config_descriptor.reserve(34);
+
+    // CONFIGURATION
+    config_descriptor.insert(config_descriptor.end(), { 0x09, 0x02 });
+    append_u16le(config_descriptor, 34);  // wTotalLength
+    config_descriptor.push_back(0x01);    // bNumInterfaces
+    config_descriptor.push_back(0x01);    // bConfigurationValue
+    config_descriptor.push_back(0x00);    // iConfiguration
+    config_descriptor.push_back(0x80);    // bmAttributes: bus-powered
+    config_descriptor.push_back(0x32);    // bMaxPower: 100 mA
+    // INTERFACE
+    config_descriptor.insert(config_descriptor.end(), { 0x09, 0x04 });
+    config_descriptor.push_back(0x00);    // bInterfaceNumber
+    config_descriptor.push_back(0x00);    // bAlternateSetting
+    config_descriptor.push_back(0x01);    // bNumEndpoints
+    config_descriptor.push_back(0x03);    // bInterfaceClass: HID
+    config_descriptor.push_back(cfg.mouse_mode ? 0x01 : 0x00);  // subclass: boot
+    config_descriptor.push_back(cfg.mouse_mode ? 0x02 : 0x00);  // protocol: mouse
+    config_descriptor.push_back(0x00);    // iInterface
+    // HID class descriptor
+    config_descriptor.insert(config_descriptor.end(), { 0x09, 0x21 });
+    append_u16le(config_descriptor, 0x0111);  // bcdHID
+    config_descriptor.push_back(0x00);        // bCountryCode
+    config_descriptor.push_back(0x01);        // bNumDescriptors
+    config_descriptor.push_back(0x22);        // bDescriptorType: REPORT
+    append_u16le(config_descriptor, static_cast<std::uint16_t>(report_descriptor.size()));
+    // ENDPOINT (interrupt IN)
+    config_descriptor.insert(config_descriptor.end(), { 0x07, 0x05 });
+    config_descriptor.push_back(0x81);    // bEndpointAddress: IN, EP1
+    config_descriptor.push_back(0x03);    // bmAttributes: interrupt
+    append_u16le(config_descriptor, packet_size);
+    config_descriptor.push_back(0x04);    // bInterval: 1 ms @ high speed
+  }
+
+  void
+  append_device_block(std::vector<std::uint8_t> &out) const {
+    auto path_str = padded_string(path, 256);
+    out.insert(out.end(), path_str.begin(), path_str.end());
+    auto busid_str = padded_string(busid, 32);
+    out.insert(out.end(), busid_str.begin(), busid_str.end());
+
+    append_u32be(out, 1);                                  // busnum
+    append_u32be(out, 1);                                  // devnum
+    append_u32be(out, 3);                                  // speed: high
+
+    append_u16be(out, cfg.vendor_id);
+    append_u16be(out, cfg.product_id);
+    append_u16be(out, 0x0100);                             // bcdDevice
+
+    out.push_back(0x00);                                   // bDeviceClass: per-interface
+    out.push_back(0x00);                                   // bDeviceSubClass
+    out.push_back(0x00);                                   // bDeviceProtocol
+    out.push_back(0x01);                                   // bConfigurationValue
+    out.push_back(0x01);                                   // bNumConfigurations
+    out.push_back(0x01);                                   // bNumInterfaces
+
+    out.push_back(0x03);                                   // bInterfaceClass: HID
+    out.push_back(0x00);                                   // bInterfaceSubClass
+    out.push_back(0x00);                                   // bInterfaceProtocol
+    out.push_back(0x00);                                   // padding
+  }
+
+  void
+  reply_submit_locked(const pending_submit &submit, std::int32_t status,
+                      const std::uint8_t *data, std::size_t size) {
+    std::vector<std::uint8_t> wire(kPduHeaderSize + size, 0);
+    put_u32be(wire.data(), 0, kRetSubmit);
+    put_u32be(wire.data(), 4, submit.seqnum);
+    put_u32be(wire.data(), 8, submit.devid);
+    put_u32be(wire.data(), 12, 1);  // direction: IN
+    put_u32be(wire.data(), 16, submit.endpoint);
+    put_i32be(wire.data(), 20, status);
+    put_i32be(wire.data(), 24, static_cast<std::int32_t>(size));
+    put_i32be(wire.data(), 32, -1);  // number_of_packets
+    put_i32be(wire.data(), 36, 0);   // error_count
+    if (size != 0) {
+      std::memcpy(wire.data() + kPduHeaderSize, data, size);
+    }
+    if (send) {
+      send(std::move(wire));
+    }
+  }
+
+  void
+  reply_unlink_locked(std::uint32_t seqnum, std::int32_t status) {
+    std::vector<std::uint8_t> wire(kPduHeaderSize, 0);
+    put_u32be(wire.data(), 0, kRetUnlink);
+    put_u32be(wire.data(), 4, seqnum);
+    put_i32be(wire.data(), 20, status);
+    if (send) {
+      send(std::move(wire));
+    }
+  }
+
+  void
+  reply_control_locked(std::uint32_t seqnum, const std::uint8_t *data, std::size_t size,
+                       std::int32_t status) {
+    std::vector<std::uint8_t> wire(kPduHeaderSize + size, 0);
+    put_u32be(wire.data(), 0, kRetSubmit);
+    put_u32be(wire.data(), 4, seqnum);
+    put_u32be(wire.data(), 8, 0);    // devid: canonical control reply
+    put_u32be(wire.data(), 12, 0);   // direction: OUT
+    put_u32be(wire.data(), 16, 0);   // endpoint: control
+    put_i32be(wire.data(), 20, status);
+    put_i32be(wire.data(), 24, static_cast<std::int32_t>(size));
+    put_i32be(wire.data(), 32, -1);
+    put_i32be(wire.data(), 36, 0);
+    if (size != 0) {
+      std::memcpy(wire.data() + kPduHeaderSize, data, size);
+    }
+    if (send) {
+      send(std::move(wire));
+    }
+  }
+
+  void
+  handle_control_submit_locked(std::uint32_t seqnum, const std::uint8_t *setup,
+                               const std::vector<std::uint8_t> &out_data) {
+    (void) out_data;
+    const std::uint8_t bmRequestType = setup[0];
+    const std::uint8_t bRequest = setup[1];
+    const std::uint16_t wValue = get_u16le(setup + 2);
+    const std::uint16_t wIndex = get_u16le(setup + 4);
+    const std::uint16_t wLength = get_u16le(setup + 6);
+    (void) wIndex;
+
+    const bool dir_in = (bmRequestType & 0x80) != 0;
+    const bool class_request = (bmRequestType & 0x60) == 0x20;
+
+    if (class_request) {
+      if (dir_in) {
+        // GET_REPORT.  The feature report (Contact Count Maximum) has its own
+        // layout: report id + one byte.  Answering it with the input layout
+        // makes HIDCLASS reject the digitizer during initialisation.
+        const std::uint8_t report_type = static_cast<std::uint8_t>(wValue >> 8);
+        std::vector<std::uint8_t> report;
+        if (report_type == 0x03) {  // FEATURE
+          report = { 0x02, 0x0A };  // Contact Count Maximum
+        }
+        else if (cfg.mouse_mode) {  // INPUT: last mouse report
+          report = last_mouse_report;
+        }
+        else {                      // INPUT: idle-touch snapshot
+          report = build_input_report(active_fingers, cfg.finger_slots);
+        }
+        const std::size_t size = std::min<std::size_t>(report.size(), wLength);
+        reply_control_locked(seqnum, report.data(), size, 0);
+      }
+      else {
+        // SET_IDLE / SET_PROTOCOL / SET_REPORT: acknowledge silently.
+        reply_control_locked(seqnum, nullptr, 0, 0);
+      }
+      return;
+    }
+
+    if (bRequest == 0x09 || bRequest == 0x01 || bRequest == 0x03) {
+      // SET_CONFIGURATION / CLEAR_FEATURE / SET_FEATURE
+      reply_control_locked(seqnum, nullptr, 0, 0);
+      return;
+    }
+    if (bRequest == 0x00) {
+      // GET_STATUS
+      const std::uint8_t status[2] = { 0x00, 0x00 };
+      reply_control_locked(seqnum, status, std::min<std::size_t>(2, wLength), 0);
+      return;
+    }
+    if (bRequest != 0x06) {
+      reply_control_locked(seqnum, nullptr, 0, kStallEpipe);
+      return;
+    }
+
+    // GET_DESCRIPTOR
+    const std::uint8_t type = static_cast<std::uint8_t>(wValue >> 8);
+    const std::uint8_t index = static_cast<std::uint8_t>(wValue & 0xFF);
+    std::vector<std::uint8_t> descriptor;
+
+    switch (type) {
+      case 0x01: {  // DEVICE
+        descriptor.resize(18);
+        descriptor[0] = 0x12;
+        descriptor[1] = 0x01;
+        put_u16le(descriptor, 2, 0x0200);  // bcdUSB
+        descriptor[4] = 0x00;              // class per-interface
+        descriptor[5] = 0x00;
+        descriptor[6] = 0x00;
+        descriptor[7] = 0x40;              // bMaxPacketSize0
+        put_u16le(descriptor, 8, cfg.vendor_id);
+        put_u16le(descriptor, 10, cfg.product_id);
+        put_u16le(descriptor, 12, 0x0100);  // bcdDevice
+        descriptor[14] = 0x01;              // iManufacturer
+        descriptor[15] = 0x02;              // iProduct
+        descriptor[16] = 0x03;              // iSerialNumber
+        descriptor[17] = 0x01;              // bNumConfigurations
+        break;
+      }
+      case 0x02:  // CONFIGURATION
+        descriptor = config_descriptor;
+        break;
+      case 0x03: {  // STRING
+        static const char *kStrings[] = { nullptr, "Sunshine", "Sunshine Virtual Touchscreen", "SSVTS0001" };
+        if (index == 0) {
+          descriptor = { 0x04, 0x03, 0x09, 0x04 };  // LANGID 0x0409
+        }
+        else if (index < std::size(kStrings) && kStrings[index] != nullptr) {
+          descriptor = hid_utf16_string(kStrings[index]);
+        }
+        else {
+          reply_control_locked(seqnum, nullptr, 0, kStallEpipe);
+          return;
+        }
+        break;
+      }
+      case 0x22:  // HID REPORT
+        descriptor = report_descriptor;
+        break;
+      default:
+        reply_control_locked(seqnum, nullptr, 0, kStallEpipe);
+        return;
+    }
+
+    const std::size_t size = std::min<std::size_t>(descriptor.size(), wLength);
+    reply_control_locked(seqnum, descriptor.data(), size, 0);
+  }
+
+  void
+  deliver_locked() {
+    while (!pending_in.empty()) {
+      if (!queued_reports.empty()) {
+        auto report = std::move(queued_reports.front());
+        queued_reports.erase(queued_reports.begin());
+        auto submit = pending_in.front();
+        pending_in.erase(pending_in.begin());
+        reply_submit_locked(submit, 0, report.data(), report.size());
+        continue;
+      }
+      if (!cfg.mouse_mode && !active_fingers.empty()) {
+        auto report = build_input_report(active_fingers, cfg.finger_slots);
+        auto submit = pending_in.front();
+        pending_in.erase(pending_in.begin());
+        reply_submit_locked(submit, 0, report.data(), report.size());
+        continue;
+      }
+      break;
+    }
+  }
+};
+
+virtual_touchscreen_device::virtual_touchscreen_device(config cfg) :
+    impl_(new impl(std::move(cfg))) {
+  impl_->busid = "1-2";
+  impl_->path = "/sys/devices/pci0000:00/1-2";
+}
+
+virtual_touchscreen_device::~virtual_touchscreen_device() = default;
+
+device_info
+virtual_touchscreen_device::info() const {
+  device_info dev;
+  dev.busid = impl_->busid;
+  dev.path = impl_->path;
+  dev.busnum = 1;
+  dev.devnum = 1;
+  dev.speed = 3;
+  dev.vendor_id = impl_->cfg.vendor_id;
+  dev.product_id = impl_->cfg.product_id;
+  dev.device_bcd = 0x0100;
+  dev.device_class = 0x00;
+  dev.device_subclass = 0x00;
+  dev.device_protocol = 0x00;
+  dev.configuration_value = 1;
+  dev.num_configurations = 1;
+  dev.interfaces.push_back(interface_info { 0x03, 0x00, 0x00 });
+  return dev;
+}
+
+void
+virtual_touchscreen_device::set_send_reply(std::function<void(std::vector<std::uint8_t>)> send) {
+  impl_->send = std::move(send);
+}
+
+bool
+virtual_touchscreen_device::imported() const {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  return impl_->imported_flag;
+}
+
+unsigned
+virtual_touchscreen_device::submitted_in_urbs() const {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  return impl_->in_submit_count;
+}
+
+bool
+virtual_touchscreen_device::handle_request(const std::vector<std::uint8_t> &pdu) {
+  if (pdu.size() < 8) {
+    return false;
+  }
+  const std::uint16_t code = get_u16be(pdu.data() + 2);
+
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+
+  if (code == kOpReqDevlist) {
+    if (pdu.size() != 8) {
+      return false;
+    }
+    std::vector<std::uint8_t> wire;
+    wire.reserve(12 + 304);
+    append_u16be(wire, kUsbipVersion);
+    append_u16be(wire, kRepDevlist);
+    append_u32be(wire, 0);  // status: ok
+    impl_->append_device_block(wire);
+    if (impl_->send) {
+      impl_->send(std::move(wire));
+    }
+    return true;
+  }
+
+  if (code == kOpReqImport) {
+    if (pdu.size() < 40) {
+      return false;
+    }
+    const auto requested = padded_string(impl_->busid, 32);
+    const bool match = std::equal(requested.begin(), requested.end(), pdu.begin() + 8);
+    std::vector<std::uint8_t> wire;
+    wire.reserve(12 + 304);
+    append_u16be(wire, kUsbipVersion);
+    append_u16be(wire, kRepImport);
+    append_u32be(wire, match ? 0 : static_cast<std::uint32_t>(-2));  // -ENODEV on mismatch
+    if (match) {
+      impl_->append_device_block(wire);
+      impl_->imported_flag = true;
+    }
+    if (impl_->send) {
+      impl_->send(std::move(wire));
+    }
+    return true;
+  }
+
+  if (code == kCmdSubmit) {
+    if (pdu.size() < kPduHeaderSize) {
+      return false;
+    }
+    const std::uint32_t seqnum = get_u32be(pdu.data() + 4);
+    const std::uint32_t devid = get_u32be(pdu.data() + 8);
+    const std::uint32_t direction = get_u32be(pdu.data() + 12);
+    const std::uint32_t endpoint = get_u32be(pdu.data() + 16);
+
+    if (endpoint == 0) {
+      const std::uint8_t *setup = pdu.data() + 40;
+      std::vector<std::uint8_t> out_data;
+      if (direction == 0 && pdu.size() > kPduHeaderSize) {
+        out_data.assign(pdu.begin() + kPduHeaderSize, pdu.end());
+      }
+      impl_->handle_control_submit_locked(seqnum, setup, out_data);
+      return true;
+    }
+
+    if (direction == 1) {
+      ++impl_->in_submit_count;
+      // Real interrupt endpoints are polled: answer queued frames first,
+      // repeat the live snapshot while contacts are held.  When idle, answer
+      // with a zero-length transfer -- parking the URB makes usbip-win2
+      // consider the device unresponsive and reset the connection.
+      if (!impl_->queued_reports.empty()) {
+        auto report = std::move(impl_->queued_reports.front());
+        impl_->queued_reports.erase(impl_->queued_reports.begin());
+        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
+                                   report.data(), report.size());
+      }
+      else if (!impl_->cfg.mouse_mode && !impl_->active_fingers.empty()) {
+        auto report = build_input_report(impl_->active_fingers, impl_->cfg.finger_slots);
+        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
+                                   report.data(), report.size());
+      }
+      else {
+        impl_->reply_submit_locked(impl::pending_submit { seqnum, devid, endpoint }, 0,
+                                   nullptr, 0);
+      }
+      return true;
+    }
+
+    // Unexpected OUT data to an interrupt endpoint: accept and drop.
+    std::vector<std::uint8_t> wire(kPduHeaderSize, 0);
+    put_u32be(wire.data(), 0, kRetSubmit);
+    put_u32be(wire.data(), 4, seqnum);
+    put_u32be(wire.data(), 8, devid);
+    put_u32be(wire.data(), 12, direction);
+    put_u32be(wire.data(), 16, endpoint);
+    put_i32be(wire.data(), 20, 0);
+    put_i32be(wire.data(), 24, static_cast<std::int32_t>(pdu.size() - kPduHeaderSize));
+    put_i32be(wire.data(), 32, -1);
+    put_i32be(wire.data(), 36, 0);
+    if (impl_->send) {
+      impl_->send(std::move(wire));
+    }
+    return true;
+  }
+
+  if (code == kCmdUnlink) {
+    if (pdu.size() < kPduHeaderSize) {
+      return false;
+    }
+    const std::uint32_t seqnum = get_u32be(pdu.data() + 4);
+    const std::uint32_t unlink_seqnum = get_u32be(pdu.data() + 20);
+    auto &pending = impl_->pending_in;
+    const auto found = std::find_if(pending.begin(), pending.end(),
+      [unlink_seqnum](const impl::pending_submit &s) { return s.seqnum == unlink_seqnum; });
+    if (found != pending.end()) {
+      pending.erase(found);
+    }
+    impl_->reply_unlink_locked(seqnum, 0);
+    return true;
+  }
+
+  return false;
+}
+
+void
+virtual_touchscreen_device::update_mouse(std::int8_t dx, std::int8_t dy, std::uint8_t buttons) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  impl_->last_mouse_report = build_mouse_report(dx, dy, buttons);
+  impl_->queued_reports.push_back(impl_->last_mouse_report);
+  impl_->deliver_locked();
+}
+
+void
+virtual_touchscreen_device::update_contacts(const std::vector<touchscreen_contact> &contacts) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+
+  // Index the requested contact set by id.
+  std::map<std::uint8_t, report_finger> next;
+  for (const auto &contact : contacts) {
+    next[contact.contact_id] = report_finger {
+      contact.contact_id,
+      contact.x,
+      contact.y,
+      contact.pressure,
+      contact.tip,
+      contact.in_range,
+    };
+  }
+
+  // Contacts that disappeared since the last update emit one explicit lift
+  // frame (tip=0, in_range=0) so the multi-touch stack releases them cleanly.
+  std::vector<report_finger> lift_frame = impl_->active_fingers;
+  bool lift_needed = false;
+  for (auto &finger : lift_frame) {
+    if (finger_is_live(finger) && !next.contains(finger.contact_id)) {
+      finger.tip = false;
+      finger.in_range = false;
+      finger.pressure = 0;
+      lift_needed = true;
+    }
+  }
+  if (lift_needed) {
+    impl_->queued_reports.push_back(build_input_report(lift_frame, impl_->cfg.finger_slots));
+  }
+
+  std::vector<report_finger> snapshot;
+  snapshot.reserve(next.size());
+  for (const auto &[id, finger] : next) {
+    (void) id;
+    snapshot.push_back(finger);
+  }
+  impl_->active_fingers = std::move(snapshot);
+  impl_->deliver_locked();
+}
+
+}  // namespace remote_usb

--- a/src/remote_usb/virtual_touchscreen_device.h
+++ b/src/remote_usb/virtual_touchscreen_device.h
@@ -1,6 +1,6 @@
 /**
  * @file src/remote_usb/virtual_touchscreen_device.h
- * @brief A local virtual multi-touch HID touchscreen served over the loopback
+ * @brief A local virtual single-touch HID touchscreen served over the loopback
  *        USB/IP bridge, so usbip-win2 attaches it as a real USB touchscreen.
  *
  * The device answers control transfers (descriptors) and queued interrupt-IN
@@ -38,12 +38,13 @@ struct touchscreen_contact {
 };
 
 /**
- * A single-client virtual USB multi-touch touchscreen.  The class owns the
+ * A single-client virtual USB single-touch touchscreen.  The class owns the
  * USB/IP device-side protocol state machine; the owner wires it to a
- * loopback_usbip_bridge with callbacks::on_request and send_reply().
+ * loopback_usbip_bridge with callbacks::on_request and send_reply(), and
+ * calls reset() from callbacks::on_closed.
  *
- * Thread-safety: handle_request() and touch callbacks may be called from
- * different threads; internal state is mutex-protected.
+ * Thread-safety: all public methods may be called from different threads;
+ * internal state is mutex-protected.
  */
 class virtual_touchscreen_device final {
 public:
@@ -57,7 +58,8 @@ public:
     /** Digitizer active-area resolution (logical max of X/Y axes). */
     std::uint16_t width_px { 1920 };
     std::uint16_t height_px { 1080 };
-    /** Number of parallel finger slots carried in every report (1..10). */
+    /** Reserved for a future parallel-slot descriptor.  The current
+     *  implementation emits single-touch reports and ignores this value. */
     std::uint8_t finger_slots { 5 };
   };
 
@@ -80,8 +82,15 @@ public:
   /** Install the reply hook (typically bridge.send_reply). */
   void set_send_reply(std::function<void(std::vector<std::uint8_t>)> send);
 
-  /** True between a successful OP_REQ_IMPORT and connection teardown. */
+  /** True between a successful OP_REQ_IMPORT and reset(). */
   bool imported() const;
+
+  /**
+   * Drop all per-connection state (imported flag, queued frames, live
+   * contacts, last mouse report, submit counter).  Call when the USB/IP
+   * client disconnects so the next session does not inherit stale frames.
+   */
+  void reset();
 
   /**
    * Replace the current contact set.  Contacts present in `contacts` are
@@ -93,7 +102,7 @@ public:
   /** Mouse mode: send a relative movement + button state frame. */
   void update_mouse(std::int8_t dx, std::int8_t dy, std::uint8_t buttons);
 
-  /** Whether the guest has issued OP_REQ_IMPORT (used by tests). */
+  /** Number of interrupt-IN submits answered so far (used by tests). */
   unsigned submitted_in_urbs() const;
 
 private:

--- a/src/remote_usb/virtual_touchscreen_device.h
+++ b/src/remote_usb/virtual_touchscreen_device.h
@@ -1,0 +1,104 @@
+/**
+ * @file src/remote_usb/virtual_touchscreen_device.h
+ * @brief A local virtual multi-touch HID touchscreen served over the loopback
+ *        USB/IP bridge, so usbip-win2 attaches it as a real USB touchscreen.
+ *
+ * The device answers control transfers (descriptors) and queued interrupt-IN
+ * submits (touch frames) directly from Sunshine.  Because the touch input
+ * enters Windows through the standard USB HID stack (hidusb.sys), the shell
+ * sees a genuine touchscreen: the native touch-keyboard auto-invoke chain,
+ * taskbar button and pointer integration all behave as with real hardware.
+ */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "loopback_usbip_bridge.h"
+
+namespace remote_usb {
+
+/** One finger sample in digitizer coordinates. */
+struct touchscreen_contact {
+  /** Stable per-finger id while the contact lives (0..0xFF). */
+  std::uint8_t contact_id { 0 };
+  std::uint16_t x { 0 };
+  std::uint16_t y { 0 };
+  /** 0..255; 0 while lifted. */
+  std::uint8_t pressure { 0 };
+  /** Finger is touching the surface. */
+  bool tip { false };
+  /** Finger is tracked (hover or contact). */
+  bool in_range { false };
+};
+
+/**
+ * A single-client virtual USB multi-touch touchscreen.  The class owns the
+ * USB/IP device-side protocol state machine; the owner wires it to a
+ * loopback_usbip_bridge with callbacks::on_request and send_reply().
+ *
+ * Thread-safety: handle_request() and touch callbacks may be called from
+ * different threads; internal state is mutex-protected.
+ */
+class virtual_touchscreen_device final {
+public:
+  struct config {
+    /** false = HID touchscreen digitizer, true = plain boot-style mouse
+     *  (control experiment to separate driver-stack issues from the
+     *  touchscreen descriptor). */
+    bool mouse_mode { false };
+    std::uint16_t vendor_id { 0x5355 };  // "SS"
+    std::uint16_t product_id { 0x5401 }; // touchscreen rev 1
+    /** Digitizer active-area resolution (logical max of X/Y axes). */
+    std::uint16_t width_px { 1920 };
+    std::uint16_t height_px { 1080 };
+    /** Number of parallel finger slots carried in every report (1..10). */
+    std::uint8_t finger_slots { 5 };
+  };
+
+  explicit virtual_touchscreen_device(config cfg);
+  ~virtual_touchscreen_device();
+
+  virtual_touchscreen_device(const virtual_touchscreen_device &) = delete;
+  virtual_touchscreen_device &operator=(const virtual_touchscreen_device &) = delete;
+
+  /** Descriptor metadata for loopback_usbip_bridge::start(). */
+  device_info info() const;
+
+  /**
+   * Handle one complete USB/IP request PDU (OP_REQ_* or USBIP_CMD_*).
+   * Replies are emitted through the send hook installed by set_send_reply().
+   * Returns false when the PDU is malformed for the current state.
+   */
+  bool handle_request(const std::vector<std::uint8_t> &pdu);
+
+  /** Install the reply hook (typically bridge.send_reply). */
+  void set_send_reply(std::function<void(std::vector<std::uint8_t>)> send);
+
+  /** True between a successful OP_REQ_IMPORT and connection teardown. */
+  bool imported() const;
+
+  /**
+   * Replace the current contact set.  Contacts present in `contacts` are
+   * reported; previously active contacts missing from the set emit one lift
+   * report (tip=0, in_range=0) and then go idle.
+   */
+  void update_contacts(const std::vector<touchscreen_contact> &contacts);
+
+  /** Mouse mode: send a relative movement + button state frame. */
+  void update_mouse(std::int8_t dx, std::int8_t dy, std::uint8_t buttons);
+
+  /** Whether the guest has issued OP_REQ_IMPORT (used by tests). */
+  unsigned submitted_in_urbs() const;
+
+private:
+  struct impl;
+  std::unique_ptr<impl> impl_;
+};
+
+}  // namespace remote_usb

--- a/src/remote_usb/virtual_touchscreen_device.h
+++ b/src/remote_usb/virtual_touchscreen_device.h
@@ -29,7 +29,8 @@ struct touchscreen_contact {
   std::uint8_t contact_id { 0 };
   std::uint16_t x { 0 };
   std::uint16_t y { 0 };
-  /** 0..255; 0 while lifted. */
+  /** Accepted for API stability; the current single-touch report layout
+   *  does not carry pressure. */
   std::uint8_t pressure { 0 };
   /** Finger is touching the surface. */
   bool tip { false };

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -62,6 +62,13 @@ namespace rtsp_stream {
     bool enable_mic { false };
     bool use_vdd;
     int custom_screen_mode;
+
+    // Client-declared intent to use the on-screen touch keyboard during the
+    // session.  Tri-state: -1 undeclared (fall back to the per-client server
+    // profile), 0 explicitly off, 1 explicitly on.  When effective-on, the
+    // host attaches the virtual USB touchscreen and applies the touch
+    // keyboard AutoInvoke registry key group for the session.
+    int touch_keyboard { -1 };
     hdr::client_display_capabilities_t reported_hdr_capabilities;
     hdr::client_display_capabilities_t hdr_capabilities;
     hdr::target_source_e hdr_target_source { hdr::target_source_e::safe_defaults };

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -64,6 +64,8 @@ extern "C" {
 #include "clipboard_bridge.h"
 #include "cursor_channel.h"
 #include "platform/common.h"
+#include "touch_keyboard_session.h"
+#include "virtual_touchscreen_session.h"
 
 #define IDX_START_A 0
 #define IDX_START_B 1
@@ -4178,6 +4180,12 @@ namespace stream {
           if (restore_display_state) {
             display_device::session_t::get().restore_state();
           }
+
+#ifdef _WIN32
+          // Touch experience teardown (paired with the mount at stream start).
+          touch_kb::end_session();
+          vts::stop();
+#endif
 
           platf::streaming_will_stop();
         }

--- a/src/touch_keyboard_session.h
+++ b/src/touch_keyboard_session.h
@@ -1,0 +1,38 @@
+/**
+ * @file src/touch_keyboard_session.h
+ * @brief Session-scoped enablement of the Windows touch keyboard
+ *        auto-invoke registry key group.
+ *
+ * When a client declares a touch-keyboard intent (or its server profile
+ * opts in), the host writes the TabletTip AutoInvoke registry key group
+ * for the duration of the stream session and restores the previous values
+ * when the session ends.  A full-variable-isolation ablation on the host
+ * (2026-09-02) confirmed the keyboard auto-invocation depends on these
+ * values; no public API or Settings surface exists to toggle them
+ * programmatically.
+ *
+ * Non-Windows platforms are no-ops.
+ */
+#pragma once
+
+namespace touch_kb {
+
+/**
+ * Apply the AutoInvoke key group for the active console user.
+ *
+ * @param effective when false, this is a no-op (client did not opt in).
+ * @return true when the key group was written (or already in the desired
+ *         state); false when the write failed or the platform is
+ *         non-Windows.
+ */
+bool
+start_session(bool effective);
+
+/**
+ * Restore the values captured by start_session().  Safe to call even when
+ * start_session() was skipped or failed; a missing undo file is a no-op.
+ */
+void
+end_session();
+
+}  // namespace touch_kb

--- a/src/virtual_touchscreen_session.h
+++ b/src/virtual_touchscreen_session.h
@@ -1,0 +1,47 @@
+/**
+ * @file src/virtual_touchscreen_session.h
+ * @brief Session-scoped virtual USB touchscreen lifecycle for Windows.
+ *
+ * When enabled for a stream session, this module attaches a virtual USB HID
+ * touchscreen through usbip-win2 so the OS has a touch digitizer for the
+ * duration of the session (enabling the touch keyboard and native touch
+ * routing).  Touch reports are pushed with push_contact()/lift_all().
+ *
+ * Non-Windows platforms are no-ops.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace vts {
+
+  struct session_config {
+    /** Path to usbip.exe (usbip-win2).  Empty resolves "usbip.exe" via PATH. */
+    std::string usbip_executable;
+    /** Digitizer active-area resolution; matches the streamed resolution. */
+    std::uint16_t width_px { 1920 };
+    std::uint16_t height_px { 1080 };
+  };
+
+  /**
+   * Attach the virtual touchscreen.  Blocking for up to ~10 s while the
+   * VHCI imports the device.  Must be paired with stop().
+   * @return true when the device is attached and visible to the OS.
+   */
+  bool
+  start(const session_config &config);
+
+  /** Lift all contacts and send a report (one per active contact). */
+  void
+  update_contact(std::uint8_t contact_id, std::uint16_t x, std::uint16_t y, bool tip);
+
+  /** Release a contact (explicit lift frame). */
+  void
+  lift_contact(std::uint8_t contact_id);
+
+  /** Detach the device and tear everything down. */
+  void
+  stop();
+
+}  // namespace vts

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,6 +216,22 @@ set_target_properties(loopback_usbip_bridge_unit_tests PROPERTIES
         CXX_STANDARD_REQUIRED ON)
 add_test(NAME loopback_usbip_bridge_unit_tests COMMAND loopback_usbip_bridge_unit_tests)
 
+add_executable(virtual_touchscreen_unit_tests
+        ${CMAKE_SOURCE_DIR}/src/remote_usb/virtual_touchscreen_device.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_virtual_touchscreen_device.cpp)
+target_include_directories(virtual_touchscreen_unit_tests PRIVATE
+        "${CMAKE_SOURCE_DIR}")
+target_link_libraries(virtual_touchscreen_unit_tests
+        Boost::system
+        ${CMAKE_THREAD_LIBS_INIT}
+        gtest_main)
+target_compile_options(virtual_touchscreen_unit_tests PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(virtual_touchscreen_unit_tests PROPERTIES
+        CXX_STANDARD 23
+        CXX_STANDARD_REQUIRED ON)
+add_test(NAME virtual_touchscreen_unit_tests COMMAND virtual_touchscreen_unit_tests)
+
 add_executable(remote_usb_broker_adapter_unit_tests
         ${CMAKE_SOURCE_DIR}/src/remote_usb/loopback_usbip_bridge.cpp
         ${CMAKE_SOURCE_DIR}/src/remote_usb/remote_usb_broker_adapter.cpp

--- a/tests/unit/test_virtual_touchscreen_device.cpp
+++ b/tests/unit/test_virtual_touchscreen_device.cpp
@@ -1,6 +1,6 @@
 /**
  * @file tests/unit/test_virtual_touchscreen_device.cpp
- * @brief Protocol tests for the virtual USB multi-touch touchscreen device.
+ * @brief Protocol tests for the virtual USB single-touch touchscreen device.
  */
 
 #include <src/remote_usb/virtual_touchscreen_device.h>
@@ -9,12 +9,19 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 namespace {
+
+  constexpr std::size_t kOpCommon = 8;
+  constexpr std::size_t kDeviceBlock = 312;
+  constexpr std::size_t kInterfaceBlock = 4;
+  constexpr std::size_t kPduHeader = 48;
+  constexpr std::int32_t kEpipe = -32;
 
   void
   put_u16be(std::vector<std::uint8_t> &out, std::size_t offset, std::uint16_t value) {
@@ -65,15 +72,26 @@ namespace {
 
   std::vector<std::uint8_t>
   make_submit(std::uint32_t seqnum, std::uint32_t devid, std::uint32_t direction,
-              std::uint32_t endpoint, const std::vector<std::uint8_t> &setup = {}) {
-    std::vector<std::uint8_t> wire(48 + setup.size(), 0);
+              std::uint32_t endpoint, const std::vector<std::uint8_t> &setup = {},
+              const std::vector<std::uint8_t> &payload = {}) {
+    std::vector<std::uint8_t> wire(48 + payload.size(), 0);
     put_u32be(wire, 0, 1);  // USBIP_CMD_SUBMIT
     put_u32be(wire, 4, seqnum);
     put_u32be(wire, 8, devid);
     put_u32be(wire, 12, direction);
     put_u32be(wire, 16, endpoint);
+    put_u32be(wire, 24, static_cast<std::uint32_t>(payload.size()));
     std::copy(setup.begin(), setup.end(), wire.begin() + 40);
+    std::copy(payload.begin(), payload.end(), wire.begin() + 48);
     return wire;
+  }
+
+  /** 32-byte NUL-padded busid tail for OP_REQ_IMPORT. */
+  std::vector<std::uint8_t>
+  make_busid(std::string_view busid) {
+    std::vector<std::uint8_t> out(32, 0);
+    std::copy(busid.begin(), busid.end(), out.begin());
+    return out;
   }
 
   /** Collects device replies so tests can assert on them. */
@@ -116,6 +134,30 @@ namespace {
       device->set_send_reply(collector.hook());
     }
 
+    /** Issue one control transfer and return its single RET_SUBMIT (empty on failure). */
+    std::vector<std::uint8_t>
+    control(std::uint32_t seqnum, const std::vector<std::uint8_t> &setup) {
+      EXPECT_TRUE(device->handle_request(make_submit(seqnum, 0, 0, 0, setup)));
+      auto replies = collector.take_all();
+      EXPECT_EQ(replies.size(), 1u);
+      return replies.empty() ? std::vector<std::uint8_t> {} : replies[0];
+    }
+
+    reply_collector collector;
+    std::unique_ptr<remote_usb::virtual_touchscreen_device> device;
+  };
+
+  class virtual_mouse_test : public ::testing::Test {
+  protected:
+    void
+    SetUp() override {
+      remote_usb::virtual_touchscreen_device::config cfg;
+      cfg.mouse_mode = true;
+      cfg.product_id = 0x5402;
+      device = std::make_unique<remote_usb::virtual_touchscreen_device>(cfg);
+      device->set_send_reply(collector.hook());
+    }
+
     reply_collector collector;
     std::unique_ptr<remote_usb::virtual_touchscreen_device> device;
   };
@@ -138,42 +180,48 @@ TEST_F(virtual_touchscreen_test, devlist_reply_contains_device_block) {
   ASSERT_EQ(replies.size(), 1u);
 
   const auto &wire = replies[0];
-  ASSERT_EQ(wire.size(), 8u + 316u);
+  ASSERT_EQ(wire.size(), kOpCommon + 4 + kDeviceBlock + kInterfaceBlock);
   // OP_REP header is big-endian: version 0x0111, code 0x0005, status ok.
   EXPECT_EQ(wire[0], 0x01);
   EXPECT_EQ(wire[1], 0x11);
   EXPECT_EQ(wire[2], 0x00);
   EXPECT_EQ(wire[3], 0x05);
   EXPECT_EQ(get_u32be_at(wire, 4), 0u);
+  EXPECT_EQ(get_u32be_at(wire, kOpCommon), 1u);  // ndev
 
   // Device block: path(256) busid(32) then numeric fields.
-  const std::size_t numeric = 8 + 256 + 32;
+  const std::size_t dev = kOpCommon + 4;
+  const std::size_t numeric = dev + 256 + 32;
   EXPECT_EQ(get_u32be_at(wire, numeric + 0), 1u);      // busnum
   EXPECT_EQ(get_u32be_at(wire, numeric + 4), 1u);      // devnum
   EXPECT_EQ(get_u32be_at(wire, numeric + 8), 3u);      // speed high
   EXPECT_EQ(get_u16be_at(wire, numeric + 12), 0x5355);  // VID
   EXPECT_EQ(get_u16be_at(wire, numeric + 14), 0x5401);  // PID
+  EXPECT_EQ(wire[dev + 311], 1u);                       // bNumInterfaces
+  EXPECT_EQ(wire[dev + kDeviceBlock], 0x03);            // interface class HID
 }
 
 TEST_F(virtual_touchscreen_test, import_matches_busid_and_sets_imported) {
-  std::vector<std::uint8_t> busid(32, 0);
-  std::copy("1-2", "1-2" + 3, busid.begin());
-  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, busid)));
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, make_busid("1-2"))));
   const auto replies = collector.take_all();
   ASSERT_EQ(replies.size(), 1u);
   EXPECT_EQ(get_u32be_at(replies[0], 4), 0u);  // status ok
-  EXPECT_EQ(replies[0].size(), 8u + 316u);
+  EXPECT_EQ(replies[0].size(), kOpCommon + kDeviceBlock);  // no interface block
   EXPECT_TRUE(device->imported());
 }
 
 TEST_F(virtual_touchscreen_test, import_rejects_foreign_busid) {
-  std::vector<std::uint8_t> busid(32, 0);
-  std::copy("9-9", "9-9" + 3, busid.begin());
-  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, busid)));
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, make_busid("9-9"))));
   const auto replies = collector.take_all();
   ASSERT_EQ(replies.size(), 1u);
   EXPECT_EQ(static_cast<std::int32_t>(get_u32be_at(replies[0], 4)), -2);  // -ENODEV
+  EXPECT_EQ(replies[0].size(), kOpCommon);
   EXPECT_FALSE(device->imported());
+}
+
+TEST_F(virtual_touchscreen_test, import_rejects_short_busid_tail) {
+  EXPECT_FALSE(device->handle_request(make_op_request(0x8003, std::vector<std::uint8_t>(31, 0))));
+  EXPECT_EQ(collector.count(), 0u);
 }
 
 TEST_F(virtual_touchscreen_test, get_device_descriptor) {
@@ -302,7 +350,7 @@ TEST_F(virtual_touchscreen_test, lift_emits_explicit_release_frame) {
   EXPECT_EQ(get_i32be_at(idle[0], 24), 0);  // actual_length 0
 }
 
-TEST_F(virtual_touchscreen_test, unlink_cancels_pending_submit) {
+TEST_F(virtual_touchscreen_test, unlink_unknown_seqnum_replies_ok) {
   // Idle polls answer immediately, so there is nothing parked to unlink; the
   // unlink still completes with status 0.
   ASSERT_TRUE(device->handle_request(make_submit(30, 0, 1, 1)));
@@ -316,6 +364,7 @@ TEST_F(virtual_touchscreen_test, unlink_cancels_pending_submit) {
 
   const auto replies = collector.take_all();
   ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].size(), kPduHeader);
   EXPECT_EQ(get_u32be_at(replies[0], 0), 4u);  // RET_UNLINK
   EXPECT_EQ(get_u32be_at(replies[0], 4), 31u);
   EXPECT_EQ(get_i32be_at(replies[0], 20), 0);
@@ -324,4 +373,232 @@ TEST_F(virtual_touchscreen_test, unlink_cancels_pending_submit) {
 TEST_F(virtual_touchscreen_test, malformed_request_rejected) {
   std::vector<std::uint8_t> short_pdu { 0x01, 0x11, 0x80, 0x05 };
   EXPECT_FALSE(device->handle_request(short_pdu));
+  // DEVLIST must be exactly op_common; SUBMIT/UNLINK need the full header.
+  EXPECT_FALSE(device->handle_request(make_op_request(0x8005, { 0x00 })));
+  std::vector<std::uint8_t> short_submit(47, 0);
+  put_u32be(short_submit, 0, 1);
+  EXPECT_FALSE(device->handle_request(short_submit));
+  std::vector<std::uint8_t> short_unlink(47, 0);
+  put_u32be(short_unlink, 0, 2);
+  EXPECT_FALSE(device->handle_request(short_unlink));
+  // Unknown op code is not handled.
+  EXPECT_FALSE(device->handle_request(make_op_request(0x8009)));
+  EXPECT_EQ(collector.count(), 0u);
+}
+
+// ---- control-request branches ----
+
+TEST_F(virtual_touchscreen_test, get_report_feature_stalls_without_feature_report) {
+  // GET_REPORT(FEATURE, id 0) -- the descriptor declares no Feature report.
+  const auto wire = control(40, { 0xA1, 0x01, 0x00, 0x03, 0x00, 0x00, 0x02, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), kEpipe);
+}
+
+TEST_F(virtual_touchscreen_test, get_report_input_returns_idle_snapshot) {
+  // GET_REPORT(INPUT) with no contacts: 5-byte all-zero frame.
+  const auto wire = control(41, { 0xA1, 0x01, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00 });
+  ASSERT_EQ(wire.size(), kPduHeader + 5);
+  EXPECT_EQ(get_i32be_at(wire, 20), 0);
+  EXPECT_EQ(wire[kPduHeader], 0x00);
+  EXPECT_EQ(get_u16le_at(wire, kPduHeader + 1), 0u);
+  EXPECT_EQ(get_u16le_at(wire, kPduHeader + 3), 0u);
+}
+
+TEST_F(virtual_touchscreen_test, class_out_requests_are_acked) {
+  // SET_IDLE
+  auto wire = control(42, { 0x21, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), 0);
+  // SET_REPORT(OUTPUT) carrying one data byte
+  ASSERT_TRUE(device->handle_request(
+    make_submit(43, 0, 0, 0, { 0x21, 0x09, 0x00, 0x02, 0x00, 0x00, 0x01, 0x00 }, { 0xAA })));
+  auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(replies[0], 20), 0);
+}
+
+TEST_F(virtual_touchscreen_test, standard_requests_status_and_unknown) {
+  // GET_STATUS -> 2 zero bytes
+  auto wire = control(44, { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
+  ASSERT_EQ(wire.size(), kPduHeader + 2);
+  EXPECT_EQ(wire[kPduHeader], 0x00);
+  EXPECT_EQ(wire[kPduHeader + 1], 0x00);
+  // SET_CONFIGURATION(1) -> zero-length ACK
+  wire = control(45, { 0x00, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), 0);
+  // Unknown bRequest (SET_ADDRESS is never seen by a device behind VHCI) -> STALL
+  wire = control(46, { 0x00, 0x05, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), kEpipe);
+}
+
+TEST_F(virtual_touchscreen_test, string_descriptors) {
+  // index 0: LANGID table
+  auto wire = control(50, { 0x80, 0x06, 0x00, 0x03, 0x00, 0x00, 0xFF, 0x00 });
+  ASSERT_EQ(wire.size(), kPduHeader + 4);
+  EXPECT_EQ(wire[kPduHeader + 0], 0x04);
+  EXPECT_EQ(wire[kPduHeader + 1], 0x03);
+  EXPECT_EQ(get_u16le_at(wire, kPduHeader + 2), 0x0409);
+  // index 1: "Sunshine" as UTF-16LE -> 2 + 8*2 bytes
+  wire = control(51, { 0x80, 0x06, 0x01, 0x03, 0x09, 0x04, 0xFF, 0x00 });
+  ASSERT_EQ(wire.size(), kPduHeader + 18);
+  EXPECT_EQ(wire[kPduHeader + 0], 18);
+  EXPECT_EQ(wire[kPduHeader + 1], 0x03);
+  EXPECT_EQ(wire[kPduHeader + 2], 'S');
+  EXPECT_EQ(wire[kPduHeader + 3], 0x00);
+  // wLength truncation honoured
+  wire = control(52, { 0x80, 0x06, 0x02, 0x03, 0x09, 0x04, 0x04, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader + 4);
+  EXPECT_EQ(get_i32be_at(wire, 24), 4);
+  // out-of-range index -> STALL
+  wire = control(53, { 0x80, 0x06, 0x09, 0x03, 0x09, 0x04, 0xFF, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), kEpipe);
+}
+
+TEST_F(virtual_touchscreen_test, unknown_descriptor_type_stalls) {
+  // GET_DESCRIPTOR(DEVICE_QUALIFIER = 0x06): not a high-speed-capable device.
+  const auto wire = control(54, { 0x80, 0x06, 0x00, 0x06, 0x00, 0x00, 0x0A, 0x00 });
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(wire, 20), kEpipe);
+}
+
+TEST_F(virtual_touchscreen_test, interrupt_out_is_accepted_and_dropped) {
+  ASSERT_TRUE(device->handle_request(make_submit(60, 5, 0, 1, {}, { 0x01, 0x02, 0x03 })));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  const auto &wire = replies[0];
+  EXPECT_EQ(wire.size(), kPduHeader);
+  EXPECT_EQ(get_u32be_at(wire, 0), 3u);    // RET_SUBMIT
+  EXPECT_EQ(get_u32be_at(wire, 4), 60u);
+  EXPECT_EQ(get_u32be_at(wire, 8), 5u);
+  EXPECT_EQ(get_u32be_at(wire, 12), 0u);   // direction OUT echoed
+  EXPECT_EQ(get_u32be_at(wire, 16), 1u);
+  EXPECT_EQ(get_i32be_at(wire, 20), 0);
+  EXPECT_EQ(get_i32be_at(wire, 24), 3);    // bytes consumed
+  EXPECT_EQ(device->submitted_in_urbs(), 0u);
+}
+
+// ---- lifecycle ----
+
+TEST_F(virtual_touchscreen_test, reset_clears_connection_state) {
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, make_busid("1-2"))));
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 1;
+  finger.x = 5;
+  finger.y = 6;
+  finger.tip = true;
+  finger.in_range = true;
+  device->update_contacts({ finger });
+  ASSERT_TRUE(device->handle_request(make_submit(70, 0, 1, 1)));
+  collector.take_all();
+  ASSERT_TRUE(device->imported());
+  ASSERT_EQ(device->submitted_in_urbs(), 1u);
+
+  device->reset();
+  EXPECT_FALSE(device->imported());
+  EXPECT_EQ(device->submitted_in_urbs(), 0u);
+
+  // Neither queued frames nor the live snapshot survive: the next poll of a
+  // fresh session is idle.
+  ASSERT_TRUE(device->handle_request(make_submit(71, 0, 1, 1)));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].size(), kPduHeader);
+  EXPECT_EQ(get_i32be_at(replies[0], 24), 0);
+}
+
+TEST_F(virtual_touchscreen_test, queued_reports_are_bounded_drop_oldest) {
+  // Each down->lift pair queues exactly one lift frame; overflow the cap.
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 1;
+  finger.tip = true;
+  finger.in_range = true;
+  const unsigned total = 100;
+  for (unsigned i = 0; i < total; ++i) {
+    finger.x = static_cast<std::uint16_t>(i);
+    device->update_contacts({ finger });
+    device->update_contacts({});
+  }
+  EXPECT_EQ(collector.count(), 0u);
+
+  // Drain: at most 64 frames come back, and the first one is the oldest
+  // survivor (x == total - 64), i.e. the earliest frames were dropped.
+  unsigned frames = 0;
+  std::uint16_t first_x = 0xFFFF;
+  for (unsigned seq = 100; seq < 100 + total + 1; ++seq) {
+    ASSERT_TRUE(device->handle_request(make_submit(seq, 0, 1, 1)));
+    auto replies = collector.take_all();
+    ASSERT_EQ(replies.size(), 1u);
+    if (replies[0].size() == kPduHeader) {
+      break;  // idle: queue drained
+    }
+    if (frames == 0) {
+      first_x = get_u16le_at(replies[0], kPduHeader + 1);
+    }
+    ++frames;
+  }
+  EXPECT_EQ(frames, 64u);
+  EXPECT_EQ(first_x, total - 64);
+}
+
+// ---- mouse control mode ----
+
+TEST_F(virtual_mouse_test, mouse_descriptors_and_reports) {
+  // Config descriptor advertises boot-mouse subclass/protocol.
+  ASSERT_TRUE(device->handle_request(
+    make_submit(80, 0, 0, 0, { 0x80, 0x06, 0x00, 0x02, 0x00, 0x00, 0xFF, 0x00 })));
+  auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), kPduHeader + 34);
+  EXPECT_EQ(replies[0][kPduHeader + 9 + 5], 0x03);  // HID
+  EXPECT_EQ(replies[0][kPduHeader + 9 + 6], 0x01);  // boot subclass
+  EXPECT_EQ(replies[0][kPduHeader + 9 + 7], 0x02);  // mouse protocol
+
+  // Report descriptor starts with Generic Desktop / Mouse.
+  ASSERT_TRUE(device->handle_request(
+    make_submit(81, 0, 0, 0, { 0x81, 0x06, 0x00, 0x22, 0x00, 0x00, 0xFF, 0x00 })));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_GT(replies[0].size(), kPduHeader + 4);
+  EXPECT_EQ(replies[0][kPduHeader + 0], 0x05);
+  EXPECT_EQ(replies[0][kPduHeader + 1], 0x01);
+  EXPECT_EQ(replies[0][kPduHeader + 2], 0x09);
+  EXPECT_EQ(replies[0][kPduHeader + 3], 0x02);
+
+  // GET_REPORT(INPUT) before any movement: neutral 3-byte report.
+  ASSERT_TRUE(device->handle_request(
+    make_submit(82, 0, 0, 0, { 0xA1, 0x01, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00 })));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), kPduHeader + 3);
+  EXPECT_EQ(replies[0][kPduHeader + 0], 0x00);
+
+  // update_mouse queues one frame; the poll returns buttons, dx, dy.
+  device->update_mouse(-3, 7, 0x01);
+  ASSERT_TRUE(device->handle_request(make_submit(83, 0, 1, 1)));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), kPduHeader + 3);
+  EXPECT_EQ(replies[0][kPduHeader + 0], 0x01);
+  EXPECT_EQ(static_cast<std::int8_t>(replies[0][kPduHeader + 1]), -3);
+  EXPECT_EQ(static_cast<std::int8_t>(replies[0][kPduHeader + 2]), 7);
+
+  // GET_REPORT(INPUT) now echoes the last mouse report.
+  ASSERT_TRUE(device->handle_request(
+    make_submit(84, 0, 0, 0, { 0xA1, 0x01, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00 })));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), kPduHeader + 3);
+  EXPECT_EQ(replies[0][kPduHeader + 0], 0x01);
+  EXPECT_EQ(static_cast<std::int8_t>(replies[0][kPduHeader + 1]), -3);
+
+  // Mouse mode has no held snapshot: the next poll is idle.
+  ASSERT_TRUE(device->handle_request(make_submit(85, 0, 1, 1)));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0].size(), kPduHeader);
 }

--- a/tests/unit/test_virtual_touchscreen_device.cpp
+++ b/tests/unit/test_virtual_touchscreen_device.cpp
@@ -1,0 +1,327 @@
+/**
+ * @file tests/unit/test_virtual_touchscreen_device.cpp
+ * @brief Protocol tests for the virtual USB multi-touch touchscreen device.
+ */
+
+#include <src/remote_usb/virtual_touchscreen_device.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+  void
+  put_u16be(std::vector<std::uint8_t> &out, std::size_t offset, std::uint16_t value) {
+    out[offset] = static_cast<std::uint8_t>(value >> 8);
+    out[offset + 1] = static_cast<std::uint8_t>(value);
+  }
+
+  void
+  put_u32be(std::vector<std::uint8_t> &out, std::size_t offset, std::uint32_t value) {
+    out[offset] = static_cast<std::uint8_t>(value >> 24);
+    out[offset + 1] = static_cast<std::uint8_t>(value >> 16);
+    out[offset + 2] = static_cast<std::uint8_t>(value >> 8);
+    out[offset + 3] = static_cast<std::uint8_t>(value);
+  }
+
+  std::uint16_t
+  get_u16be_at(const std::vector<std::uint8_t> &in, std::size_t offset) {
+    return static_cast<std::uint16_t>((static_cast<std::uint16_t>(in[offset]) << 8) | in[offset + 1]);
+  }
+
+  std::uint16_t
+  get_u16le_at(const std::vector<std::uint8_t> &in, std::size_t offset) {
+    return static_cast<std::uint16_t>(in[offset] | (in[offset + 1] << 8));
+  }
+
+  std::uint32_t
+  get_u32be_at(const std::vector<std::uint8_t> &in, std::size_t offset) {
+    return (static_cast<std::uint32_t>(in[offset]) << 24) |
+           (static_cast<std::uint32_t>(in[offset + 1]) << 16) |
+           (static_cast<std::uint32_t>(in[offset + 2]) << 8) |
+           static_cast<std::uint32_t>(in[offset + 3]);
+  }
+
+  std::int32_t
+  get_i32be_at(const std::vector<std::uint8_t> &in, std::size_t offset) {
+    return static_cast<std::int32_t>(get_u32be_at(in, offset));
+  }
+
+  std::vector<std::uint8_t>
+  make_op_request(std::uint16_t code, const std::vector<std::uint8_t> &tail = {}) {
+    std::vector<std::uint8_t> wire(8 + tail.size(), 0);
+    put_u16be(wire, 0, 0x0111);
+    put_u16be(wire, 2, code);
+    put_u32be(wire, 4, 0);
+    std::copy(tail.begin(), tail.end(), wire.begin() + 8);
+    return wire;
+  }
+
+  std::vector<std::uint8_t>
+  make_submit(std::uint32_t seqnum, std::uint32_t devid, std::uint32_t direction,
+              std::uint32_t endpoint, const std::vector<std::uint8_t> &setup = {}) {
+    std::vector<std::uint8_t> wire(48 + setup.size(), 0);
+    put_u32be(wire, 0, 1);  // USBIP_CMD_SUBMIT
+    put_u32be(wire, 4, seqnum);
+    put_u32be(wire, 8, devid);
+    put_u32be(wire, 12, direction);
+    put_u32be(wire, 16, endpoint);
+    std::copy(setup.begin(), setup.end(), wire.begin() + 40);
+    return wire;
+  }
+
+  /** Collects device replies so tests can assert on them. */
+  class reply_collector {
+  public:
+    std::function<void(std::vector<std::uint8_t>)>
+    hook() {
+      return [this](std::vector<std::uint8_t> wire) {
+        std::lock_guard<std::mutex> lock(mutex);
+        replies.push_back(std::move(wire));
+      };
+    }
+
+    std::vector<std::vector<std::uint8_t>>
+    take_all() {
+      std::lock_guard<std::mutex> lock(mutex);
+      return std::exchange(replies, {});
+    }
+
+    std::size_t
+    count() {
+      std::lock_guard<std::mutex> lock(mutex);
+      return replies.size();
+    }
+
+  private:
+    std::mutex mutex;
+    std::vector<std::vector<std::uint8_t>> replies;
+  };
+
+  class virtual_touchscreen_test : public ::testing::Test {
+  protected:
+    void
+    SetUp() override {
+      remote_usb::virtual_touchscreen_device::config cfg;
+      cfg.width_px = 1920;
+      cfg.height_px = 1080;
+      cfg.finger_slots = 5;
+      device = std::make_unique<remote_usb::virtual_touchscreen_device>(cfg);
+      device->set_send_reply(collector.hook());
+    }
+
+    reply_collector collector;
+    std::unique_ptr<remote_usb::virtual_touchscreen_device> device;
+  };
+
+}  // namespace
+
+TEST_F(virtual_touchscreen_test, info_reports_hid_interface) {
+  const auto info = device->info();
+  EXPECT_EQ(info.vendor_id, 0x5355);
+  EXPECT_EQ(info.product_id, 0x5401);
+  EXPECT_EQ(info.busid, "1-2");
+  EXPECT_EQ(info.speed, 3u);
+  ASSERT_EQ(info.interfaces.size(), 1u);
+  EXPECT_EQ(info.interfaces[0].interface_class, 0x03);
+}
+
+TEST_F(virtual_touchscreen_test, devlist_reply_contains_device_block) {
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8005)));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+
+  const auto &wire = replies[0];
+  ASSERT_EQ(wire.size(), 8u + 316u);
+  // OP_REP header is big-endian: version 0x0111, code 0x0005, status ok.
+  EXPECT_EQ(wire[0], 0x01);
+  EXPECT_EQ(wire[1], 0x11);
+  EXPECT_EQ(wire[2], 0x00);
+  EXPECT_EQ(wire[3], 0x05);
+  EXPECT_EQ(get_u32be_at(wire, 4), 0u);
+
+  // Device block: path(256) busid(32) then numeric fields.
+  const std::size_t numeric = 8 + 256 + 32;
+  EXPECT_EQ(get_u32be_at(wire, numeric + 0), 1u);      // busnum
+  EXPECT_EQ(get_u32be_at(wire, numeric + 4), 1u);      // devnum
+  EXPECT_EQ(get_u32be_at(wire, numeric + 8), 3u);      // speed high
+  EXPECT_EQ(get_u16be_at(wire, numeric + 12), 0x5355);  // VID
+  EXPECT_EQ(get_u16be_at(wire, numeric + 14), 0x5401);  // PID
+}
+
+TEST_F(virtual_touchscreen_test, import_matches_busid_and_sets_imported) {
+  std::vector<std::uint8_t> busid(32, 0);
+  std::copy("1-2", "1-2" + 3, busid.begin());
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, busid)));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(get_u32be_at(replies[0], 4), 0u);  // status ok
+  EXPECT_EQ(replies[0].size(), 8u + 316u);
+  EXPECT_TRUE(device->imported());
+}
+
+TEST_F(virtual_touchscreen_test, import_rejects_foreign_busid) {
+  std::vector<std::uint8_t> busid(32, 0);
+  std::copy("9-9", "9-9" + 3, busid.begin());
+  ASSERT_TRUE(device->handle_request(make_op_request(0x8003, busid)));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(static_cast<std::int32_t>(get_u32be_at(replies[0], 4)), -2);  // -ENODEV
+  EXPECT_FALSE(device->imported());
+}
+
+TEST_F(virtual_touchscreen_test, get_device_descriptor) {
+  // GET_DESCRIPTOR(DEVICE), wLength=18
+  std::vector<std::uint8_t> setup = { 0x80, 0x06, 0x00, 0x01, 0x00, 0x00, 0x12, 0x00 };
+  ASSERT_TRUE(device->handle_request(make_submit(1, 0, 0, 0, setup)));
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), 48u + 18u);
+  EXPECT_EQ(get_u32be_at(replies[0], 0), 3u);  // RET_SUBMIT
+  EXPECT_EQ(get_u32be_at(replies[0], 4), 1u);  // seqnum echo
+  EXPECT_EQ(get_i32be_at(replies[0], 20), 0);  // status
+  EXPECT_EQ(get_i32be_at(replies[0], 24), 18);  // actual length
+  const std::size_t data = 48;
+  EXPECT_EQ(replies[0][data + 0], 0x12);
+  EXPECT_EQ(replies[0][data + 1], 0x01);
+  EXPECT_EQ(get_u16le_at(replies[0], data + 8), 0x5355);  // VID LE
+  EXPECT_EQ(get_u16le_at(replies[0], data + 10), 0x5401);  // PID LE
+}
+
+TEST_F(virtual_touchscreen_test, get_config_descriptor_and_report_descriptor) {
+  // GET_DESCRIPTOR(CONFIGURATION), wLength=255
+  std::vector<std::uint8_t> setup = { 0x80, 0x06, 0x00, 0x02, 0x00, 0x00, 0xFF, 0x00 };
+  ASSERT_TRUE(device->handle_request(make_submit(2, 0, 0, 0, setup)));
+  auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_EQ(replies[0].size(), 48u + 34u);
+  const std::size_t cfg = 48;
+  EXPECT_EQ(replies[0][cfg + 0], 0x09);
+  EXPECT_EQ(replies[0][cfg + 1], 0x02);
+  EXPECT_EQ(get_u16le_at(replies[0], cfg + 2), 34u);  // wTotalLength
+  EXPECT_EQ(replies[0][cfg + 9 + 5], 0x03);           // interface class: HID
+
+  // GET_DESCRIPTOR(REPORT) via class request to interface
+  std::vector<std::uint8_t> setup_report = { 0x81, 0x06, 0x00, 0x22, 0x00, 0x00, 0xFF, 0x00 };
+  ASSERT_TRUE(device->handle_request(make_submit(3, 0, 0, 0, setup_report)));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  ASSERT_GT(replies[0].size(), 48u);
+  const std::size_t len = replies[0].size() - 48u;
+  EXPECT_EQ(len, 60u);
+  EXPECT_EQ(replies[0][48 + 0], 0x05);  // Usage Page (Digitizers)
+  EXPECT_EQ(replies[0][48 + 1], 0x0D);
+}
+
+TEST_F(virtual_touchscreen_test, touch_down_delivers_queued_report) {
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 1;
+  finger.x = 960;
+  finger.y = 540;
+  finger.pressure = 128;
+  finger.tip = true;
+  finger.in_range = true;
+  device->update_contacts({ finger });
+  // The frame is queued until the guest polls the endpoint.
+  EXPECT_EQ(collector.take_all().size(), 0u);
+
+  ASSERT_TRUE(device->handle_request(make_submit(10, 7, 1, 1)));
+  EXPECT_EQ(device->submitted_in_urbs(), 1u);
+
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  const auto &wire = replies[0];
+  EXPECT_EQ(get_u32be_at(wire, 0), 3u);        // RET_SUBMIT
+  EXPECT_EQ(get_u32be_at(wire, 4), 10u);       // seqnum echo
+  EXPECT_EQ(get_u32be_at(wire, 8), 7u);        // devid echo
+  EXPECT_EQ(get_u32be_at(wire, 12), 1u);       // direction IN
+  EXPECT_EQ(get_u32be_at(wire, 16), 1u);       // endpoint
+  EXPECT_EQ(get_i32be_at(wire, 20), 0);        // status
+  EXPECT_EQ(get_i32be_at(wire, 24), 5);        // status + X16 + Y16
+
+  const std::size_t r = 48;
+  EXPECT_EQ(wire[r], 0x07);                    // tip | in range | confidence
+  EXPECT_EQ(get_u16le_at(wire, r + 1), 960u);  // x
+  EXPECT_EQ(get_u16le_at(wire, r + 3), 540u);  // y
+}
+
+TEST_F(virtual_touchscreen_test, held_contact_repeats_snapshot_per_poll) {
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 1;
+  finger.x = 100;
+  finger.y = 200;
+  finger.tip = true;
+  finger.in_range = true;
+  device->update_contacts({ finger });
+  // No pending submit: nothing is sent until the guest polls.
+  EXPECT_EQ(collector.take_all().size(), 0u);
+
+  ASSERT_TRUE(device->handle_request(make_submit(11, 0, 1, 1)));
+  auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0][48], 0x07);      // still down
+
+  // Second poll while held: snapshot repeats.
+  ASSERT_TRUE(device->handle_request(make_submit(12, 0, 1, 1)));
+  replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0][48], 0x07);
+}
+
+TEST_F(virtual_touchscreen_test, lift_emits_explicit_release_frame) {
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 3;
+  finger.x = 10;
+  finger.y = 20;
+  finger.tip = true;
+  finger.in_range = true;
+  device->update_contacts({ finger });
+  // First poll consumes the down frame.
+  ASSERT_TRUE(device->handle_request(make_submit(19, 0, 1, 1)));
+  collector.take_all();
+
+  // Lift: the next poll receives the explicit release frame.
+  device->update_contacts({});
+
+  ASSERT_TRUE(device->handle_request(make_submit(20, 0, 1, 1)));
+  auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(replies[0][48], 0x00);      // released status byte
+
+  // With no contacts left, further polls answer with zero-length transfers.
+  ASSERT_TRUE(device->handle_request(make_submit(21, 0, 1, 1)));
+  const auto idle = collector.take_all();
+  ASSERT_EQ(idle.size(), 1u);
+  EXPECT_EQ(idle[0].size(), 48u);
+  EXPECT_EQ(get_i32be_at(idle[0], 24), 0);  // actual_length 0
+}
+
+TEST_F(virtual_touchscreen_test, unlink_cancels_pending_submit) {
+  // Idle polls answer immediately, so there is nothing parked to unlink; the
+  // unlink still completes with status 0.
+  ASSERT_TRUE(device->handle_request(make_submit(30, 0, 1, 1)));
+  collector.take_all();
+
+  std::vector<std::uint8_t> unlink(48, 0);
+  put_u32be(unlink, 0, 2);   // USBIP_CMD_UNLINK
+  put_u32be(unlink, 4, 31);  // this request's seqnum
+  put_u32be(unlink, 20, 30); // unlink seqnum target
+  ASSERT_TRUE(device->handle_request(unlink));
+
+  const auto replies = collector.take_all();
+  ASSERT_EQ(replies.size(), 1u);
+  EXPECT_EQ(get_u32be_at(replies[0], 0), 4u);  // RET_UNLINK
+  EXPECT_EQ(get_u32be_at(replies[0], 4), 31u);
+  EXPECT_EQ(get_i32be_at(replies[0], 20), 0);
+}
+
+TEST_F(virtual_touchscreen_test, malformed_request_rejected) {
+  std::vector<std::uint8_t> short_pdu { 0x01, 0x11, 0x80, 0x05 };
+  EXPECT_FALSE(device->handle_request(short_pdu));
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -106,6 +106,7 @@ if(WIN32)
             Boost::asio
             Boost::system
             shell32
+            ole32
             user32
             advapi32
             ws2_32

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -93,6 +93,29 @@ if(WIN32)
             ${PLATFORM_LIBRARIES})
     target_compile_options(vdd-frame-channel-probe PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
 
+    add_executable(vtouch-poc
+            vtouch_poc.cpp
+            "${CMAKE_SOURCE_DIR}/src/remote_usb/loopback_usbip_bridge.cpp"
+            "${CMAKE_SOURCE_DIR}/src/remote_usb/virtual_touchscreen_device.cpp")
+    set_target_properties(vtouch-poc PROPERTIES
+            CXX_STANDARD 23
+            CXX_STANDARD_REQUIRED ON)
+    target_include_directories(vtouch-poc PRIVATE
+            "${CMAKE_SOURCE_DIR}")
+    target_link_libraries(vtouch-poc
+            Boost::asio
+            Boost::system
+            shell32
+            user32
+            advapi32
+            ws2_32
+            mswsock)
+    target_compile_options(vtouch-poc PRIVATE
+            $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+    if(MINGW)
+        target_link_options(vtouch-poc PRIVATE -municode)
+    endif()
+
     add_custom_target(check-vdd-ioctl-abi
             COMMAND powershell -NoProfile -ExecutionPolicy Bypass
                     -File "${CMAKE_CURRENT_SOURCE_DIR}/check_vdd_ioctl_abi.ps1"

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -1,0 +1,554 @@
+/**
+ * @file tools/vtouch_poc.cpp
+ * @brief POC: attach the virtual USB touchscreen through usbip-win2 and poke
+ *        it interactively to verify Windows-native touch keyboard auto-invoke.
+ *
+ * Usage: vtouch-poc [--usbip <path to usbip.exe>]
+ * Commands (stdin):
+ *   tap <x> <y>      single tap in primary-screen pixels
+ *   down <x> <y>     contact down
+ *   move <x> <y>     contact move
+ *   lift             contact up
+ *   circle           draw a slow circle at screen centre for ~2 s
+ *   status           print keyboard/window visibility
+ *   quit             detach and exit
+ */
+#ifndef UNICODE
+#define UNICODE
+#endif
+#ifndef _UNICODE
+#define _UNICODE
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <shellapi.h>
+
+#include <boost/system/error_code.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <src/remote_usb/loopback_usbip_bridge.h>
+#include <src/remote_usb/virtual_touchscreen_device.h>
+
+namespace fs = std::filesystem;
+
+static bool
+is_elevated() {
+  FARPROC proc = GetProcAddress(GetModuleHandleW(L"shell32.dll"), "IsUserAnAdmin");
+  if (!proc) {
+    return false;
+  }
+  return ((BOOL (WINAPI *)()) proc)() != FALSE;
+}
+
+static std::string
+run_tool(const std::wstring &cmdline) {
+  SECURITY_ATTRIBUTES sa = { sizeof(sa), nullptr, TRUE };
+  HANDLE read_end = nullptr, write_end = nullptr;
+  if (!CreatePipe(&read_end, &write_end, &sa, 0)) {
+    return "pipe failed";
+  }
+  STARTUPINFOW si = {};
+  si.cb = sizeof(si);
+  si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+  si.wShowWindow = SW_HIDE;
+  si.hStdOutput = write_end;
+  si.hStdError = write_end;
+  PROCESS_INFORMATION pi = {};
+  std::vector<wchar_t> mutable_cmd(cmdline.begin(), cmdline.end());
+  mutable_cmd.push_back(L'\0');
+  if (!CreateProcessW(nullptr, mutable_cmd.data(), nullptr, nullptr, TRUE, 0,
+                      nullptr, nullptr, &si, &pi)) {
+    CloseHandle(read_end);
+    CloseHandle(write_end);
+    return "create process failed";
+  }
+  CloseHandle(write_end);
+  std::string out;
+  char buf[1024];
+  DWORD read = 0;
+  while (ReadFile(read_end, buf, sizeof(buf), &read, nullptr) && read != 0) {
+    out.append(buf, read);
+  }
+  WaitForSingleObject(pi.hProcess, 15000);
+  DWORD code = 0;
+  GetExitCodeProcess(pi.hProcess, &code);
+  CloseHandle(read_end);
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
+  char tail[64];
+  snprintf(tail, sizeof(tail), "[exit %lu]", (unsigned long) code);
+  out += tail;
+  return out;
+}
+
+static void
+print_status() {
+  HWND tip = FindWindowW(L"IPTip_Main_Window", nullptr);
+  bool tip_visible = tip && IsWindowVisible(tip);
+  printf("keyboard: IPTip hwnd=%p visible=%d\n", (void *) tip, (int) tip_visible);
+}
+
+// ---- auto mode: create a foreground edit window, tap it, watch the keyboard ----
+
+static HWND g_host = nullptr, g_edit = nullptr;
+static bool g_imported = false;
+static bool g_verbose = false;
+static int g_raw_input_frames = 0;
+
+static void
+print_raw_digitizer_count(const char *tag) {
+  UINT count = 0;
+  if (GetRawInputDeviceList(nullptr, &count, sizeof(RAWINPUTDEVICELIST)) != 0 || count == 0) {
+    printf("[raw] %s: device list unavailable\n", tag);
+    return;
+  }
+  std::vector<RAWINPUTDEVICELIST> devs(count);
+  GetRawInputDeviceList(devs.data(), &count, sizeof(RAWINPUTDEVICELIST));
+  int digitizers = 0;
+  for (const auto &d : devs) {
+    RID_DEVICE_INFO info {};
+    UINT size = sizeof(info);
+    if (GetRawInputDeviceInfoW(d.hDevice, RIDI_DEVICEINFO, &info, &size) > 0 &&
+        info.hid.usUsagePage == 0x0D) {
+      ++digitizers;
+      wchar_t name[512] = {};
+      UINT nsize = sizeof(name);
+      GetRawInputDeviceInfoW(d.hDevice, RIDI_DEVICENAME, name, &nsize);
+      printf("[raw] %s: digitizer vid=0x%04X pid=0x%04X usage=0x%02X path=%ls\n", tag,
+             info.hid.dwVendorId, info.hid.dwProductId, info.hid.usUsage, name);
+    }
+  }
+  printf("[raw] %s: %d digitizer(s) total\n", tag, digitizers);
+}
+
+static void
+dump_pdu(const char *tag, const std::vector<std::uint8_t> &pdu) {
+  if (!g_verbose) return;
+  printf("%s %zu bytes:", tag, pdu.size());
+  for (size_t i = 0; i < pdu.size() && i < 64; ++i) {
+    if (i % 16 == 0) printf("\n  ");
+    printf("%02X ", pdu[i]);
+  }
+  printf("\n");
+}
+
+static LRESULT CALLBACK
+host_proc(HWND h, UINT m, WPARAM w, LPARAM l) {
+  if (m == WM_INPUT) {
+    UINT size = 0;
+    GetRawInputData((HRAWINPUT) l, RID_INPUT, nullptr, &size, sizeof(RAWINPUTHEADER));
+    if (size > 0 && size <= 512) {
+      static thread_local std::vector<BYTE> buf(512);
+      if (GetRawInputData((HRAWINPUT) l, RID_INPUT, buf.data(), &size, sizeof(RAWINPUTHEADER)) > 0) {
+        auto *raw = (RAWINPUT *) buf.data();
+        if (raw->header.dwType == RIM_TYPEHID) {
+          ++g_raw_input_frames;
+          printf("[raw] WM_INPUT hid dwSize=%u count=%u first=%02X %02X %02X %02X\n",
+                 raw->data.hid.dwSizeHid, raw->data.hid.dwCount,
+                 raw->data.hid.bRawData[0], raw->data.hid.bRawData[1],
+                 raw->data.hid.bRawData[2], raw->data.hid.bRawData[3]);
+        }
+      }
+    }
+  }
+  if (m >= 0x0246 && m <= 0x024A) {  // WM_POINTERDOWN/UP/UPDATE/... window
+    UINT32 pid = (UINT32) (w & 0xFFFF);
+    POINTER_INFO pi {};
+    if (GetPointerInfo(pid, &pi)) {
+      printf("[ptr] msg=0x%03X id=%u type=%u flags=0x%X at (%ld,%ld)\n",
+             m, pid, pi.pointerType, pi.pointerFlags,
+             (long) pi.ptPixelLocation.x, (long) pi.ptPixelLocation.y);
+    }
+    else {
+      printf("[ptr] msg=0x%03X id=%u GetPointerInfo failed %lu\n", m, pid, GetLastError());
+    }
+  }
+  return DefWindowProcW(h, m, w, l);
+}
+
+/** Returns true when the touch keyboard window becomes visible. */
+static bool
+wait_keyboard_visible(int timeout_ms) {
+  for (int i = 0; i < timeout_ms / 250; ++i) {
+    HWND tip = FindWindowW(L"IPTip_Main_Window", nullptr);
+    if (tip && IsWindowVisible(tip)) {
+      return true;
+    }
+    Sleep(250);
+  }
+  return false;
+}
+
+static int g_clicks = 0;
+static WNDPROC g_old_edit_proc = nullptr;
+
+static LRESULT CALLBACK
+edit_proc_hook(HWND h, UINT m, WPARAM w, LPARAM l) {
+  if (m == 0x0201 || m == 0x0202 || (m >= 0x0240 && m <= 0x025F)) {
+    ++g_clicks;
+    printf("[click] edit got msg 0x%03X (total %d)\n", m, g_clicks);
+  }
+  return CallWindowProcW(g_old_edit_proc, h, m, w, l);
+}
+
+static void
+StealForeground() {
+  HWND fg = GetForegroundWindow();
+  DWORD fg_thread = GetWindowThreadProcessId(fg, nullptr);
+  DWORD cur = GetCurrentThreadId();
+  AttachThreadInput(cur, fg_thread, TRUE);
+  SetForegroundWindow(g_host);
+  SetFocus(g_edit);
+  AttachThreadInput(cur, fg_thread, FALSE);
+}
+
+static int
+run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h) {
+  WNDCLASSW wc = {};
+  wc.lpfnWndProc = host_proc;
+  wc.lpszClassName = L"VtouchPocHost";
+  wc.hInstance = GetModuleHandleW(nullptr);
+  RegisterClassW(&wc);
+  g_host = CreateWindowExW(0, wc.lpszClassName, L"Vtouch POC", WS_OVERLAPPEDWINDOW,
+                           200, 200, 640, 320, nullptr, nullptr, wc.hInstance, nullptr);
+  g_edit = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", L"click target",
+                           WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL,
+                           10, 10, 600, 48, g_host, nullptr, wc.hInstance, nullptr);
+  g_old_edit_proc = (WNDPROC) SetWindowLongPtrW(g_edit, GWLP_WNDPROC, (LONG_PTR) edit_proc_hook);
+  ShowWindow(g_host, SW_SHOW);
+  EnableMouseInPointer(TRUE);  // observe WM_POINTER with pointerType
+
+  // Sink for digitizer raw input so we can see whether our HID frames reach
+  // the input stack at all.
+  RAWINPUTDEVICE rid {};
+  rid.usUsagePage = 0x0D;
+  rid.usUsage = 0x04;  // touchscreen
+  rid.dwFlags = RIDEV_INPUTSINK;
+  rid.hwndTarget = g_host;
+  if (!RegisterRawInputDevices(&rid, 1, sizeof(rid))) {
+    printf("[raw] RegisterRawInputDevices failed err=%lu\n", GetLastError());
+  }
+
+  // Bring the edit to foreground (attach to the current foreground thread).
+  HWND fg = GetForegroundWindow();
+  DWORD fg_thread = GetWindowThreadProcessId(fg, nullptr);
+  DWORD cur = GetCurrentThreadId();
+  AttachThreadInput(cur, fg_thread, TRUE);
+  SetForegroundWindow(g_host);
+  SetFocus(g_edit);
+  AttachThreadInput(cur, fg_thread, FALSE);
+  Sleep(400);
+
+  RECT r;
+  GetWindowRect(g_edit, &r);
+  int x = (r.left + r.right) / 2, y = (r.top + r.bottom) / 2;
+  printf("[auto] foreground set; tapping edit centre at (%d,%d)\n", x, y);
+
+  auto to_digitizer = [&](int px, int py) {
+    dev.update_contacts({ remote_usb::touchscreen_contact {
+      1,
+      (std::uint16_t) ((std::int64_t) px * 1920 / screen_w),
+      (std::uint16_t) ((std::int64_t) py * 1080 / screen_h),
+      100, true, true } });
+  };
+  // Three tap attempts; each checks whether the edit gains keyboard focus.
+  bool ever_focused = false;
+  for (int attempt = 1; attempt <= 3 && !ever_focused; ++attempt) {
+    StealForeground();
+    Sleep(200);
+    to_digitizer(x, y);
+    Sleep(120);
+    to_digitizer(x, y + 1);
+    Sleep(60);
+    to_digitizer(x, y);
+    Sleep(120);
+    dev.update_contacts({});
+    Sleep(600);
+    GUITHREADINFO gti {};
+    gti.cbSize = sizeof(gti);
+    GetGUIThreadInfo(0, &gti);
+    bool focused = gti.hwndFocus == g_edit;
+    ever_focused |= focused;
+    POINT cur;
+    GetCursorPos(&cur);
+    printf("[auto] tap #%d: focus=%s cursor=(%ld,%ld) target=(%d,%d)\n",
+           attempt, focused ? "ON EDIT" : "not on edit", (long) cur.x, (long) cur.y, x, y);
+    print_status();
+  }
+  printf("[auto] edit focus ever gained: %s\n", ever_focused ? "YES" : "NO");
+  printf("[auto] tap sent; waiting up to 8 s for the touch keyboard...\n");
+  bool visible = wait_keyboard_visible(8000);
+  printf("[auto] raw input frames seen at sink: %d\n", g_raw_input_frames);
+  printf("[auto] RESULT: touch keyboard %s\n", visible ? "VISIBLE (auto-invoke works!)"
+                                                      : "not visible (auto-invoke did not fire)");
+  print_status();
+  return visible ? 0 : 2;
+}
+
+int
+wmain(int argc, wchar_t **argv) {
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  std::wstring usbip_path;
+  bool auto_mode = false;
+  bool mouse_mode = false;
+  for (int i = 1; i < argc; ++i) {
+    if (wcscmp(argv[i], L"--usbip") == 0 && i + 1 < argc) {
+      usbip_path = argv[++i];
+    }
+    else if (wcscmp(argv[i], L"--auto") == 0) {
+      auto_mode = true;
+    }
+    else if (wcscmp(argv[i], L"--verbose") == 0) {
+      g_verbose = true;
+    }
+    else if (wcscmp(argv[i], L"--mouse") == 0) {
+      mouse_mode = true;
+    }
+    else if (wcscmp(argv[i], L"--log") == 0 && i + 1 < argc) {
+      _wfreopen(argv[++i], L"w", stdout);
+      setvbuf(stdout, nullptr, _IONBF, 0);
+    }
+  }
+  if (usbip_path.empty()) {
+    usbip_path = L"usbip.exe";
+  }
+
+  if (!is_elevated()) {
+    printf("not elevated; the attach step will request UAC.\n");
+  }
+
+  remote_usb::virtual_touchscreen_device::config cfg;
+  cfg.mouse_mode = mouse_mode;
+  cfg.product_id = mouse_mode ? 0x5402 : 0x5401;
+  cfg.width_px = 1920;
+  cfg.height_px = 1080;
+  remote_usb::virtual_touchscreen_device dev(cfg);
+
+  remote_usb::loopback_usbip_bridge bridge;
+  boost::system::error_code ec;
+
+  auto callbacks = remote_usb::callbacks {};
+  callbacks.on_request = [&dev](std::vector<std::uint8_t> pdu) {
+    dump_pdu("REQ <<", pdu);
+    return dev.handle_request(pdu);
+  };
+  callbacks.on_imported = []() {
+    g_imported = true;
+    printf(">>> vhci imported the device\n");
+  };
+  callbacks.on_closed = [](remote_usb::close_reason reason) {
+    printf(">>> bridge closed (%d)\n", (int) reason);
+  };
+
+  auto endpoint = bridge.start(dev.info(), std::move(callbacks), ec);
+  if (!endpoint) {
+    printf("bridge start failed: %s\n", ec.message().c_str());
+    return 1;
+  }
+  dev.set_send_reply([&bridge](std::vector<std::uint8_t> wire) {
+    dump_pdu("REP >>", wire);
+    bridge.send_reply(std::move(wire));
+  });
+
+  printf("bridge listening on %s:%u busid=%s\n", endpoint->address.c_str(),
+         endpoint->port, endpoint->busid.c_str());
+
+  // Attach through usbip-win2.  The attach command needs admin rights; when
+  // we are not elevated, launch it via UAC and wait for the IMPORT request.
+  {
+    std::wstring cmd = L"\"" + usbip_path + L"\" --tcp-port " +
+                       std::to_wstring(endpoint->port) + L" attach --remote " +
+                       std::wstring(endpoint->address.begin(), endpoint->address.end()) +
+                       L" --bus-id " + std::wstring(endpoint->busid.begin(), endpoint->busid.end()) +
+                       L" --terse";
+    if (is_elevated()) {
+      std::string out = run_tool(cmd);
+      printf("usbip attach: %s\n", out.c_str());
+    }
+    else {
+      printf("not elevated; requesting UAC for the attach command...\n");
+      char log_path[MAX_PATH];
+      snprintf(log_path, sizeof(log_path), "%s\\vtouch-attach.log", getenv("TEMP") ? getenv("TEMP") : ".");
+      wchar_t cmd_buf[2048];
+      swprintf_s(cmd_buf,
+                 L"/c \"\"%s\" --tcp-port %u attach --remote %hs --bus-id %hs --terse"
+                 L" > \"%hs\" 2>&1\"",
+                 usbip_path.c_str(), endpoint->port, endpoint->address.c_str(),
+                 endpoint->busid.c_str(), log_path);
+      SHELLEXECUTEINFOW sei = {};
+      sei.cbSize = sizeof(sei);
+      sei.fMask = SEE_MASK_NOCLOSEPROCESS;
+      sei.lpVerb = L"runas";
+      sei.lpFile = L"cmd.exe";
+      sei.lpParameters = cmd_buf;
+      sei.nShow = SW_HIDE;
+      if (!ShellExecuteExW(&sei)) {
+        printf("UAC declined; cannot attach without admin.\n");
+        bridge.stop();
+        return 1;
+      }
+      WaitForSingleObject(sei.hProcess, 30000);
+      CloseHandle(sei.hProcess);
+      FILE *log = fopen(log_path, "r");
+      if (log) {
+        char buf[2048];
+        size_t n = fread(buf, 1, sizeof(buf) - 1, log);
+        buf[n] = 0;
+        printf("usbip attach output: %s\n", buf);
+        fclose(log);
+      }
+    }
+  }
+
+  // The bridge answers OP_REQ_IMPORT itself; wait for its callback.  The
+  // VHCI service retries attach attempts in the background, so be generous.
+  for (int i = 0; i < 600 && !g_imported; ++i) {
+    Sleep(100);
+  }
+  if (!g_imported) {
+    printf("device was not imported (attach failed or timed out).\n");
+    bridge.stop();
+    return 1;
+  }
+  printf("device imported by VHCI; checking raw input device list...\n");
+  Sleep(1500);  // let HIDCLASS finish enumeration
+  print_raw_digitizer_count("after-attach");
+  system("powershell -NoProfile -Command \"Get-PnpDevice | Where-Object { ($_.Present) -and ($_.InstanceId -match 'VID_5355')} | Format-List FriendlyName,Status,Class,Present,InstanceId | Out-File -Encoding utf8 C:\\Users\\mohaha\\AppData\\Local\\Temp\\vt-pnp-online.txt\"");
+  system("powershell -NoProfile -Command \"Get-PnpDevice -Class HIDClass | Where-Object Present | Format-List FriendlyName,Status,InstanceId | Out-File -Encoding utf8 C:\\Users\\mohaha\\AppData\\Local\\Temp\\vt-hid-online.txt\"");
+
+  const int screen_w = GetSystemMetrics(SM_CXSCREEN);
+  const int screen_h = GetSystemMetrics(SM_CYSCREEN);
+
+  if (mouse_mode) {
+  POINT start_pos, now_pos;
+  GetCursorPos(&start_pos);
+  double max_dist = 0;
+  auto sampler = std::thread([&]() {
+    while (true) {
+      Sleep(40);
+      GetCursorPos(&now_pos);
+      double d = hypot(now_pos.x - start_pos.x, now_pos.y - start_pos.y);
+      double snap = d;
+      if (snap > max_dist) max_dist = snap;
+    }
+  });
+  sampler.detach();
+    printf("[mouse] wiggling the pointer for 4 s -- watch the cursor\n");
+    for (int i = 0; i < 200; ++i) {
+      double a = 2.0 * 3.141592653589793 * i / 50.0;
+      dev.update_mouse((std::int8_t) (cos(a) * 6), (std::int8_t) (sin(a) * 6), 0);
+      Sleep(20);
+    }
+  Sleep(300);
+  GetCursorPos(&now_pos);
+  double final_dist = hypot(now_pos.x - start_pos.x, now_pos.y - start_pos.y);
+  printf("[mouse] cursor moved: max=%.0f px final=%.0f px -> %s\n", max_dist, final_dist,
+         (max_dist > 20 ? "INPUT PATH WORKS" : "cursor did not move"));
+    printf("[mouse] wiggle done\n");
+    Sleep(2000);
+    bridge.stop();
+    return 0;
+  }
+
+  if (auto_mode) {
+    int rc = run_auto(dev, screen_w, screen_h);
+    Sleep(3000);
+    bridge.stop();
+    return rc;
+  }
+
+  printf("screen %dx%d. commands: tap x y | down x y | move x y | lift | circle | status | quit\n",
+         screen_w, screen_h);
+
+  std::vector<remote_usb::touchscreen_contact> contacts;
+  remote_usb::touchscreen_contact finger;
+  finger.contact_id = 1;
+  bool held = false;
+
+  auto to_digitizer = [&](int x, int y) {
+    finger.x = (std::uint16_t) ((std::int64_t) (x - 0) * cfg.width_px / screen_w);
+    finger.y = (std::uint16_t) ((std::int64_t) (y - 0) * cfg.height_px / screen_h);
+  };
+
+  char line[256];
+  bool running = true;
+  while (running && fgets(line, sizeof(line), stdin)) {
+    char cmd[32] = { 0 };
+    int x = 0, y = 0;
+    if (sscanf(line, "%31s %d %d", cmd, &x, &y) < 1) {
+      continue;
+    }
+    if (strcmp(cmd, "tap") == 0) {
+      to_digitizer(x, y);
+      finger.tip = true;
+      finger.in_range = true;
+      finger.pressure = 100;
+      dev.update_contacts({ finger });
+      Sleep(60);
+      finger.tip = false;
+      finger.in_range = false;
+      finger.pressure = 0;
+      dev.update_contacts({ finger });
+      print_status();
+    }
+    else if (strcmp(cmd, "down") == 0) {
+      to_digitizer(x, y);
+      finger.tip = true;
+      finger.in_range = true;
+      finger.pressure = 100;
+      held = true;
+      dev.update_contacts({ finger });
+      print_status();
+    }
+    else if (strcmp(cmd, "move") == 0) {
+      to_digitizer(x, y);
+      dev.update_contacts({ finger });
+    }
+    else if (strcmp(cmd, "lift") == 0) {
+      if (held) {
+        finger.tip = false;
+        finger.in_range = false;
+        finger.pressure = 0;
+        held = false;
+        dev.update_contacts({ finger });
+      }
+      print_status();
+    }
+    else if (strcmp(cmd, "circle") == 0) {
+      const int cx = screen_w / 2, cy = screen_h / 2, r = screen_h / 8;
+      for (int i = 0; i <= 128 && running; ++i) {
+        double a = 2.0 * 3.141592653589793 * i / 128.0;
+        to_digitizer(cx + (int) (r * cos(a)), cy + (int) (r * sin(a)));
+        finger.tip = true;
+        finger.in_range = true;
+        finger.pressure = 100;
+        dev.update_contacts({ finger });
+        Sleep(12);
+        if (i % 32 == 0) {
+          print_status();
+        }
+      }
+      finger.tip = false;
+      finger.in_range = false;
+      finger.pressure = 0;
+      dev.update_contacts({ finger });
+      print_status();
+    }
+    else if (strcmp(cmd, "status") == 0) {
+      print_status();
+    }
+    else if (strcmp(cmd, "quit") == 0) {
+      running = false;
+    }
+  }
+
+  bridge.stop();
+  printf("bye\n");
+  return 0;
+}

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -12,6 +12,27 @@
  *   circle           draw a slow circle at screen centre for ~2 s
  *   status           print keyboard/window visibility
  *   quit             detach and exit
+ *
+ * Flags:
+ *   --auto    run the full automated verdict (attach, foreground edit,
+ *             synthetic taps, focus/click/keyboard-visibility checks)
+ *   --mouse   attach a boot-mouse profile instead (control experiment;
+ *             verified working: moves the real cursor)
+ *   --log <path>   redirect all output to a file (use with elevated runs)
+ *   --verbose hex-dump every USB/IP PDU
+ *
+ * Known issue (open): with the touchscreen profile, hover positioning works
+ * (the cursor tracks the contact pixel exactly) but tip-down click delivery
+ * does not happen: the target window receives no WM_LBUTTONDOWN /
+ * WM_POINTERDOWN, focus never lands, and the touch keyboard never auto-
+ * invokes.  Reproduced consistently on Windows 11 26200 + usbip-win2
+ * 0.9.7.7 with four report-descriptor variants (parallel multi-touch,
+ * vmulti-style hybrid, minimal single-touch, +Confidence bit).  Run
+ * `--auto --log <file>` and read the `tap #` / `[click]` / `RESULT` lines;
+ * a mouse-profile build (`--mouse`) proves the USB/IP -> VHCI -> HIDCLASS
+ * -> input-stack path itself works.  Suspects: 26200 touch-stack policy
+ * for virtual HID touchscreens, remote-session interference, hvctl
+ * validation of non-certified digitizers.
  */
 #ifndef UNICODE
 #define UNICODE

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -282,6 +282,22 @@ edit_proc_hook(HWND h, UINT m, WPARAM w, LPARAM l) {
 }
 
 static void
+create_test_window() {
+  WNDCLASSW wc = {};
+  wc.lpfnWndProc = host_proc;
+  wc.lpszClassName = L"VtouchPocHost";
+  wc.hInstance = GetModuleHandleW(nullptr);
+  RegisterClassW(&wc);
+  g_host = CreateWindowExW(0, wc.lpszClassName, L"Vtouch POC", WS_OVERLAPPEDWINDOW,
+                           200, 200, 640, 320, nullptr, nullptr, wc.hInstance, nullptr);
+  g_edit = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", L"click target",
+                           WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL,
+                           10, 10, 600, 48, g_host, nullptr, wc.hInstance, nullptr);
+  g_old_edit_proc = (WNDPROC) SetWindowLongPtrW(g_edit, GWLP_WNDPROC, (LONG_PTR) edit_proc_hook);
+  ShowWindow(g_host, SW_SHOW);
+}
+
+static void
 StealForeground() {
   HWND fg = GetForegroundWindow();
   DWORD fg_thread = GetWindowThreadProcessId(fg, nullptr);
@@ -558,6 +574,46 @@ wmain(int argc, wchar_t **argv) {
     printf("[mouse] cursor moved: max=%.0f px final=%.0f px -> %s\n", max_dist, final_dist,
            (max_dist > 20 ? "INPUT PATH WORKS" : "cursor did not move"));
     printf("[mouse] wiggle done\n");
+
+    // Secondary control experiment: point the cursor at the edit field and
+    // send a left button press+release through the virtual mouse.  This
+    // checks the click path of the virtual HID device; the touchscreen
+    // profile's own tip-click issue is tracked separately.
+    {
+      create_test_window();
+      Sleep(300);
+      StealForeground();
+      Sleep(200);
+      SetForegroundWindow(g_host);
+      SetFocus(g_edit);
+      Sleep(200);
+      // Nudge the cursor onto the edit centre with relative moves.
+      POINT cur;
+      GetCursorPos(&cur);
+      RECT r;
+      GetWindowRect(g_edit, &r);
+      int tx = (r.left + r.right) / 2, ty = (r.top + r.bottom) / 2;
+      while ((abs(cur.x - tx) > 60 || abs(cur.y - ty) > 60)) {
+        dev.update_mouse((std::int8_t) ((tx - cur.x) / 8), (std::int8_t) ((ty - cur.y) / 8), 0);
+        cur.x += (tx - cur.x) / 8;
+        cur.y += (ty - cur.y) / 8;
+        Sleep(15);
+      }
+      g_clicks = 0;
+      dev.update_mouse(0, 0, 0x01);  // left down
+      Sleep(60);
+      dev.update_mouse(0, 0, 0x00);  // left up
+      Sleep(600);
+      GUITHREADINFO gti {};
+      gti.cbSize = sizeof(gti);
+      GetGUIThreadInfo(0, &gti);
+      printf("[mouse] click messages seen at edit: %d, focus on edit: %s\n",
+             g_clicks, gti.hwndFocus == g_edit ? "YES" : "no");
+      printf("[mouse] VERDICT: virtual-mouse left-click %s\n",
+             (g_clicks > 0 && gti.hwndFocus == g_edit) ? "WORKS"
+             : (g_clicks > 0 ? "delivered but focus off" : "NOT delivered"));
+    }
+
     Sleep(2000);
     bridge.stop();
     return 0;

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -21,13 +21,17 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <objbase.h>
 #include <shellapi.h>
+#include <shobjidl.h>
 
 #include <boost/system/error_code.hpp>
 
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <filesystem>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -46,13 +50,19 @@ is_elevated() {
   return ((BOOL (WINAPI *)()) proc)() != FALSE;
 }
 
+/**
+ * Run a child process with stdout/stderr captured, killing it after
+ * `timeout_ms`.  The pipe is drained on a helper thread so the timeout is
+ * enforced even while the child keeps its output handles open.
+ */
 static std::string
-run_tool(const std::wstring &cmdline) {
+run_tool(const std::wstring &cmdline, DWORD timeout_ms = 15000) {
   SECURITY_ATTRIBUTES sa = { sizeof(sa), nullptr, TRUE };
   HANDLE read_end = nullptr, write_end = nullptr;
   if (!CreatePipe(&read_end, &write_end, &sa, 0)) {
     return "pipe failed";
   }
+  SetHandleInformation(read_end, HANDLE_FLAG_INHERIT, 0);
   STARTUPINFOW si = {};
   si.cb = sizeof(si);
   si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
@@ -70,34 +80,85 @@ run_tool(const std::wstring &cmdline) {
   }
   CloseHandle(write_end);
   std::string out;
-  char buf[1024];
-  DWORD read = 0;
-  while (ReadFile(read_end, buf, sizeof(buf), &read, nullptr) && read != 0) {
-    out.append(buf, read);
+  std::thread reader([&]() {
+    char buf[1024];
+    DWORD read = 0;
+    while (ReadFile(read_end, buf, sizeof(buf), &read, nullptr) && read != 0) {
+      out.append(buf, read);
+    }
+  });
+  bool timed_out = false;
+  if (WaitForSingleObject(pi.hProcess, timeout_ms) == WAIT_TIMEOUT) {
+    timed_out = true;
+    TerminateProcess(pi.hProcess, 1);
+    WaitForSingleObject(pi.hProcess, 5000);
   }
-  WaitForSingleObject(pi.hProcess, 15000);
+  // Once the child is gone the write end has no more owners (usbip.exe spawns
+  // no grandchildren), so the reader observes EOF and exits.
+  reader.join();
   DWORD code = 0;
   GetExitCodeProcess(pi.hProcess, &code);
   CloseHandle(read_end);
   CloseHandle(pi.hProcess);
   CloseHandle(pi.hThread);
   char tail[64];
-  snprintf(tail, sizeof(tail), "[exit %lu]", (unsigned long) code);
+  snprintf(tail, sizeof(tail), timed_out ? "[timeout, killed]" : "[exit %lu]", (unsigned long) code);
   out += tail;
   return out;
 }
 
+/** Dispatch queued window messages, then sleep until `ms` has elapsed. */
+static void
+pump_sleep(DWORD ms) {
+  const ULONGLONG deadline = GetTickCount64() + ms;
+  for (;;) {
+    MSG msg;
+    unsigned dispatched = 0;
+    while (dispatched++ < 256 && PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&msg);
+      DispatchMessageW(&msg);
+    }
+    const ULONGLONG now = GetTickCount64();
+    if (now >= deadline) {
+      return;
+    }
+    MsgWaitForMultipleObjects(0, nullptr, FALSE, (DWORD) (deadline - now), QS_ALLINPUT);
+  }
+}
+
+static bool
+keyboard_visible(RECT *location = nullptr) {
+  IFrameworkInputPane *pane = nullptr;
+  if (SUCCEEDED(CoCreateInstance(CLSID_FrameworkInputPane, nullptr, CLSCTX_INPROC_SERVER,
+                                 IID_IFrameworkInputPane, reinterpret_cast<void **>(&pane)))) {
+    RECT rect {};
+    const bool visible = SUCCEEDED(pane->Location(&rect)) &&
+                         rect.right > rect.left && rect.bottom > rect.top;
+    pane->Release();
+    if (location) {
+      *location = rect;
+    }
+    if (visible) {
+      return true;
+    }
+  }
+
+  HWND tip = FindWindowW(L"IPTip_Main_Window", nullptr);
+  return tip && IsWindowVisible(tip);
+}
+
 static void
 print_status() {
-  HWND tip = FindWindowW(L"IPTip_Main_Window", nullptr);
-  bool tip_visible = tip && IsWindowVisible(tip);
-  printf("keyboard: IPTip hwnd=%p visible=%d\n", (void *) tip, (int) tip_visible);
+  RECT rect {};
+  const bool visible = keyboard_visible(&rect);
+  printf("keyboard: visible=%d rect=(%ld,%ld)-(%ld,%ld)\n", (int) visible,
+         (long) rect.left, (long) rect.top, (long) rect.right, (long) rect.bottom);
 }
 
 // ---- auto mode: create a foreground edit window, tap it, watch the keyboard ----
 
 static HWND g_host = nullptr, g_edit = nullptr;
-static bool g_imported = false;
+static std::atomic_bool g_imported { false };  // written on the bridge I/O thread
 static bool g_verbose = false;
 static int g_raw_input_frames = 0;
 
@@ -149,10 +210,13 @@ host_proc(HWND h, UINT m, WPARAM w, LPARAM l) {
         auto *raw = (RAWINPUT *) buf.data();
         if (raw->header.dwType == RIM_TYPEHID) {
           ++g_raw_input_frames;
-          printf("[raw] WM_INPUT hid dwSize=%u count=%u first=%02X %02X %02X %02X\n",
-                 raw->data.hid.dwSizeHid, raw->data.hid.dwCount,
-                 raw->data.hid.bRawData[0], raw->data.hid.bRawData[1],
-                 raw->data.hid.bRawData[2], raw->data.hid.bRawData[3]);
+          if (g_verbose) {
+            printf("[raw] WM_INPUT hid dwSize=%lu count=%lu first=%02X %02X %02X %02X\n",
+                   (unsigned long) raw->data.hid.dwSizeHid,
+                   (unsigned long) raw->data.hid.dwCount,
+                   raw->data.hid.bRawData[0], raw->data.hid.bRawData[1],
+                   raw->data.hid.bRawData[2], raw->data.hid.bRawData[3]);
+          }
         }
       }
     }
@@ -176,11 +240,10 @@ host_proc(HWND h, UINT m, WPARAM w, LPARAM l) {
 static bool
 wait_keyboard_visible(int timeout_ms) {
   for (int i = 0; i < timeout_ms / 250; ++i) {
-    HWND tip = FindWindowW(L"IPTip_Main_Window", nullptr);
-    if (tip && IsWindowVisible(tip)) {
+    if (keyboard_visible()) {
       return true;
     }
-    Sleep(250);
+    pump_sleep(250);
   }
   return false;
 }
@@ -204,7 +267,7 @@ StealForeground() {
   DWORD cur = GetCurrentThreadId();
   AttachThreadInput(cur, fg_thread, TRUE);
   SetForegroundWindow(g_host);
-  SetFocus(g_edit);
+  SetFocus(g_host);
   AttachThreadInput(cur, fg_thread, FALSE);
 }
 
@@ -214,12 +277,25 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
   wc.lpfnWndProc = host_proc;
   wc.lpszClassName = L"VtouchPocHost";
   wc.hInstance = GetModuleHandleW(nullptr);
-  RegisterClassW(&wc);
+  if (!RegisterClassW(&wc) && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+    printf("[auto] RegisterClass failed err=%lu\n", GetLastError());
+    return 1;
+  }
   g_host = CreateWindowExW(0, wc.lpszClassName, L"Vtouch POC", WS_OVERLAPPEDWINDOW,
                            200, 200, 640, 320, nullptr, nullptr, wc.hInstance, nullptr);
+  if (!g_host) {
+    printf("[auto] CreateWindow(host) failed err=%lu\n", GetLastError());
+    return 1;
+  }
   g_edit = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", L"click target",
                            WS_CHILD | WS_VISIBLE | ES_AUTOHSCROLL,
                            10, 10, 600, 48, g_host, nullptr, wc.hInstance, nullptr);
+  if (!g_edit) {
+    printf("[auto] CreateWindow(edit) failed err=%lu\n", GetLastError());
+    DestroyWindow(g_host);
+    g_host = nullptr;
+    return 1;
+  }
   g_old_edit_proc = (WNDPROC) SetWindowLongPtrW(g_edit, GWLP_WNDPROC, (LONG_PTR) edit_proc_hook);
   ShowWindow(g_host, SW_SHOW);
   EnableMouseInPointer(TRUE);  // observe WM_POINTER with pointerType
@@ -235,18 +311,22 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
     printf("[raw] RegisterRawInputDevices failed err=%lu\n", GetLastError());
   }
 
-  // Bring the edit to foreground (attach to the current foreground thread).
+  // Activate the host but leave the edit unfocused; the touch must focus it.
   HWND fg = GetForegroundWindow();
   DWORD fg_thread = GetWindowThreadProcessId(fg, nullptr);
   DWORD cur = GetCurrentThreadId();
   AttachThreadInput(cur, fg_thread, TRUE);
   SetForegroundWindow(g_host);
-  SetFocus(g_edit);
+  SetFocus(g_host);
   AttachThreadInput(cur, fg_thread, FALSE);
-  Sleep(400);
+  pump_sleep(400);
 
-  RECT r;
-  GetWindowRect(g_edit, &r);
+  RECT r {};
+  if (!GetWindowRect(g_edit, &r) || IsRectEmpty(&r)) {
+    printf("[auto] GetWindowRect(edit) failed err=%lu rect=(%ld,%ld)-(%ld,%ld)\n",
+           GetLastError(), (long) r.left, (long) r.top, (long) r.right, (long) r.bottom);
+    return 1;
+  }
   int x = (r.left + r.right) / 2, y = (r.top + r.bottom) / 2;
   printf("[auto] foreground set; tapping edit centre at (%d,%d)\n", x, y);
 
@@ -261,15 +341,15 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
   bool ever_focused = false;
   for (int attempt = 1; attempt <= 3 && !ever_focused; ++attempt) {
     StealForeground();
-    Sleep(200);
+    pump_sleep(200);
     to_digitizer(x, y);
-    Sleep(120);
+    pump_sleep(120);
     to_digitizer(x, y + 1);
-    Sleep(60);
+    pump_sleep(60);
     to_digitizer(x, y);
-    Sleep(120);
+    pump_sleep(120);
     dev.update_contacts({});
-    Sleep(600);
+    pump_sleep(600);
     GUITHREADINFO gti {};
     gti.cbSize = sizeof(gti);
     GetGUIThreadInfo(0, &gti);
@@ -293,6 +373,7 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
 
 int
 wmain(int argc, wchar_t **argv) {
+  const HRESULT com_result = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   setvbuf(stdout, nullptr, _IONBF, 0);
   std::wstring usbip_path;
   bool auto_mode = false;
@@ -339,10 +420,11 @@ wmain(int argc, wchar_t **argv) {
     return dev.handle_request(pdu);
   };
   callbacks.on_imported = []() {
-    g_imported = true;
+    g_imported.store(true);
     printf(">>> vhci imported the device\n");
   };
-  callbacks.on_closed = [](remote_usb::close_reason reason) {
+  callbacks.on_closed = [&dev](remote_usb::close_reason reason) {
+    dev.reset();
     printf(">>> bridge closed (%d)\n", (int) reason);
   };
 
@@ -362,56 +444,51 @@ wmain(int argc, wchar_t **argv) {
   // Attach through usbip-win2.  The attach command needs admin rights; when
   // we are not elevated, launch it via UAC and wait for the IMPORT request.
   {
-    std::wstring cmd = L"\"" + usbip_path + L"\" --tcp-port " +
-                       std::to_wstring(endpoint->port) + L" attach --remote " +
-                       std::wstring(endpoint->address.begin(), endpoint->address.end()) +
-                       L" --bus-id " + std::wstring(endpoint->busid.begin(), endpoint->busid.end()) +
-                       L" --terse";
+    const std::wstring args = L"--tcp-port " + std::to_wstring(endpoint->port) +
+                              L" attach --remote " +
+                              std::wstring(endpoint->address.begin(), endpoint->address.end()) +
+                              L" --bus-id " +
+                              std::wstring(endpoint->busid.begin(), endpoint->busid.end()) +
+                              L" --terse";
     if (is_elevated()) {
-      std::string out = run_tool(cmd);
+      std::string out = run_tool(L"\"" + usbip_path + L"\" " + args);
       printf("usbip attach: %s\n", out.c_str());
     }
     else {
+      // Launch usbip.exe itself (never a shell) so the caller-supplied path
+      // cannot be interpreted as command syntax under elevation.  Its output
+      // is not captured; success is observed through on_imported below.
       printf("not elevated; requesting UAC for the attach command...\n");
-      char log_path[MAX_PATH];
-      snprintf(log_path, sizeof(log_path), "%s\\vtouch-attach.log", getenv("TEMP") ? getenv("TEMP") : ".");
-      wchar_t cmd_buf[2048];
-      swprintf_s(cmd_buf,
-                 L"/c \"\"%s\" --tcp-port %u attach --remote %hs --bus-id %hs --terse"
-                 L" > \"%hs\" 2>&1\"",
-                 usbip_path.c_str(), endpoint->port, endpoint->address.c_str(),
-                 endpoint->busid.c_str(), log_path);
       SHELLEXECUTEINFOW sei = {};
       sei.cbSize = sizeof(sei);
       sei.fMask = SEE_MASK_NOCLOSEPROCESS;
       sei.lpVerb = L"runas";
-      sei.lpFile = L"cmd.exe";
-      sei.lpParameters = cmd_buf;
+      sei.lpFile = usbip_path.c_str();
+      sei.lpParameters = args.c_str();
       sei.nShow = SW_HIDE;
-      if (!ShellExecuteExW(&sei)) {
-        printf("UAC declined; cannot attach without admin.\n");
+      if (!ShellExecuteExW(&sei) || !sei.hProcess) {
+        printf("UAC declined or launch failed (err=%lu); cannot attach without admin.\n",
+               GetLastError());
         bridge.stop();
         return 1;
       }
-      WaitForSingleObject(sei.hProcess, 30000);
-      CloseHandle(sei.hProcess);
-      FILE *log = fopen(log_path, "r");
-      if (log) {
-        char buf[2048];
-        size_t n = fread(buf, 1, sizeof(buf) - 1, log);
-        buf[n] = 0;
-        printf("usbip attach output: %s\n", buf);
-        fclose(log);
+      DWORD code = 0;
+      if (WaitForSingleObject(sei.hProcess, 30000) == WAIT_TIMEOUT) {
+        printf("usbip attach still running after 30 s; continuing to wait for import.\n");
       }
+      else if (GetExitCodeProcess(sei.hProcess, &code)) {
+        printf("usbip attach exit code: %lu\n", (unsigned long) code);
+      }
+      CloseHandle(sei.hProcess);
     }
   }
 
   // The bridge answers OP_REQ_IMPORT itself; wait for its callback.  The
   // VHCI service retries attach attempts in the background, so be generous.
-  for (int i = 0; i < 600 && !g_imported; ++i) {
+  for (int i = 0; i < 600 && !g_imported.load(); ++i) {
     Sleep(100);
   }
-  if (!g_imported) {
+  if (!g_imported.load()) {
     printf("device was not imported (attach failed or timed out).\n");
     bridge.stop();
     return 1;
@@ -419,37 +496,46 @@ wmain(int argc, wchar_t **argv) {
   printf("device imported by VHCI; checking raw input device list...\n");
   Sleep(1500);  // let HIDCLASS finish enumeration
   print_raw_digitizer_count("after-attach");
-  system("powershell -NoProfile -Command \"Get-PnpDevice | Where-Object { ($_.Present) -and ($_.InstanceId -match 'VID_5355')} | Format-List FriendlyName,Status,Class,Present,InstanceId | Out-File -Encoding utf8 C:\\Users\\mohaha\\AppData\\Local\\Temp\\vt-pnp-online.txt\"");
-  system("powershell -NoProfile -Command \"Get-PnpDevice -Class HIDClass | Where-Object Present | Format-List FriendlyName,Status,InstanceId | Out-File -Encoding utf8 C:\\Users\\mohaha\\AppData\\Local\\Temp\\vt-hid-online.txt\"");
+  // Fixed command text, launched without a shell; output goes to our log.
+  printf("[pnp] %s\n",
+         run_tool(L"powershell.exe -NoProfile -NonInteractive -Command "
+                  L"\"Get-PnpDevice | Where-Object { $_.Present -and $_.InstanceId -match 'VID_5355' } "
+                  L"| Format-List FriendlyName,Status,Class,InstanceId | Out-String -Width 200\"")
+           .c_str());
 
   const int screen_w = GetSystemMetrics(SM_CXSCREEN);
   const int screen_h = GetSystemMetrics(SM_CYSCREEN);
 
   if (mouse_mode) {
-  POINT start_pos, now_pos;
-  GetCursorPos(&start_pos);
-  double max_dist = 0;
-  auto sampler = std::thread([&]() {
-    while (true) {
-      Sleep(40);
-      GetCursorPos(&now_pos);
-      double d = hypot(now_pos.x - start_pos.x, now_pos.y - start_pos.y);
-      double snap = d;
-      if (snap > max_dist) max_dist = snap;
-    }
-  });
-  sampler.detach();
+    POINT start_pos;
+    GetCursorPos(&start_pos);
+    std::atomic_bool stop_sampling { false };
+    std::mutex sample_mutex;
+    double max_dist = 0;  // guarded by sample_mutex
+    std::thread sampler([&]() {
+      while (!stop_sampling.load()) {
+        Sleep(40);
+        POINT p;
+        GetCursorPos(&p);
+        const double d = hypot(p.x - start_pos.x, p.y - start_pos.y);
+        std::lock_guard<std::mutex> lock(sample_mutex);
+        if (d > max_dist) max_dist = d;
+      }
+    });
     printf("[mouse] wiggling the pointer for 4 s -- watch the cursor\n");
     for (int i = 0; i < 200; ++i) {
       double a = 2.0 * 3.141592653589793 * i / 50.0;
       dev.update_mouse((std::int8_t) (cos(a) * 6), (std::int8_t) (sin(a) * 6), 0);
       Sleep(20);
     }
-  Sleep(300);
-  GetCursorPos(&now_pos);
-  double final_dist = hypot(now_pos.x - start_pos.x, now_pos.y - start_pos.y);
-  printf("[mouse] cursor moved: max=%.0f px final=%.0f px -> %s\n", max_dist, final_dist,
-         (max_dist > 20 ? "INPUT PATH WORKS" : "cursor did not move"));
+    Sleep(300);
+    stop_sampling.store(true);
+    sampler.join();
+    POINT now_pos;
+    GetCursorPos(&now_pos);
+    double final_dist = hypot(now_pos.x - start_pos.x, now_pos.y - start_pos.y);
+    printf("[mouse] cursor moved: max=%.0f px final=%.0f px -> %s\n", max_dist, final_dist,
+           (max_dist > 20 ? "INPUT PATH WORKS" : "cursor did not move"));
     printf("[mouse] wiggle done\n");
     Sleep(2000);
     bridge.stop();
@@ -458,7 +544,7 @@ wmain(int argc, wchar_t **argv) {
 
   if (auto_mode) {
     int rc = run_auto(dev, screen_w, screen_h);
-    Sleep(3000);
+    pump_sleep(3000);
     bridge.stop();
     return rc;
   }
@@ -550,5 +636,8 @@ wmain(int argc, wchar_t **argv) {
 
   bridge.stop();
   printf("bye\n");
+  if (SUCCEEDED(com_result)) {
+    CoUninitialize();
+  }
   return 0;
 }

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -411,9 +411,9 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
     SetCursorPos(mx, my);
     Sleep(150);
     mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
-    Sleep(60);
+    pump_sleep(60);
     mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
-    Sleep(1000);
+    pump_sleep(1000);
     GUITHREADINFO g2 {};
     g2.cbSize = sizeof(g2);
     GetGUIThreadInfo(0, &g2);

--- a/tools/vtouch_poc.cpp
+++ b/tools/vtouch_poc.cpp
@@ -399,6 +399,31 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
     print_status();
   }
   printf("[auto] edit focus ever gained: %s\n", ever_focused ? "YES" : "NO");
+
+  // Real-click control: a genuine mouse click, same trigger as the human
+  // verification, judged via IFrameworkInputPane.
+  {
+    StealForeground();
+    Sleep(200);
+    RECT rr;
+    GetWindowRect(g_edit, &rr);
+    int mx = (rr.left + rr.right) / 2, my = (rr.top + rr.bottom) / 2;
+    SetCursorPos(mx, my);
+    Sleep(150);
+    mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
+    Sleep(60);
+    mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
+    Sleep(1000);
+    GUITHREADINFO g2 {};
+    g2.cbSize = sizeof(g2);
+    GetGUIThreadInfo(0, &g2);
+    RECT krect {};
+    bool kv = keyboard_visible(&krect);
+    printf("[realclick] click at (%d,%d): focus on edit=%s keyboard visible=%s rect=(%ld,%ld)-(%ld,%ld)\n",
+           mx, my, g2.hwndFocus == g_edit ? "YES" : "no", kv ? "YES" : "no",
+           (long) krect.left, (long) krect.top, (long) krect.right, (long) krect.bottom);
+  }
+
   printf("[auto] tap sent; waiting up to 8 s for the touch keyboard...\n");
   bool visible = wait_keyboard_visible(8000);
   printf("[auto] raw input frames seen at sink: %d\n", g_raw_input_frames);
@@ -411,6 +436,20 @@ run_auto(remote_usb::virtual_touchscreen_device &dev, int screen_w, int screen_h
 int
 wmain(int argc, wchar_t **argv) {
   const HRESULT com_result = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+  // Physical-pixel coordinates everywhere: without this, GetWindowRect /
+  // SetCursorPos / synthetic touch coordinates are virtualised on scaled
+  // displays and taps land on the wrong pixel.
+  {
+    using SetCtxFn = BOOL(WINAPI *)(void *);
+    auto fn = (SetCtxFn) GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetProcessDpiAwarenessContext");
+    void *per_monitor_v2 = (void *) -4;  // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+    if (fn && fn(per_monitor_v2)) {
+      printf("dpi awareness: per-monitor v2\n");
+    }
+    else {
+      printf("dpi awareness: unavailable or set failed\n");
+    }
+  }
   setvbuf(stdout, nullptr, _IONBF, 0);
   std::wstring usbip_path;
   bool auto_mode = false;


### PR DESCRIPTION
## 背景

流会话中 Windows 触摸键盘的自动弹出依赖宿主机存在触摸 digitizer。无真实触摸屏的宿主机上，Sunshine 的合成指针注入（InjectSyntheticPointerInput）在 Windows 11 25H2 (26200) 上已验证失效（API 假成功），原生“点击文本框自动弹键盘”链路无法触发。本 PR 落地替代路线的 POC：**让 Sunshine 自己充当 USB/IP 设备端，向系统提供一个虚拟 USB HID 触摸屏**。

## 方案

```
Sunshine (virtual_touchscreen_device)
  → loopback_usbip_bridge（已有组件，复用）
    → usbip-win2 0.9.7.7 VHCI（上游已签名，不修改）
      → Windows USB 栈 → hidusb.sys → HIDCLASS → 原生输入栈
```

- **零驱动开发、零新增签名**：触摸屏只是 USB 设备数据，HID 类驱动 Windows 自带；usbip-win2 使用上游已签名版本
- `virtual_touchscreen_device`：完整 USB 设备（描述符/字符串）、单点 HID digitizer 报告描述符（Tip / In-Range / Confidence / 绝对 16-bit X/Y）、控制传输应答器、中断 IN 触摸帧队列（显式 lift 帧）、idle 零长度保活
- `vtouch_poc`：支持自动 attach、交互式触点、boot-mouse 对照、PDU dump、日志和输入状态观测
- 未接入主 input 路径；设备类与工具保持独立，供后续迭代

## 已验证（Windows 11 26200 + usbip-win2 0.9.7.7 真机）

- ✅ attach → IMPORT → 完整 USB 枚举 → 中断 IN 轮询 → 触摸报告往返
- ✅ 驱动自动安装；设备管理器显示“符合 HID 标准的触摸屏”（`HID\VID_5355&PID_5401`）
- ✅ boot-mouse 对照模式推动真实光标，证明 USB/IP → VHCI → hidusb → HIDCLASS 链路可用
- ✅ console 会话中虚拟触摸 tap 真实记事本文本区，光标落入文本框并自动弹出 Windows 触摸键盘
- ✅ 目标窗口收到 `WM_POINTERDOWN/UP`；tip-down 能正常进入 Windows pointer/touch 栈
- ✅ 断开后重新 attach 成功；设备可再次枚举和接收触摸
- ✅ 协议状态机单测 22/22

此前“仅 hover、tip-down 不产生 click”的结果来自远程控制会话及 POC 判定限制，已在物理 console 会话复测推翻。Windows 11 现代触摸键盘由 TextInputHost 承载，旧的 `IPTip_Main_Window + IsWindowVisible()` 会产生假阴性；POC 现优先使用 `IFrameworkInputPane::Location()`。裸 Win32 `EDIT` 的自动唤起仍受当前桌面、焦点和 Text Services 状态影响，因此 `--auto` 结果只作为诊断，真实应用文本框的 console E2E 为最终判据。

## Review 后修复

- 修正 DEVLIST/IMPORT wire layout（`ndev`、device block、interface block）
- 无声明的 FEATURE/OUTPUT GET_REPORT 正确返回 STALL
- 输入帧队列限制为 64，溢出丢最旧帧；移除不可达 pending-submit 死代码
- 增加连接 teardown `reset()`，避免旧触点/帧泄漏到下个会话
- 修复 reply callback、import 标志和采样线程的数据竞争/生命周期问题
- UAC attach 直接执行 `usbip.exe`，移除提权 `cmd.exe /c` 注入面
- 子进程输出并发读取并落实超时终止
- 自动模式阻塞等待加入消息泵；限制单轮消息派发，避免高频 `WM_INPUT` 导致饥饿
- 非 verbose 模式不再逐帧打印 raw input，避免日志无限膨胀

## 测试

- [x] `virtual_touchscreen_unit_tests`：22/22 通过
- [x] `vtouch-poc` 构建通过（MinGW UCRT64）
- [x] 真机 attach / 枚举 / 报告流 / detach / reattach
- [x] 物理 console 会话：虚拟触摸 tap 记事本 → 触摸键盘自动弹出
