### PR TITLE
fix(remote-usb): accept Android bus IDs and clean up helpers

### DIFF
--- a/src/remote_usb/remote_usb_host_controller.cpp
+++ b/src/remote_usb/remote_usb_host_controller.cpp
@@ -9,6 +9,8 @@
 #include <charconv>
 #include <cctype>
 #include <chrono>
+#include <cstdlib>
+#include <filesystem>
 #include <limits>
 #include <system_error>
 #include <utility>
@@ -25,6 +27,38 @@ namespace bp = boost::process::v1;
 using namespace std::chrono_literals;
 
 constexpr std::uint16_t kMaxHubPort = 255;
+
+std::string
+resolve_executable(std::string executable) {
+  const std::filesystem::path requested(executable);
+  if (requested.has_parent_path()) {
+    return executable;
+  }
+
+  const auto discovered = bp::search_path(executable);
+  if (!discovered.empty()) {
+    return discovered.string();
+  }
+
+#ifdef _WIN32
+  /* usbip-win2's installer does not add its directory to the service account's
+   * PATH. Sunshine normally runs as LocalSystem, so also probe the standard
+   * machine-wide install directory. */
+  for (const char *variable: {"ProgramW6432", "ProgramFiles"}) {
+    const auto *program_files = std::getenv(variable);
+    if (!program_files || !*program_files) {
+      continue;
+    }
+    const auto candidate = std::filesystem::path(program_files) / "USBip" / requested;
+    std::error_code error;
+    if (std::filesystem::is_regular_file(candidate, error)) {
+      return candidate.string();
+    }
+  }
+#endif
+
+  return executable;
+}
 
 std::string
 platform_default_executable() {
@@ -81,7 +115,7 @@ run_process(const std::string &executable,
   bp::group process_group;
 
   try {
-    child = bp::child(executable,
+    child = bp::child(resolve_executable(executable),
                       bp::args(arguments),
                       process_group,
                       bp::std_in < bp::null,

--- a/src/remote_usb/remote_usb_host_controller.cpp
+++ b/src/remote_usb/remote_usb_host_controller.cpp
@@ -6,6 +6,7 @@
 #include "remote_usb_host_controller.h"
 
 #include <algorithm>
+#include <array>
 #include <charconv>
 #include <cctype>
 #include <chrono>
@@ -17,6 +18,7 @@
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/process/v1.hpp>
+#include <boost/process/v1/async_pipe.hpp>
 #include <boost/process/v1/pipe.hpp>
 
 namespace remote_usb {
@@ -92,6 +94,31 @@ append_bounded(std::string &destination,
   destination.append(value.data(), std::min(remaining, value.size()));
 }
 
+void
+drain_pipe(bp::async_pipe &pipe,
+           asio::io_context &context,
+           std::string &destination,
+           std::size_t maximum) noexcept {
+  try {
+    std::array<char, 4096> buffer {};
+    std::function<void()> read_next;
+    read_next = [&]() {
+      pipe.async_read_some(asio::buffer(buffer), [&](const auto &error, std::size_t count) {
+        if (count != 0) {
+          append_bounded(destination, std::string_view(buffer.data(), count), maximum);
+        }
+        if (!error) {
+          read_next();
+        }
+      });
+    };
+    read_next();
+    context.run();
+  }
+  catch (...) {
+  }
+}
+
 /*
  * Drain both child pipes concurrently.  usbip-win2 normally prints a single
  * line, but draining rather than relying on a fixed pipe buffer keeps a broken
@@ -105,8 +132,10 @@ run_process(const std::string &executable,
             std::size_t max_output_bytes,
             const usbip_reader_thread_factory &reader_thread_factory) {
   usbip_command_result result;
-  bp::ipstream standard_output;
-  bp::ipstream standard_error;
+  asio::io_context output_context;
+  asio::io_context error_context;
+  bp::async_pipe standard_output(output_context);
+  bp::async_pipe standard_error(error_context);
   std::error_code launch_error;
   bp::child child;
   // usbip-win2 may launch a worker process that inherits our output pipes.
@@ -142,44 +171,35 @@ run_process(const std::string &executable,
     }
 
     /* A failed group termination must not leave a descendant holding either
-     * output pipe open forever. Terminate the direct child as a best effort,
-     * then close our pipe handles so the reader joins have a bounded exit. */
+     * output pipe open forever. Terminate the direct child as a best effort;
+     * the caller cancels the asynchronous reads before joining them. */
     std::error_code child_error;
     child.terminate(child_error);
-    try {
-      standard_output.pipe().close();
-    }
-    catch (...) {
-    }
-    try {
-      standard_error.pipe().close();
-    }
-    catch (...) {
-    }
     return group_error;
+  };
+  const auto cancel_readers = [&]() noexcept {
+    try {
+      standard_output.cancel();
+    }
+    catch (...) {
+    }
+    try {
+      standard_error.cancel();
+    }
+    catch (...) {
+    }
   };
   try {
     output_reader = reader_thread_factory([&]() {
-      std::string line;
-      while (std::getline(standard_output, line)) {
-        append_bounded(result.standard_output, line, max_output_bytes);
-        if (result.standard_output.size() < max_output_bytes) {
-          append_bounded(result.standard_output, "\n", max_output_bytes);
-        }
-      }
+      drain_pipe(standard_output, output_context, result.standard_output, max_output_bytes);
     });
     error_reader = reader_thread_factory([&]() {
-      std::string line;
-      while (std::getline(standard_error, line)) {
-        append_bounded(result.standard_error, line, max_output_bytes);
-        if (result.standard_error.size() < max_output_bytes) {
-          append_bounded(result.standard_error, "\n", max_output_bytes);
-        }
-      }
+      drain_pipe(standard_error, error_context, result.standard_error, max_output_bytes);
     });
   }
   catch (const std::exception &exception) {
     terminate_tree();
+    cancel_readers();
     std::error_code ignored;
     child.wait(ignored);
     if (output_reader.joinable()) {
@@ -194,6 +214,7 @@ run_process(const std::string &executable,
   }
   catch (...) {
     terminate_tree();
+    cancel_readers();
     std::error_code ignored;
     child.wait(ignored);
     if (output_reader.joinable()) {
@@ -232,6 +253,9 @@ run_process(const std::string &executable,
    * inherited pipe handles. Terminate the remaining group before joining the
    * readers so normal-exit, cancellation, and timeout all use the same path. */
   const auto group_error = terminate_tree();
+  if (group_error) {
+    cancel_readers();
+  }
   output_reader.join();
   error_reader.join();
   if (wait_error && !terminated) {

--- a/src/remote_usb/remote_usb_host_controller.cpp
+++ b/src/remote_usb/remote_usb_host_controller.cpp
@@ -75,10 +75,15 @@ run_process(const std::string &executable,
   bp::ipstream standard_error;
   std::error_code launch_error;
   bp::child child;
+  // usbip-win2 may launch a worker process that inherits our output pipes.
+  // Keep the complete helper tree in a process group so timeout/cancel also
+  // closes those inherited handles and the reader threads can finish.
+  bp::group process_group;
 
   try {
     child = bp::child(executable,
                       bp::args(arguments),
+                      process_group,
                       bp::std_in < bp::null,
                       bp::std_out > standard_output,
                       bp::std_err > standard_error,
@@ -117,7 +122,7 @@ run_process(const std::string &executable,
   }
   catch (const std::exception &exception) {
     std::error_code ignored;
-    child.terminate(ignored);
+    process_group.terminate(ignored);
     child.wait(ignored);
     if (output_reader.joinable()) {
       output_reader.join();
@@ -131,7 +136,7 @@ run_process(const std::string &executable,
   }
   catch (...) {
     std::error_code ignored;
-    child.terminate(ignored);
+    process_group.terminate(ignored);
     child.wait(ignored);
     if (output_reader.joinable()) {
       output_reader.join();
@@ -152,14 +157,14 @@ run_process(const std::string &executable,
       result.cancelled = true;
       terminated = true;
       std::error_code ignored;
-      child.terminate(ignored);
+      process_group.terminate(ignored);
       break;
     }
     if (std::chrono::steady_clock::now() >= deadline) {
       result.timed_out = true;
       terminated = true;
       std::error_code ignored;
-      child.terminate(ignored);
+      process_group.terminate(ignored);
       break;
     }
     std::this_thread::sleep_for(5ms);

--- a/src/remote_usb/remote_usb_host_controller.cpp
+++ b/src/remote_usb/remote_usb_host_controller.cpp
@@ -134,6 +134,30 @@ run_process(const std::string &executable,
 
   std::thread output_reader;
   std::thread error_reader;
+  const auto terminate_tree = [&]() noexcept {
+    std::error_code group_error;
+    process_group.terminate(group_error);
+    if (!group_error) {
+      return group_error;
+    }
+
+    /* A failed group termination must not leave a descendant holding either
+     * output pipe open forever. Terminate the direct child as a best effort,
+     * then close our pipe handles so the reader joins have a bounded exit. */
+    std::error_code child_error;
+    child.terminate(child_error);
+    try {
+      standard_output.pipe().close();
+    }
+    catch (...) {
+    }
+    try {
+      standard_error.pipe().close();
+    }
+    catch (...) {
+    }
+    return group_error;
+  };
   try {
     output_reader = reader_thread_factory([&]() {
       std::string line;
@@ -155,8 +179,8 @@ run_process(const std::string &executable,
     });
   }
   catch (const std::exception &exception) {
+    terminate_tree();
     std::error_code ignored;
-    process_group.terminate(ignored);
     child.wait(ignored);
     if (output_reader.joinable()) {
       output_reader.join();
@@ -169,8 +193,8 @@ run_process(const std::string &executable,
     return result;
   }
   catch (...) {
+    terminate_tree();
     std::error_code ignored;
-    process_group.terminate(ignored);
     child.wait(ignored);
     if (output_reader.joinable()) {
       output_reader.join();
@@ -190,15 +214,13 @@ run_process(const std::string &executable,
     if (cancel && cancel->load(std::memory_order_acquire)) {
       result.cancelled = true;
       terminated = true;
-      std::error_code ignored;
-      process_group.terminate(ignored);
+      terminate_tree();
       break;
     }
     if (std::chrono::steady_clock::now() >= deadline) {
       result.timed_out = true;
       terminated = true;
-      std::error_code ignored;
-      process_group.terminate(ignored);
+      terminate_tree();
       break;
     }
     std::this_thread::sleep_for(5ms);
@@ -206,10 +228,17 @@ run_process(const std::string &executable,
 
   std::error_code wait_error;
   child.wait(wait_error);
+  /* The direct helper may exit while one of its descendants still owns the
+   * inherited pipe handles. Terminate the remaining group before joining the
+   * readers so normal-exit, cancellation, and timeout all use the same path. */
+  const auto group_error = terminate_tree();
   output_reader.join();
   error_reader.join();
   if (wait_error && !terminated) {
     result.standard_error = wait_error.message();
+  }
+  else if (group_error && !terminated) {
+    append_bounded(result.standard_error, group_error.message(), max_output_bytes);
   }
   result.exit_code = child.exit_code();
   return result;

--- a/src/remote_usb/reverse_tunnel_service.cpp
+++ b/src/remote_usb/reverse_tunnel_service.cpp
@@ -50,7 +50,8 @@ namespace remote_usb {
         const bool allowed = (c >= '0' && c <= '9') ||
                              (c >= 'a' && c <= 'z') ||
                              (c >= 'A' && c <= 'Z') ||
-                             c == '-' || c == '.';
+                             // libusb-backed Android exporters use IDs such as "1-9:0".
+                             c == '-' || c == '.' || c == ':';
         if (!allowed) {
           return false;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,6 +223,13 @@ set_target_properties(virtual_touchscreen_unit_tests PROPERTIES
         CXX_STANDARD_REQUIRED ON)
 add_test(NAME virtual_touchscreen_unit_tests COMMAND virtual_touchscreen_unit_tests)
 
+add_executable(remote_usb_process_tree_helper
+        ${CMAKE_SOURCE_DIR}/tests/tools/remote_usb_process_tree_helper.cpp)
+target_link_libraries(remote_usb_process_tree_helper PRIVATE
+        Boost::process Boost::system ${CMAKE_THREAD_LIBS_INIT})
+set_target_properties(remote_usb_process_tree_helper PROPERTIES
+        CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON)
+
 add_executable(remote_usb_host_controller_unit_tests
         ${CMAKE_SOURCE_DIR}/src/remote_usb/remote_usb_host_controller.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_remote_usb_host_controller.cpp)
@@ -237,6 +244,9 @@ target_link_libraries(remote_usb_host_controller_unit_tests
         gtest_main)
 target_compile_options(remote_usb_host_controller_unit_tests PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+target_compile_definitions(remote_usb_host_controller_unit_tests PRIVATE
+        REMOTE_USB_PROCESS_TREE_HELPER="$<TARGET_FILE:remote_usb_process_tree_helper>")
+add_dependencies(remote_usb_host_controller_unit_tests remote_usb_process_tree_helper)
 set_target_properties(remote_usb_host_controller_unit_tests PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON)

--- a/tests/tools/remote_usb_process_tree_helper.cpp
+++ b/tests/tools/remote_usb_process_tree_helper.cpp
@@ -1,0 +1,29 @@
+#include <boost/process/v1.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <string_view>
+#include <thread>
+
+int main(int argc, char **argv) {
+  using namespace std::chrono_literals;
+  namespace bp = boost::process::v1;
+
+  if (argc == 2 && std::string_view(argv[1]) == "--hold-pipes") {
+    std::this_thread::sleep_for(30s);
+    return 0;
+  }
+  for (int index = 1; index < argc; ++index) {
+    if (std::string_view(argv[index]) == "detach") {
+      return 0;
+    }
+  }
+
+  /* The descendant inherits stdout/stderr, then outlives this direct child.
+   * run_process must terminate the surrounding process group before joining
+   * its pipe readers or the controller test will wait for the full 30 seconds. */
+  bp::child holder(argv[0], "--hold-pipes");
+  holder.detach();
+  std::cout << "7\n" << std::flush;
+  return 0;
+}

--- a/tests/tools/reverse_tunnel_probe.cpp
+++ b/tests/tools/reverse_tunnel_probe.cpp
@@ -39,6 +39,7 @@ int main(int argc, char **argv) {
         result.exit_code = 0;
         return result;
       }
+      std::cout << "ATTACH_BUSID " << args[6] << std::endl;
       auto socket = std::make_shared<tcp::socket>(helper_io);
       socket->connect(tcp::endpoint(asio::ip::make_address("127.0.0.1"), std::stoi(args[1])));
       const std::string request("\0IMPORT\n", 8);

--- a/tests/tools/test_reverse_tunnel.py
+++ b/tests/tools/test_reverse_tunnel.py
@@ -103,9 +103,9 @@ def main():
             ctx.load_cert_chain(root / f"{identity}.crt", root / f"{identity}.key")
             return ctx.wrap_socket(socket.create_connection(("127.0.0.1", port), timeout=5))
 
-        def handshake(sock, supplied_token=token, tail=b""):
+        def handshake(sock, supplied_token=token, tail=b"", busid="1-1"):
             sock.sendall(json.dumps({"op": "forward", "token": supplied_token,
-                                     "busid": "1-1"}).encode() + b"\n" + tail)
+                                     "busid": busid}).encode() + b"\n" + tail)
 
         with server("limited") as (port, log), contextlib.ExitStack() as sockets:
             for _ in range(2):
@@ -133,11 +133,15 @@ def main():
                     handshake(client, supplied_token)
                     assert json.loads(line(client))["reason"] == "unauthorized"
             assert "IMPORT_EXCHANGED" not in log.read_text()
-            for tail in (b"", b"REPLY\0\r\n"):
+            for invalid_busid in ("", "1/9", "1 9", "x" * 32):
+                with connect(port) as client:
+                    handshake(client, busid=invalid_busid)
+                    assert json.loads(line(client))["reason"] == "invalid busid"
+            for busid, tail in (("1-1", b""), ("1-1", b"REPLY\0\r\n"), ("1-9:0", b"")):
                 before = log.read_text().count("DETACHED")
                 attached_before = log.read_text().count("attached busid")
                 with connect(port) as client:
-                    handshake(client, tail=tail)
+                    handshake(client, tail=tail, busid=busid)
                     assert json.loads(line(client))["op"] == "ready"
                     assert receive(client, 8) == b"\0IMPORT\n"
                     if not tail:

--- a/tests/tools/test_reverse_tunnel.py
+++ b/tests/tools/test_reverse_tunnel.py
@@ -147,6 +147,8 @@ def main():
                     if not tail:
                         client.sendall(b"REPLY\0\r\n")
                     wait_for(lambda: log.read_text().count("attached busid") > attached_before)
+                    if busid == "1-9:0":
+                        wait_for(lambda: "ATTACH_BUSID 1-9:0" in log.read_text())
                 wait_for(lambda: log.read_text().count("DETACHED") > before)
             try:
                 with connect(port, "wrong") as client:

--- a/tests/unit/test_remote_usb_host_controller.cpp
+++ b/tests/unit/test_remote_usb_host_controller.cpp
@@ -127,6 +127,22 @@ TEST(RemoteUsbHostController, StopIsDestructorSafeBoundary) {
   static_assert(noexcept(std::declval<remote_usb::usbip_host_controller &>().stop()));
 }
 
+TEST(RemoteUsbHostController, DefaultRunnerTerminatesDescendantPipeHolders) {
+  remote_usb::usbip_host_controller_config config;
+  config.executable = REMOTE_USB_PROCESS_TREE_HELPER;
+  config.backend = remote_usb::usbip_host_backend::usbip_win2;
+  config.attach_timeout = 5s;
+  config.detach_timeout = 5s;
+  remote_usb::usbip_host_controller controller(std::move(config));
+  result_harness results;
+
+  const auto started = std::chrono::steady_clock::now();
+  ASSERT_NE(controller.attach(make_request(), results.callback()), 0U);
+  ASSERT_TRUE(results.wait_results(1));
+  EXPECT_EQ(results.result_at(0).status, remote_usb::usbip_host_status::ok);
+  EXPECT_LT(std::chrono::steady_clock::now() - started, 2s);
+}
+
 TEST(RemoteUsbHostController, ExplicitlyUnsupportedBackendDoesNotLaunchHelper) {
   command_harness commands;
   result_harness results;

--- a/tests/unit/test_remote_usb_host_controller.cpp
+++ b/tests/unit/test_remote_usb_host_controller.cpp
@@ -127,6 +127,7 @@ TEST(RemoteUsbHostController, StopIsDestructorSafeBoundary) {
   static_assert(noexcept(std::declval<remote_usb::usbip_host_controller &>().stop()));
 }
 
+#ifdef REMOTE_USB_PROCESS_TREE_HELPER
 TEST(RemoteUsbHostController, DefaultRunnerTerminatesDescendantPipeHolders) {
   remote_usb::usbip_host_controller_config config;
   config.executable = REMOTE_USB_PROCESS_TREE_HELPER;
@@ -142,6 +143,7 @@ TEST(RemoteUsbHostController, DefaultRunnerTerminatesDescendantPipeHolders) {
   EXPECT_EQ(results.result_at(0).status, remote_usb::usbip_host_status::ok);
   EXPECT_LT(std::chrono::steady_clock::now() - started, 2s);
 }
+#endif
 
 TEST(RemoteUsbHostController, ExplicitlyUnsupportedBackendDoesNotLaunchHelper) {
   command_harness commands;


### PR DESCRIPTION
## 改了啥呀

- 接受 Android 导出的接口级 bus ID（例如 `1-9:0`），并补齐非法值、尾随数据和精确 attach 参数覆盖。
- 用进程组管理 usbip-win2 helper，并用可取消的异步管道收集输出；正常退出、取消、超时和 reader 创建失败都会有界清理。
- Sunshine 作为服务运行时，会从系统 PATH 以及标准 `Program Files\USBip` 安装目录寻找 `usbip.exe`。杂鱼 helper 藏得再深也不会再报“找不到文件”啦。

## 为啥要改

Android usbipdcpp 的 bus ID 带接口后缀，旧校验会在 TLS 隧道建立后拒绝 attach。usbip-win2 还可能派生持有输出管道的进程；只等待直接子进程会让 Sunshine 在清理时卡住。服务账户的 PATH 通常也不包含 usbip-win2 的安装目录。

## 验证

- `RemoteUsbHostController.*`：20/20 通过；真实 helper 会派生继承 stdout/stderr 的后代进程，同一生产路径在 Windows 145 ms、Linux 9 ms 内返回。
- `tests/tools/test_reverse_tunnel.py`：证书、token、bus ID、尾随数据、attach/detach、取消与失败路径全部通过。
- Windows + usbip-win2 0.9.7.8 + OPPO PKJ110：Android K380 (`046d:b34d`, `1-6:0`) attach 到 hub port 1，Windows 枚举 11 个复合/HID 节点且 problem code 为 0；串流退出后端口与 PnP 节点全部清理。
