### PR TITLE
fix(ci): 修复 RTX SDK 私有下载配置

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,7 +209,7 @@ jobs:
         shell: msys2 {0}
         env:
           # Same-repository PRs are trusted; fork PRs never receive the private credential.
-          RTX_VIDEO_SDK_URL: ${{ (github.repository == 'AlkaidLab/foundation-sunshine' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'AlkaidLab/foundation-sunshine')) && vars.RTX_VIDEO_SDK_URL || '' }}
+          RTX_VIDEO_SDK_URL: ${{ (github.repository == 'AlkaidLab/foundation-sunshine' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'AlkaidLab/foundation-sunshine')) && secrets.RTX_VIDEO_SDK_URL || '' }}
           RTX_VIDEO_SDK_TOKEN: ${{ (github.repository == 'AlkaidLab/foundation-sunshine' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'AlkaidLab/foundation-sunshine')) && secrets.DRIVER_DOWNLOAD_TOKEN || '' }}
           RTX_VIDEO_NGX_APPLICATION_ID: ${{ (github.repository == 'AlkaidLab/foundation-sunshine' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'AlkaidLab/foundation-sunshine')) && secrets.RTX_VIDEO_NGX_APPLICATION_ID || '' }}
           SUNSHINE_RTX_HDR: ${{ !(github.repository == 'AlkaidLab/foundation-sunshine' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'AlkaidLab/foundation-sunshine')) && 'OFF' || (github.event_name != 'pull_request' && github.ref == 'refs/heads/master') && 'ON' || inputs.rtx_hdr || 'AUTO' }}

--- a/.github/workflows/sign-and-repackage.yml
+++ b/.github/workflows/sign-and-repackage.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Configure Windows
         shell: msys2 {0}
         env:
-          RTX_VIDEO_SDK_URL: ${{ steps.hdr_source.outputs.trusted == 'true' && vars.RTX_VIDEO_SDK_URL || '' }}
+          RTX_VIDEO_SDK_URL: ${{ steps.hdr_source.outputs.trusted == 'true' && secrets.RTX_VIDEO_SDK_URL || '' }}
           RTX_VIDEO_SDK_TOKEN: ${{ steps.hdr_source.outputs.trusted == 'true' && secrets.DRIVER_DOWNLOAD_TOKEN || '' }}
           RTX_VIDEO_NGX_APPLICATION_ID: ${{ steps.hdr_source.outputs.trusted == 'true' && secrets.RTX_VIDEO_NGX_APPLICATION_ID || '' }}
           SUNSHINE_RTX_HDR: ${{ github.repository == 'AlkaidLab/foundation-sunshine' && 'ON' || 'OFF' }}


### PR DESCRIPTION
## 说明

RTX Video SDK 下载地址已配置为 GitHub Actions Secret，但普通 Windows 构建和签名重打包工作流读取的是同名 Repository Variable。受保护的 `master` 构建要求启用 RTX HDR，因此 URL 为空时会在 CMake 配置阶段失败。

## 修改

- 普通 Windows 构建改为从 `secrets.RTX_VIDEO_SDK_URL` 读取 SDK 下载地址。
- 签名重打包工作流使用同一 Secret，避免正式发布链路再次失败。
- 保留现有可信来源判断；fork PR 仍不会取得 SDK URL、下载令牌或 NGX Application ID。