### PR TITLE
fix(display): 流活动中放弃延迟显示设置应用，防止采集管线楔死

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -535,34 +535,26 @@ namespace display_device {
                            should_prepare_vdd,
                            vulkan_hdr_bridge_requested]() {
         if (settings.is_changing_settings_going_to_fail()) {
-          BOOST_LOG(warning) << "Applying display settings will fail - retrying later...";
+          BOOST_LOG(warning) << "[Display Deferred Retry] CCD access is still unavailable; retrying later";
           return false;
         }
 
-        // 流已在采集时应用显示设置，会在 sealed frame channel 之下重建 VDD 的
-        // 拓扑/模式/HDR，生产端被杀后没有任何通知采集管线重置的通道，视频线程
-        // 将永远等不到新帧（与静态桌面不可区分），造成黑屏+僵尸会话并污染后续
-        // 会话。放弃本次延迟应用，由下一个会话在 launch 阶段应用（安全路径）。
-        //
-        // 已注册 launch ticket 但尚未完成 RTSP PLAY 的在途启动同样要排除：
-        // 其 configure_display 已经执行完毕，慢客户端可能在应用中途打开采集。
-        // ticket 从 /launch 注册存活到 PLAY 之后，与 _session_slots 无缝衔接，
-        // 因此「活跃流或在途启动」恒可覆盖每一个即将插入的会话。检查之后才
-        // 发起的 /launch 无此风险：其 configure_display 会阻塞在 session_t::mutex
-        // 上（本重试持锁运行），采集必然晚于本次应用。
-        if (rtsp_stream::session_count() > 0 || rtsp_stream::pending_session_count() > 0) {
-          BOOST_LOG(warning) << "Skipping deferred display settings: a stream is active or a session launch is in progress. They will be applied at the next session start.";
+        // 延迟任务不能在会话准备或采集期间重建显示路径。NVHTTP 准备计数覆盖
+        // configure_display 返回到 RTSP ticket 发布之间的窗口；ticket 和活跃
+        // 会话计数覆盖后续握手及串流生命周期。之后才进入的请求会阻塞在本锁上。
+        if (rtsp_stream::session_starting_or_active()) {
+          BOOST_LOG(warning) << "[Display Deferred Retry] Active-session guard triggered; skipping display changes and deferring them to the next session start";
           return true;
         }
 
         if (should_prepare_vdd) {
           const auto vdd_stage_result = apply_vdd_display_stage(config_copy, pre_vdd_devices);
           if (vdd_stage_result == vdd_stage_result_e::modes_failed) {
-            BOOST_LOG(warning) << "The rebuilt VDD has not published the requested mode yet; retrying the deferred display configuration";
+            BOOST_LOG(warning) << "[Display Deferred Retry] The rebuilt VDD has not published the requested mode yet; retrying later";
             return false;
           }
           if (vdd_stage_result == vdd_stage_result_e::topology_failed) {
-            BOOST_LOG(warning) << "The deferred VDD topology change is still unavailable; retrying without tearing down the active monitor";
+            BOOST_LOG(warning) << "[Display Deferred Retry] The VDD topology change is still unavailable; retrying without tearing down the active monitor";
             return false;
           }
         }
@@ -577,7 +569,7 @@ namespace display_device {
         }
         retry_session.hdr_capabilities = hdr_capabilities;
         if (!settings.apply_config(config_copy, retry_session, pre_saved_initial_topology)) {
-          BOOST_LOG(warning) << "Failed to apply display settings - will stop trying, but will allow stream to continue.";
+          BOOST_LOG(warning) << "[Display Deferred Retry] Applying display settings failed; stopping retries while allowing the stream to continue";
           // WARNING! After call to the method below, this lambda function is no longer valid!
           // DO NOT access anything from the capture list!
           restore_state_impl(revert_reason_e::config_cleanup);
@@ -593,11 +585,12 @@ namespace display_device {
           platf::vulkan_hdr_bridge::disable();
         }
 #endif
+        BOOST_LOG(info) << "[Display Deferred Retry] Display settings applied successfully";
         pending_vdd_.reset();
         return true;
       });
 
-      BOOST_LOG(warning) << "It is already known that display settings cannot be changed. Allowing stream to start without changing the settings, but will retry changing settings later...";
+      BOOST_LOG(warning) << "[Display Deferred Retry] CCD access is unavailable; allowing the stream to start and scheduling a display-settings retry";
       return {
         configure_result_t::result_e::deferred_retry,
         "Display settings cannot be changed yet; Sunshine will retry while the stream starts.",

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -539,6 +539,15 @@ namespace display_device {
           return false;
         }
 
+        // 流已在采集时应用显示设置，会在 sealed frame channel 之下重建 VDD 的
+        // 拓扑/模式/HDR，生产端被杀后没有任何通知采集管线重置的通道，视频线程
+        // 将永远等不到新帧（与静态桌面不可区分），造成黑屏+僵尸会话并污染后续
+        // 会话。放弃本次延迟应用，由下一个会话在 launch 阶段应用（安全路径）。
+        if (rtsp_stream::session_count() > 0) {
+          BOOST_LOG(warning) << "Skipping deferred display settings: a stream is active and applying them mid-stream would invalidate the capture pipeline. They will be applied at the next session start.";
+          return true;
+        }
+
         if (should_prepare_vdd) {
           const auto vdd_stage_result = apply_vdd_display_stage(config_copy, pre_vdd_devices);
           if (vdd_stage_result == vdd_stage_result_e::modes_failed) {

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -543,8 +543,15 @@ namespace display_device {
         // 拓扑/模式/HDR，生产端被杀后没有任何通知采集管线重置的通道，视频线程
         // 将永远等不到新帧（与静态桌面不可区分），造成黑屏+僵尸会话并污染后续
         // 会话。放弃本次延迟应用，由下一个会话在 launch 阶段应用（安全路径）。
-        if (rtsp_stream::session_count() > 0) {
-          BOOST_LOG(warning) << "Skipping deferred display settings: a stream is active and applying them mid-stream would invalidate the capture pipeline. They will be applied at the next session start.";
+        //
+        // 已注册 launch ticket 但尚未完成 RTSP PLAY 的在途启动同样要排除：
+        // 其 configure_display 已经执行完毕，慢客户端可能在应用中途打开采集。
+        // ticket 从 /launch 注册存活到 PLAY 之后，与 _session_slots 无缝衔接，
+        // 因此「活跃流或在途启动」恒可覆盖每一个即将插入的会话。检查之后才
+        // 发起的 /launch 无此风险：其 configure_display 会阻塞在 session_t::mutex
+        // 上（本重试持锁运行），采集必然晚于本次应用。
+        if (rtsp_stream::session_count() > 0 || rtsp_stream::pending_session_count() > 0) {
+          BOOST_LOG(warning) << "Skipping deferred display settings: a stream is active or a session launch is in progress. They will be applied at the next session start.";
           return true;
         }
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -703,6 +703,7 @@ namespace nvhttp {
 
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     const auto launch_session = make_launch_session(host_audio, args);
+    const rtsp_stream::launch_preparation_guard_t launch_preparation;
     launch_session->rtsp_peer_address = net::addr_to_normalized_string(request->remote_endpoint().address());
     const auto fingerprint_match = client_fingerprint::match_client(args);
     launch_session->highly_suspected_unknown_client = fingerprint_match.suspicious;
@@ -871,6 +872,7 @@ namespace nvhttp {
       host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     }
     const auto launch_session = make_launch_session(host_audio, args);
+    const rtsp_stream::launch_preparation_guard_t launch_preparation;
     if (launch_session->width <= 0 || launch_session->height <= 0 || launch_session->fps <= 0) {
       BOOST_LOG(warning) << "Resume request has no usable mode; keeping the current display resolution and refresh rate for compatibility. "sv
                             "Update Moonlight-Switch to a version that sends mode on Resume when one is available."sv;

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include <vector>
 
 // lib includes
+#include <boost/atomic.hpp>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 
@@ -48,6 +49,18 @@ using asio::ip::udp;
 using namespace std::literals;
 
 namespace rtsp_stream {
+  namespace {
+    boost::atomic_uint32_t launch_preparations { 0 };
+  }
+
+  launch_preparation_guard_t::launch_preparation_guard_t() noexcept {
+    ++launch_preparations;
+  }
+
+  launch_preparation_guard_t::~launch_preparation_guard_t() noexcept {
+    --launch_preparations;
+  }
+
   void
   launch_session_t::set_hdr_target(
     const hdr::client_display_capabilities_t &capabilities,
@@ -980,6 +993,13 @@ namespace rtsp_stream {
   int
   pending_session_count() {
     return server.pending_session_count();
+  }
+
+  bool
+  session_starting_or_active() {
+    return launch_preparations.load() != 0 ||
+           server.pending_session_count() != 0 ||
+           server.session_count() != 0;
   }
 
   void

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -119,6 +119,19 @@ namespace rtsp_stream {
   launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
 
   /**
+   * @brief Track an NVHTTP launch while it prepares the display and publishes its RTSP ticket.
+   */
+  class launch_preparation_guard_t {
+  public:
+    launch_preparation_guard_t() noexcept;
+    ~launch_preparation_guard_t() noexcept;
+
+    launch_preparation_guard_t(const launch_preparation_guard_t &) = delete;
+    launch_preparation_guard_t &
+    operator=(const launch_preparation_guard_t &) = delete;
+  };
+
+  /**
    * @brief Clear state for the specified launch session.
    * @param launch_session_id The ID of the session to clear.
    */
@@ -137,6 +150,12 @@ namespace rtsp_stream {
    */
   int
   pending_session_count();
+
+  /**
+   * @brief Check whether an NVHTTP launch, RTSP handshake, or stream session is active.
+   */
+  bool
+  session_starting_or_active();
 
   /**
    * @brief Terminates all streaming sessions on the RTSP execution context.


### PR DESCRIPTION
## 问题

2026-09-11 事故：服务重启后 ~40 秒内的首个客户端连接 → 黑屏 → 客户端超时自动断开。Sunshine 侧会话楔死为僵尸（不清理、不感知客户端断开），并经共享 sealed frame channel 的 keyed mutex 污染后续所有会话（encoder mutex key 2 连续 16ms 超时、Could not convert image），只能靠重启服务恢复。

## 根因

- `configure_display` 因 `no_ccd_access` 走 deferred_retry（StateRetryTimer，5s 周期），流先行启动并打开 VDD sealed frame channel；
- 重试线程随后在采集运行中应用 vdd_prep 拓扑 + 显示模式 + HDR 切换，模式切换销毁帧生产端；
- 采集层没有外部触发的重置机制：`capture_e::reinit` 仅由「收到新帧后发现 desc/generation 变化」触发（display_vdd.cpp），生产端死亡后 `next_frame` 永远返回 timeout，与 `minimum_fps_target=1` 的静态桌面空转**不可区分**；
- 视频线程同时承载控制包处理，楔死后客户端断开无人感知 → 僵尸会话。

## 修复

延迟重试 lambda 在 CCD 就绪检查之后、实际应用之前增加活跃流守卫：`rtsp_stream::session_count() > 0` 时放弃本次应用（`return true` 停止重试）并输出告警，显示设置由下一个会话的 launch 阶段应用——先于采集启动、已验证的安全路径（事故当日 10:08 的自愈连接即走此路径）。

权衡：本次流以 launch 时的显示状态运行（物理显示器不关闭、HDR 不切换），画面正常；下个会话全量应用。会话结束恢复不受影响（apply 从未执行 → 跳过拓扑恢复的既有安全分支）。

## 为什么不是「触发 capture reinit」

对事故进程的取证显示僵尸视频线程为**硬阻塞**（无会话窗口内零日志、零 CPU），reinit 信号无法送达卡死线程；从源头避免流中模式切换是唯一可靠解。后续可另行考虑会话级 watchdog 作为纵深防御。

## 测试

- ucrt64/Ninja 增量编译通过；
- 真机复现验证：重启 Sunshine 服务 → 40 秒内连接 → 期望日志出现 `Skipping deferred display settings: a stream is active...`，流持续正常而非黑屏；
- 回归面：仅影响 deferred_retry 分支，立即应用路径与无流场景行为不变。