### PR TITLE
feat(input): 客户端经 launch 参数声明手柄类型

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -569,6 +569,7 @@ namespace config {
     true,  // virtual mouse (use driver if available)
     false, // amf_draw_mouse_cursor
     true,  // clipboard_sync (default on; effective only when the user-session GUI agent is alive and forwards data)
+    true,  // client_gamepad_override (client-declared type wins; no official client sends it today)
   };
 
   sunshine_t sunshine {
@@ -1566,6 +1567,7 @@ namespace config {
     bool_f(vars, "motion_as_ds4", input.motion_as_ds4);
     bool_f(vars, "touchpad_as_ds4", input.touchpad_as_ds4);
     bool_f(vars, "enable_dsu_server", input.enable_dsu_server);
+    bool_f(vars, "client_gamepad_override", input.client_gamepad_override);
     
     int temp_port = static_cast<int>(input.dsu_server_port);
     int_between_f(vars, "dsu_server_port", temp_port, { 1024, 65535 });

--- a/src/config.h
+++ b/src/config.h
@@ -230,6 +230,7 @@ namespace config {
     bool virtual_mouse;
     bool amf_draw_mouse_cursor;
     bool clipboard_sync;  ///< Bidirectional clipboard sync (text + single image). On by default; effective only when the user-session GUI agent is alive. Set to false to force-disable.
+    bool client_gamepad_override;  ///< Honor the client-declared controller type carried on the /launch query (Sunshine extension). On by default; set false to keep host-side selection authoritative.
   };
 
   namespace flag {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -293,6 +293,24 @@ namespace nvhttp {
     // Client-declared touch-keyboard intent (Sunshine protocol extension).
     // -1 undeclared: fall back to the per-client server profile.
     launch_session->touch_keyboard = util::from_view(get_arg(args, "touchKeyboard", "-1"));
+    // Client-declared controller emulation type (Sunshine protocol extension
+    // carried on the /launch and /resume query string). Values outside the
+    // host vocabulary are ignored with a warning and treated as undeclared.
+    {
+      auto declared_gamepad = get_arg(args, "gamepad", "");
+      if (!declared_gamepad.empty() &&
+          declared_gamepad != "auto"sv && declared_gamepad != "x360"sv &&
+          declared_gamepad != "ds4"sv && declared_gamepad != "ds5"sv) {
+        BOOST_LOG(warning) << "Ignoring unknown client gamepad preference: "sv << declared_gamepad;
+        declared_gamepad.clear();
+      }
+      launch_session->client_gamepad = declared_gamepad;
+      if (!declared_gamepad.empty()) {
+        BOOST_LOG(info) << "Client declared gamepad preference: "sv << declared_gamepad;
+      }
+      // Publish for the input layer (gamepads arrive after the stream starts).
+      platf::set_client_gamepad_pref(launch_session->client_gamepad);
+    }
     const auto hdr_capabilities = hdr::parse_client_display_capabilities(
       find_arg(args, "maxBrightness"),
       find_arg(args, "minBrightness"),
@@ -460,6 +478,7 @@ namespace nvhttp {
         "corever"sv,
         "customScreenMode"sv,
         "display_name"sv,
+        "gamepad"sv,
         "gcmap"sv,
         "hdrMode"sv,
         "localAudioPlayMode"sv,

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -1097,6 +1097,14 @@ namespace platf {
    */
   void
   set_gamepad_mode(int mode);
+  /**
+   * @brief Publish the client-declared controller type for the upcoming session.
+   * @param pref Empty = undeclared (host-side selection chain applies),
+   *             otherwise one of: auto, x360, ds4, ds5. Consumed per gamepad
+   *             allocation while the session streams; re-set on every launch.
+   */
+  void
+  set_client_gamepad_pref(std::string pref);
   void
   abs_mouse(input_t &input, const touch_port_t &touch_port, float x, float y);
   void

--- a/src/platform/linux/input/inputtino.cpp
+++ b/src/platform/linux/input/inputtino.cpp
@@ -47,6 +47,11 @@ namespace platf {
   }
 
   void
+  set_client_gamepad_pref(std::string pref) {
+    // Client-declared gamepad selection only overrides the Windows ViGEm backend.
+  }
+
+  void
   move_mouse(input_t &input, int deltaX, int deltaY) {
     auto raw = (input_raw_t *) input.get();
     platf::mouse::move(raw, deltaX, deltaY);

--- a/src/platform/linux/input/legacy_input.cpp
+++ b/src/platform/linux/input/legacy_input.cpp
@@ -1192,6 +1192,11 @@ namespace platf {
   }
 
   void
+  set_client_gamepad_pref(std::string pref) {
+    // Client-declared gamepad selection only overrides the Windows ViGEm backend.
+  }
+
+  void
   move_mouse(input_t &input, int deltaX, int deltaY) {
     auto raw = (input_raw_t *) input.get();
     auto mouse_rel = raw->mouse_rel_input.get();

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -391,6 +391,11 @@ const KeyCodeMap kKeyCodesMap[] = {
   }
 
   void
+  set_client_gamepad_pref(std::string pref) {
+    // Client-declared gamepad selection is currently Windows-only.
+  }
+
+  void
   move_mouse(
     input_t &input,
     const int deltaX,

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -498,6 +498,23 @@ namespace platf {
     BOOST_LOG(info) << "Gamepad mode set to: "sv << names[mode];
   }
 
+  // Client-declared gamepad type for the in-flight session, published at
+  // /launch time (see nvhttp.cpp). Empty = undeclared.
+  static std::mutex client_gamepad_pref_mutex;
+  static std::string client_gamepad_pref;
+
+  void
+  set_client_gamepad_pref(std::string pref) {
+    std::lock_guard lock(client_gamepad_pref_mutex);
+    client_gamepad_pref = std::move(pref);
+  }
+
+  static std::string
+  get_client_gamepad_pref() {
+    std::lock_guard lock(client_gamepad_pref_mutex);
+    return client_gamepad_pref;
+  }
+
   static int
   effective_gamepad_mode() {
     const auto app_mode = current_gamepad_mode.load(std::memory_order_relaxed);
@@ -1915,12 +1932,25 @@ namespace platf {
     // Component files may have been installed while Sunshine stayed running.
     // Refresh once per allocation; the input packet hot path reads only the cache.
     ds5::refresh_component_availability();
-    const auto gamepad_mode = effective_gamepad_mode();
-    const auto per_app_override = current_gamepad_mode.load(std::memory_order_relaxed) != 0;
+    // Client-declared preference (Sunshine /launch extension) outranks the
+    // per-app and global host-side selection while client_gamepad_override is on.
+    const auto client_pref = get_client_gamepad_pref();
+    const bool client_declared = !client_pref.empty() && config::input.client_gamepad_override;
+    auto gamepad_mode = client_declared
+      ? (client_pref == "x360"sv ? 2 : client_pref == "ds4"sv ? 3 : client_pref == "ds5"sv ? 4 : 1)
+      : effective_gamepad_mode();
+    const auto per_app_override = !client_declared && current_gamepad_mode.load(std::memory_order_relaxed) != 0;
+    const char *selection_source = client_declared ? "client selection" : (per_app_override ? "per-app selection" : "global selection");
+
+    if (gamepad_mode == 4 && client_declared && (!raw->ds5_sidecar || !raw->ds5_sidecar->configured())) {
+      // The client cannot know the host component state; degrade instead of failing.
+      BOOST_LOG(warning) << "Client declared DualSense but the sidecar component is unavailable; falling back to DualShock 4"sv;
+      gamepad_mode = 3;
+    }
 
     if (gamepad_mode == 4) {
       BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualSense controller ("
-                      << (per_app_override ? "per-app selection" : "global selection") << ')';
+                      << selection_source << ')';
       if (!raw->ds5_sidecar || !raw->ds5_sidecar->configured()) {
         BOOST_LOG(error) << "DualSense emulation is selected but its optional sidecar component is unavailable"sv;
         return -1;
@@ -1946,11 +1976,11 @@ namespace platf {
     VIGEM_TARGET_TYPE selectedGamepadType;
 
     if (gamepad_mode == 2) {
-      BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be Xbox 360 controller ("sv << (per_app_override ? "per-app selection" : "global selection") << ')';
+      BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be Xbox 360 controller ("sv << selection_source << ')';
       selectedGamepadType = Xbox360Wired;
     }
     else if (gamepad_mode == 3) {
-      BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualShock 4 controller ("sv << (per_app_override ? "per-app selection" : "global selection") << ')';
+      BOOST_LOG(info) << "Gamepad " << id.globalIndex << " will be DualShock 4 controller ("sv << selection_source << ')';
       selectedGamepadType = DualShock4Wired;
     }
     else if (metadata.type == LI_CTYPE_PS) {

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -70,6 +70,11 @@ namespace rtsp_stream {
     // host attaches the virtual USB touchscreen and applies the touch
     // keyboard AutoInvoke registry key group for the session.
     int touch_keyboard { -1 };
+    // Client-declared controller emulation type for this session (Sunshine
+    // protocol extension carried on the /launch and /resume query string).
+    // Empty = undeclared: the host-side selection chain applies as before.
+    // One of: auto, x360, ds4, ds5.
+    std::string client_gamepad;
     hdr::client_display_capabilities_t reported_hdr_capabilities;
     hdr::client_display_capabilities_t hdr_capabilities;
     hdr::target_source_e hdr_target_source { hdr::target_source_e::safe_defaults };


### PR DESCRIPTION
## 概述

为客户端显式指定控制器类型提供主机端基座：客户端在发起串流时，在 `/launch` 与 `/resume` 查询串上追加 `gamepad=<值>`，主机端在为该会话分配虚拟手柄时优先采用该声明。

这是纯主机端改动，**零协议/子模块变更**——/launch 查询参数是 Moonlight 生态现成的扩展通道（`touchKeyboard`、`useVdd`、`sdrBrightness` 等均走此通道），客户端 fork 拼接 URL 即可接入。

## 改动

| 文件 | 内容 |
|---|---|
| `src/nvhttp.cpp` | `make_launch_session` 解析 `gamepad` 参数并校验白名单（`auto`/`x360`/`ds4`/`ds5`），非法值忽略并告警；`/launch` 与 `/resume` 双路径覆盖；参数加入日志安全白名单 |
| `src/rtsp.h` | `launch_session_t` 新增 `client_gamepad` 字段（空 = 未声明） |
| `src/platform/common.h` | 声明 `platf::set_client_gamepad_pref()` |
| `src/platform/windows/input.cpp` | `alloc_gamepad` 前置客户端声明层：声明值压过每应用覆盖 / DS5 开关 / 全局配置；分配日志标注来源（client / per-app / global selection） |
| `src/config.{h,cpp}` | 新增 `client_gamepad_override` 开关（默认开，关闭后客户端声明被忽略，保持服务端权威） |
| linux / macos | `set_client_gamepad_pref` no-op 桩（与 `set_gamepad_mode` 同策略，该能力仅 Windows ViGEm 后端） |

## 决策链

```
客户端声明（未声明时不存在） > 每应用覆盖 > DS5 开关 > 全局显式 > auto 启发式
```

- 未声明：决策链原封不动，现有客户端（含官方 Moonlight）零影响
- 声明 `ds5` 但 DS5 sidecar 组件不可用：**降级为 DualShock 4** 并记 warning（客户端无法感知主机组件状态，不应硬失败；服务端自己显式选择 DS5 仍保持原有的硬失败语义）
- 声明 `auto`：强制走逐手柄启发式链，压过服务端固定配置
- 值域外（如未来的 `switch`/`steam`）：忽略 + 告警，会话内回退原链路

## 审阅要点

- 偏好经 `platf::set_client_gamepad_pref` 在每次 launch 时重设（含未声明置空），取消的 launch 会在下一次真实 launch 自愈；游戏手柄分配只发生在实际串流中，时序安全
- 读取侧为 mutex 保护的字符串，仅在游戏手柄分配时读取（非热路径）
- 声明 `ds5` 且组件缺失时的降级分支是新行为，其余路径未触碰
- 真机验证方式：fork 客户端带 `gamepad=ds4` 串流 → 日志应出现 `Client declared gamepad preference: ds4` 与 `will be DualShock 4 controller (client selection)`；不带参数时日志与主干一致

## 后续（不在本 PR）

- 客户端侧选择 UI 与置参（fork Moonlight 仓库）
- 控制面板高级区暴露 `client_gamepad_override` 开关
- Switch Pro / Steam Controller 仿真目标落地后扩展值域