### PR TITLE
feat(rtx-hdr): GUI 本地组件管理原型

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1921,6 +1921,104 @@ namespace config {
     }
   }
 
+  std::string
+  get_config_value(const std::string &key) {
+    std::lock_guard lock { config_file_mutex };
+    try {
+      const auto values = parse_config(file_handler::read_file(sunshine.config_file.c_str()));
+      const auto value = values.find(key);
+      return value == values.end() ? std::string {} : value->second;
+    }
+    catch (const std::exception &exception) {
+      BOOST_LOG(warning) << "Failed to read config value '" << key << "': " << exception.what();
+      return {};
+    }
+  }
+
+  config_update_e
+  set_rtx_hdr_backend_path(const std::string &backend_path) {
+    std::lock_guard lock { config_file_mutex };
+    try {
+      const auto config_path = file_handler::path_from_utf8(sunshine.config_file);
+      std::ifstream input(config_path, std::ios::binary);
+      if (!input.is_open()) {
+        BOOST_LOG(error) << "Unable to open Sunshine config for RTX HDR update: " << sunshine.config_file;
+        return config_update_e::error;
+      }
+      const std::string content {
+        std::istreambuf_iterator<char> { input },
+        std::istreambuf_iterator<char> {},
+      };
+      if (!input.eof() && input.fail()) {
+        BOOST_LOG(error) << "Unable to read Sunshine config for RTX HDR update: " << sunshine.config_file;
+        return config_update_e::error;
+      }
+      auto parsed = parse_config(content);
+      std::map<std::string, std::string> values { parsed.begin(), parsed.end() };
+      const auto current = values.find("rtx_hdr_backend_path");
+      const std::string current_value = current == values.end() ? std::string {} : current->second;
+      if (current_value == backend_path) {
+        return config_update_e::unchanged;
+      }
+      if (backend_path.empty()) {
+        values.erase("rtx_hdr_backend_path");
+      }
+      else {
+        values["rtx_hdr_backend_path"] = backend_path;
+      }
+
+      std::ostringstream serialized;
+      for (const auto &[key, value] : values) {
+        if (!value.empty() && value != "null") {
+          serialized << key << " = " << value << std::endl;
+        }
+      }
+      const auto temporary = config_path.parent_path() /
+                             (config_path.filename().wstring() + L".rtx-hdr.tmp");
+      {
+        std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+        if (!output.is_open()) {
+          BOOST_LOG(error) << "Unable to create temporary Sunshine config: " << file_handler::path_to_utf8(temporary);
+          return config_update_e::error;
+        }
+        output << serialized.str();
+        output.flush();
+        if (!output) {
+          BOOST_LOG(error) << "Unable to flush temporary Sunshine config: " << file_handler::path_to_utf8(temporary);
+          output.close();
+          std::error_code cleanup_error;
+          std::filesystem::remove(temporary, cleanup_error);
+          return config_update_e::error;
+        }
+      }
+#ifdef _WIN32
+      if (!MoveFileExW(
+            temporary.c_str(),
+            config_path.c_str(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        BOOST_LOG(error) << "Unable to atomically replace Sunshine config: " << GetLastError();
+        std::error_code cleanup_error;
+        std::filesystem::remove(temporary, cleanup_error);
+        return config_update_e::error;
+      }
+#else
+      std::error_code replace_error;
+      std::filesystem::rename(temporary, config_path, replace_error);
+      if (replace_error) {
+        BOOST_LOG(error) << "Unable to atomically replace Sunshine config: " << replace_error.message();
+        std::error_code cleanup_error;
+        std::filesystem::remove(temporary, cleanup_error);
+        return config_update_e::error;
+      }
+#endif
+      return config_update_e::changed;
+    }
+    catch (const std::exception &exception) {
+      BOOST_LOG(error) << "Failed to update RTX HDR backend path: " << exception.what();
+      return config_update_e::error;
+    }
+  }
+
   bool
   update_full_config(const std::map<std::string, std::string> &fullConfig) {
     std::lock_guard lock { config_file_mutex };

--- a/src/config.h
+++ b/src/config.h
@@ -302,6 +302,18 @@ namespace config {
   bool
   update_config(const std::map<std::string, std::string> &updates);
 
+  std::string
+  get_config_value(const std::string &key);
+
+  enum class config_update_e {
+    changed,
+    unchanged,
+    error,
+  };
+
+  config_update_e
+  set_rtx_hdr_backend_path(const std::string &backend_path);
+
   bool
   update_full_config(const std::map<std::string, std::string> &fullConfig);
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1426,6 +1426,30 @@ namespace confighttp {
   }
 
   void
+  write_runtime_error(resp_https_t response, SimpleWeb::StatusCode http_status, int status_code, const std::string &status_message);
+
+  bool
+  require_localhost(resp_https_t response, req_https_t request, const std::string &action);
+
+  std::filesystem::path
+  managedRtxHdrVersionsRoot() {
+    return file_handler::path_from_utf8(SUNSHINE_ASSETS_DIR).parent_path() /
+           "tools" / "rtx_hdr" / "versions";
+  }
+
+  bool
+  isManagedRtxHdrBackendPath(const std::string &backend_path) {
+    if (backend_path.empty()) return true;
+    std::error_code error;
+    const auto root = std::filesystem::weakly_canonical(managedRtxHdrVersionsRoot(), error);
+    if (error || !std::filesystem::is_directory(root, error)) return false;
+    const auto candidate = std::filesystem::canonical(file_handler::path_from_utf8(backend_path), error);
+    if (error || !std::filesystem::is_regular_file(candidate, error)) return false;
+    return boost::iequals(file_handler::path_to_utf8(candidate.filename()), "foundation_truehdr_backend.dll") &&
+           candidate.parent_path().parent_path() == root;
+  }
+
+  void
   saveConfig(resp_https_t response, req_https_t request) {
     if (!check_content_type(response, request, "application/json")) return;
     if (!authenticate(response, request)) return;
@@ -1487,6 +1511,63 @@ namespace confighttp {
     }
 
     outputTree.put("status", "true");
+  }
+
+  void
+  getRtxHdrBackendPath(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    if (!require_localhost(response, request, "reading the RTX HDR component path")) return;
+    const auto backend_path = config::get_config_value("rtx_hdr_backend_path");
+    send_response(response, json {
+      { "status", true },
+      { "persisted_path", backend_path },
+      { "active_path", config::video.rtx_hdr_backend_path },
+      { "restart_required", backend_path != config::video.rtx_hdr_backend_path },
+    });
+  }
+
+  void
+  saveRtxHdrBackendPath(resp_https_t response, req_https_t request) {
+    if (!check_content_type(response, request, "application/json")) return;
+    if (!authenticate(response, request)) return;
+    if (!require_localhost(response, request, "updating the RTX HDR component path")) return;
+
+    try {
+      std::stringstream body;
+      body << request->content.rdbuf();
+      const auto input = json::parse(body.str());
+      if (!input.is_object() || !input.contains("backend_path") || !input["backend_path"].is_string()) {
+        throw std::invalid_argument("backend_path must be a string");
+      }
+      const auto backend_path = input["backend_path"].get<std::string>();
+      if (backend_path.size() > 4096) {
+        throw std::invalid_argument("backend_path is too long");
+      }
+      if (!isManagedRtxHdrBackendPath(backend_path)) {
+        throw std::invalid_argument(
+          "backend_path must resolve to a regular foundation_truehdr_backend.dll under the managed version store");
+      }
+
+      const auto update = config::set_rtx_hdr_backend_path(backend_path);
+      if (update == config::config_update_e::error) {
+        throw std::runtime_error("failed to persist RTX HDR backend path");
+      }
+      const bool changed = update == config::config_update_e::changed;
+      send_response(response, json {
+        { "status", true },
+        { "persisted_path", backend_path },
+        { "active_path", config::video.rtx_hdr_backend_path },
+        { "restart_required", backend_path != config::video.rtx_hdr_backend_path },
+        { "changed", changed },
+      });
+    }
+    catch (const std::invalid_argument &exception) {
+      write_runtime_error(response, SimpleWeb::StatusCode::client_error_bad_request, 400, exception.what());
+    }
+    catch (const std::exception &exception) {
+      BOOST_LOG(error) << "saveRtxHdrBackendPath: " << exception.what();
+      write_runtime_error(response, SimpleWeb::StatusCode::server_error_internal_server_error, 500, exception.what());
+    }
   }
 
   void
@@ -3842,6 +3923,8 @@ namespace confighttp {
     server.resource["^/api/apps$"]["POST"] = saveApp;
     server.resource["^/api/config$"]["GET"] = getConfig;
     server.resource["^/api/config$"]["POST"] = saveConfig;
+    server.resource["^/api/config/rtx-hdr-backend$"]["GET"] = getRtxHdrBackendPath;
+    server.resource["^/api/config/rtx-hdr-backend$"]["POST"] = saveRtxHdrBackendPath;
     server.resource["^/api/webhook/config$"]["GET"] = getWebhookConfig;
     server.resource["^/api/webhook/config$"]["POST"] = saveWebhookConfig;
     server.resource["^/api/webhook/test$"]["POST"] = testWebhook;

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -1,16 +1,19 @@
 <script setup>
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import PlatformLayout from '../../components/layout/PlatformLayout.vue'
 import VddPrerequisiteNotice from '../../components/common/VddPrerequisiteNotice.vue'
 import AdapterNameSelector from './advanced/AdapterNameSelector.vue'
 import CaptureCompatibilityOverrides from './advanced/CaptureCompatibilityOverrides.vue'
+import { createNativeRtxHdrBridge } from '../../utils/nativeRtxHdrBridge.js'
 
 const { t } = useI18n()
 
 const props = defineProps(['platform', 'config', 'global_prep_cmd'])
 
 const config = ref(props.config)
+const nativeRtxHdrManagerAvailable = ref(false)
+let nativeRtxHdrBridge
 
 // 检查是否在 Tauri 环境中（通过 inject-script.js 注入）
 const isTauri = computed(() => {
@@ -111,7 +114,22 @@ onMounted(() => {
   if (isTauri.value && isWGCSelected.value) {
     checkSunshineMode()
   }
+  nativeRtxHdrBridge = createNativeRtxHdrBridge({
+    windowObject: window,
+    documentObject: document,
+    onAvailability: (available) => { nativeRtxHdrManagerAvailable.value = available },
+  })
+  window.addEventListener('message', nativeRtxHdrBridge.handleMessage)
+  nativeRtxHdrBridge.requestContext()
 })
+
+onBeforeUnmount(() => {
+  if (nativeRtxHdrBridge) {
+    window.removeEventListener('message', nativeRtxHdrBridge.handleMessage)
+  }
+})
+
+const openNativeRtxHdrManager = () => nativeRtxHdrBridge?.openManager()
 
 watch(isWGCSelected, (newValue) => {
   if (newValue && isTauri.value) {
@@ -265,6 +283,15 @@ const hdrToggleDisabled = computed(() => codecStrategy.value !== 'modern')
           placeholder="C:\\Program Files\\Sunshine\\tools\\rtx_hdr\\foundation_truehdr_backend.dll"
         />
         <div class="form-text">{{ $t('config.rtx_hdr_backend_path_desc') }}</div>
+        <button
+          v-if="nativeRtxHdrManagerAvailable"
+          type="button"
+          class="btn btn-outline-primary btn-sm mt-2"
+          @click="openNativeRtxHdrManager"
+        >
+          <i class="fas fa-puzzle-piece me-1" aria-hidden="true"></i>
+          Control Panel · RTX HDR
+        </button>
       </div>
     </div>
 

--- a/src_assets/common/assets/web/tests/nativeRtxHdrBridge.test.js
+++ b/src_assets/common/assets/web/tests/nativeRtxHdrBridge.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createNativeRtxHdrBridge,
+  isTrustedRtxHdrBridgeMessage,
+  resolveControlPanelOrigin,
+} from '../utils/nativeRtxHdrBridge.js'
+
+test('RTX HDR bridge accepts only known control-panel origins', () => {
+  assert.equal(resolveControlPanelOrigin('https://tauri.localhost/frame', ''), 'https://tauri.localhost')
+  assert.equal(resolveControlPanelOrigin('https://evil.example/frame', ''), '')
+})
+
+test('RTX HDR bridge rejects forged source, origin, and source markers', () => {
+  const parent = {}
+  const valid = {
+    source: parent,
+    origin: 'https://tauri.localhost',
+    data: { source: 'sunshine-control-panel' },
+  }
+  assert.equal(isTrustedRtxHdrBridgeMessage(valid, parent, valid.origin), true)
+  assert.equal(isTrustedRtxHdrBridgeMessage({ ...valid, source: {} }, parent, valid.origin), false)
+  assert.equal(isTrustedRtxHdrBridgeMessage({ ...valid, origin: 'https://evil.example' }, parent, valid.origin), false)
+  assert.equal(isTrustedRtxHdrBridgeMessage({ ...valid, data: { source: 'evil' } }, parent, valid.origin), false)
+})
+
+test('standalone WebUI never advertises or opens the native manager', () => {
+  const messages = []
+  const standalone = {
+    parent: null,
+    location: { ancestorOrigins: [] },
+  }
+  standalone.parent = standalone
+  standalone.postMessage = (message) => messages.push(message)
+  const bridge = createNativeRtxHdrBridge({
+    windowObject: standalone,
+    documentObject: { referrer: '' },
+    onAvailability: () => assert.fail('standalone bridge must stay unavailable'),
+  })
+  assert.equal(bridge.requestContext(), false)
+  assert.equal(bridge.openManager(), false)
+  assert.deepEqual(messages, [])
+})
+
+test('embedded WebUI opens only after a trusted capability response', () => {
+  const messages = []
+  const parent = { postMessage: (message, origin) => messages.push({ message, origin }) }
+  const embedded = { parent, location: { ancestorOrigins: ['https://tauri.localhost'] } }
+  let available = false
+  const bridge = createNativeRtxHdrBridge({
+    windowObject: embedded,
+    documentObject: { referrer: '' },
+    onAvailability: (value) => { available = value },
+  })
+  assert.equal(bridge.openManager(), false)
+  assert.equal(bridge.requestContext(), true)
+  bridge.handleMessage({
+    source: parent,
+    origin: 'https://tauri.localhost',
+    data: { type: 'native-rtx-hdr-context', source: 'sunshine-control-panel', available: true },
+  })
+  assert.equal(available, true)
+  assert.equal(bridge.openManager(), true)
+  assert.equal(messages.at(-1).message.type, 'native-rtx-hdr-open-request')
+  assert.equal(messages.at(-1).origin, 'https://tauri.localhost')
+})

--- a/src_assets/common/assets/web/utils/nativeRtxHdrBridge.js
+++ b/src_assets/common/assets/web/utils/nativeRtxHdrBridge.js
@@ -1,0 +1,72 @@
+export const CONTROL_PANEL_ORIGINS = new Set([
+  'http://tauri.localhost',
+  'https://tauri.localhost',
+  'tauri://localhost',
+  'http://localhost:8080',
+  'https://localhost:8080',
+])
+
+export function normalizeControlPanelOrigin(url) {
+  try {
+    const parsed = new URL(url)
+    return parsed.origin === 'null' ? `${parsed.protocol}//${parsed.host}` : parsed.origin
+  } catch {
+    return ''
+  }
+}
+
+export function resolveControlPanelOrigin(referrer, ancestorOrigin) {
+  return [referrer, ancestorOrigin]
+    .map(normalizeControlPanelOrigin)
+    .find((origin) => CONTROL_PANEL_ORIGINS.has(origin)) || ''
+}
+
+export function isTrustedRtxHdrBridgeMessage(event, parentWindow, controlPanelOrigin) {
+  return Boolean(
+    controlPanelOrigin
+    && CONTROL_PANEL_ORIGINS.has(controlPanelOrigin)
+    && event.source === parentWindow
+    && event.origin === controlPanelOrigin
+    && event.data?.source === 'sunshine-control-panel'
+  )
+}
+
+export function createNativeRtxHdrBridge({ windowObject, documentObject, onAvailability }) {
+  const controlPanelOrigin = resolveControlPanelOrigin(
+    documentObject.referrer,
+    windowObject.location.ancestorOrigins?.[0],
+  )
+  let available = false
+
+  const handleMessage = (event) => {
+    if (!isTrustedRtxHdrBridgeMessage(event, windowObject.parent, controlPanelOrigin)) return
+    if (event.data.type === 'native-rtx-hdr-context') {
+      available = event.data.available === true
+      onAvailability(available)
+    }
+  }
+
+  const requestContext = () => {
+    if (windowObject.parent === windowObject || !controlPanelOrigin) return false
+    windowObject.parent.postMessage(
+      { type: 'native-rtx-hdr-context-request', source: 'sunshine-webui' },
+      controlPanelOrigin,
+    )
+    return true
+  }
+
+  const openManager = () => {
+    if (!available || !controlPanelOrigin) return false
+    windowObject.parent.postMessage(
+      {
+        type: 'native-rtx-hdr-open-request',
+        source: 'sunshine-webui',
+        requestId: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      },
+      controlPanelOrigin,
+    )
+    return true
+  }
+
+  return { controlPanelOrigin, handleMessage, requestContext, openManager }
+}


### PR DESCRIPTION
## 概要

为 RTX HDR 本地组件管理原型提供 Core 窄配置 API、WebUI 直达入口，并将控制面板子模块 pin 到 qiin2333/sunshine-control-panel#116。

## Core 配置事务

- 新增 localhost-only `GET/POST /api/config/rtx-hdr-backend`。
- POST 只接受空路径，或 canonical 后严格位于 `<install>/tools/rtx_hdr/versions/<hash>/foundation_truehdr_backend.dll` 的普通文件。
- 专用配置写入在 `config_file_mutex` 内完成读取、比较和更新，读取失败即终止。
- 写入同目录临时文件后通过 `MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH)` 原子替换，避免截断原配置。
- API 同时返回 persisted path、active runtime path 和 restart-required，供 GUI 在重启后确认真正生效。
- 保留高级设置里的手工 backend path 能力；窄托管 API 不改变既有 WebUI 权限模型。

## WebUI → Control Panel

- RTX HDR backend 设置旁新增 Control Panel 入口。
- 仅在嵌入式控制面板通过 capability handshake 后显示；独立浏览器不显示、不尝试启动本机 GUI。
- 精确校验父窗口、allowlist origin 和消息 source，只发送固定的 RTX HDR 管理页请求。

## 控制面板 pin

- pin `qiin2333/sunshine-control-panel@69ac2836`（https://github.com/qiin2333/sunshine-control-panel/pull/116）。
- GUI 本地选择两个 DLL；不下载、不扫描、不再分发 NVIDIA runtime。
- UAC helper 安装 hash 不可变版本，切换后重启 Core 并等待 persisted/active 路径一致。

## 验证

- WebUI ESLint: passed
- WebUI tests: 128/128 passed（含 4 项 native bridge 测试）
- WebUI production build: passed
- `config.cpp` / `confighttp.cpp`: 使用项目完整 compile_commands 参数真实编译通过
- Control Panel renderer: 71/71 passed + production build passed
- Control Panel Rust: 170 passed, 3 environment-dependent ignored, 0 failed

## 依赖

配套控制面板 PR：https://github.com/qiin2333/sunshine-control-panel/pull/116