### PR TITLE
feat(display): 恢复串流场景兼容Moonlight-Switch

### DIFF
--- a/src/display_device/parsed_config.cpp
+++ b/src/display_device/parsed_config.cpp
@@ -723,7 +723,7 @@ namespace display_device {
   }
 
   boost::optional<parsed_config_t>
-  make_parsed_config(const config::video_t &config, const rtsp_stream::launch_session_t &session) {
+  make_parsed_config(const config::video_t &config, const rtsp_stream::launch_session_t &session, bool is_reconfigure) {
     parsed_config_t parsed_config;
 
     // 显示器目标、是否为VDD、以及device_prep统一在此解析
@@ -736,10 +736,13 @@ namespace display_device {
     parsed_config.device_prep = intent.device_prep;
     parsed_config.change_hdr_state = parse_hdr_option(config, session);
 
+    // Resume 的任意零值模式都不能用于显示配置；保持现有分辨率和刷新率。
+    const bool resume_mode_invalid = !is_reconfigure && (session.width <= 0 || session.height <= 0 || session.fps <= 0);
     // 解析分辨率和刷新率配置
-    if (!parse_resolution_option(config, session, parsed_config) ||
-        !parse_refresh_rate_option(config, session, parsed_config) ||
-        !remap_display_modes_if_needed(config, session, parsed_config)) {
+    if (!resume_mode_invalid &&
+        (!parse_resolution_option(config, session, parsed_config) ||
+         !parse_refresh_rate_option(config, session, parsed_config) ||
+         !remap_display_modes_if_needed(config, session, parsed_config))) {
       // 任何一步失败都返回空值
       return boost::none;
     }

--- a/src/display_device/parsed_config.h
+++ b/src/display_device/parsed_config.h
@@ -202,17 +202,18 @@ namespace display_device {
    * @brief Parse the user configuration and the session information.
    * @param config User's video related configuration.
    * @param session Session information.
+   * @param is_reconfigure True for Launch and dynamic reconfiguration; false for Resume.
    * @returns Parsed configuration or empty optional if parsing has failed.
    *
    * EXAMPLES:
    * ```cpp
    * const std::shared_ptr<rtsp_stream::launch_session_t> launch_session; // Assuming ptr is properly initialized
    * const config::video_t &video_config { config::video };
-   * const auto parsed_config = make_parsed_config(video_config, *launch_session);
+   * const auto parsed_config = make_parsed_config(video_config, *launch_session, false);
    * ```
    */
   boost::optional<parsed_config_t>
-  make_parsed_config(const config::video_t &config, const rtsp_stream::launch_session_t &session);
+  make_parsed_config(const config::video_t &config, const rtsp_stream::launch_session_t &session, bool is_reconfigure);
 
   /**
    * @brief Whether display preparation should put the source display in HDR mode.

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -407,7 +407,7 @@ namespace display_device {
       }
     }
 
-    auto parsed_config = make_parsed_config(config, session);
+    auto parsed_config = make_parsed_config(config, session, is_reconfigure);
     if (!parsed_config) {
       BOOST_LOG(error) << "Failed to parse configuration for the display device settings!";
       restore_state_impl(revert_reason_e::config_cleanup);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1023,6 +1023,10 @@ namespace nvhttp {
       host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     }
     const auto launch_session = make_launch_session(host_audio, args);
+    if (launch_session->width <= 0 || launch_session->height <= 0 || launch_session->fps <= 0) {
+      BOOST_LOG(warning) << "Resume request has no usable mode; keeping the current display resolution and refresh rate for compatibility. "sv
+                            "Update Moonlight-Switch to a version that sends mode on Resume when one is available."sv;
+    }
     launch_session->rtsp_peer_address = net::addr_to_normalized_string(request->remote_endpoint().address());
     const auto fingerprint_match = client_fingerprint::match_client(args);
     launch_session->highly_suspected_unknown_client = fingerprint_match.suspicious;


### PR DESCRIPTION
## 说明

Moonlight-Switch 的恢复串流请求可能不携带 `mode`。Sunshine 原先会将其解析为 `0x0x0`，VDD 随后把该占位值当作目标模式执行更新，导致 Resume 在建立串流前失败。

Resume 通常沿用原会话的显示模式。缺少可用模式时应保持当前分辨率和刷新率，不应将零值传给显示配置。

## 修改

- 复用现有 `is_reconfigure` 上下文，仅在 Resume 且宽、高、FPS 任意一项不大于零时跳过分辨率、刷新率和模式映射。
- 保留 Launch 和串流中动态重配置的原有处理。
- 增加兼容提示日志，建议更新到会在 Resume 请求中发送 `mode` 的 Moonlight-Switch 版本。